### PR TITLE
Implement routing_mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,28 @@ microk8s enable metallb 192.168.0.10-192.168.0.100 # You likely wanna change the
 juju deploy ./traefik-k8s_ubuntu-20.04-amd64.charm traefik-ingress --trust --resource traefik-image=docker.io/jnsgruk/traefik:2.6.1
 ```
 
+## Configurations
+
+* `external_hostname` allows you to specify a host for the URL that Traefik will assume is its externally-visible URL, and that will be used to generate the URLs passed to the proxied applications.
+  If unspecified, Traefik will use the ingress ip of its Kubernetes service.
+* `routing_mode`: structured as an enumeration, that allows you to select how Traefik will generate routes:
+  * `path`: Traefik will use its externally-visible url and create a route for the requester that will be structure like:
+    ```
+    http://<external_hostname>:<port>/<requester_model_name>-<requester_application_name>-<requester-unit-index>
+    ```
+    For example, an ingress-per-unit provider with `http://foo` external URL, will provide to the unit `my-unit/2` in the `my-model` model the following URL:
+    ```
+    http://foo/my-model-my-unit-2
+    ```
+  * `subdomain`: Traefik will use its externally-visible url, and create a route for the requester that will be structure like:
+    ```
+    http://<requester_model_name>-<requester_application_name>-<requester-unit-index>.<external_hostname>:<port>/
+    ```
+    For example, an ingress-per-unit provider with `http://foo:8080` external URL, will provide to the unit `my-unit/2` in the `my-model` model the following URL:
+    ```
+    http://my-model-my-unit-2.foo:8080
+    ```
+
 ## Relations
 
 ### Providing ingress proxying

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ These instructions assume you will run the charm on [`microk8s`](https://microk8
 
 ```sh
 sudo snap install microk8s
-microk8s enable storage dns registry
-microk8s enable metallb 192.168.0.10-192.168.0.100 # You likely wanna change these IP ranges
+microk8s enable storage dns
+# The following line is required unless you plan to use the `external_hostname` configuration option
+microk8s enable metallb 192.168.0.10-192.168.0.100 # You likely want change these IP ranges
 ```
 
 ## Usage
@@ -23,23 +24,39 @@ juju deploy ./traefik-k8s_ubuntu-20.04-amd64.charm traefik-ingress --trust --res
 ## Configurations
 
 * `external_hostname` allows you to specify a host for the URL that Traefik will assume is its externally-visible URL, and that will be used to generate the URLs passed to the proxied applications.
-  If unspecified, Traefik will use the ingress ip of its Kubernetes service.
+  If `external_hostname` is unspecified, Traefik will use the ingress ip of its Kubernetes service, and the charm will go into `WaitingStatus` if it does not discover an ingress IP on its Kubernetes service.
+  The [Setup](#setup) section shows how to optionally set up `metallb` with MicroK8s, so that Traefik's Kubernetes service will receive an ingress IP.
+
 * `routing_mode`: structured as an enumeration, that allows you to select how Traefik will generate routes:
   * `path`: Traefik will use its externally-visible url and create a route for the requester that will be structure like:
+
     ```
     http://<external_hostname>:<port>/<requester_model_name>-<requester_application_name>-<requester-unit-index>
     ```
+
     For example, an ingress-per-unit provider with `http://foo` external URL, will provide to the unit `my-unit/2` in the `my-model` model the following URL:
+
     ```
     http://foo/my-model-my-unit-2
     ```
-  * `subdomain`: Traefik will use its externally-visible url, and create a route for the requester that will be structure like:
+
+  * `subdomain`: Traefik will use its externally-visible url, based on `external_hostname` or, missing that, the ingress IP, and create a route for the requester that will be structure like:
+
     ```
     http://<requester_model_name>-<requester_application_name>-<requester-unit-index>.<external_hostname>:<port>/
     ```
+
     For example, an ingress-per-unit provider with `http://foo:8080` external URL, will provide to the unit `my-unit/2` in the `my-model` model the following URL:
+
     ```
     http://my-model-my-unit-2.foo:8080
+    ```
+
+    **IMPORTANT:** With the `subdomain` routing mode, incoming HTTP requests have the `Host` header set to match one of the routes.
+    Considering the example above, incoming requests are expected to have the following HTTP header:
+
+    ```
+    Host: my-model-my-unit-2.foo
     ```
 
 ## Relations

--- a/config.yaml
+++ b/config.yaml
@@ -8,3 +8,32 @@ options:
       If unspecified, the gateway ingress ip address will be used, e.g,
       as provided by MetalLB.
     type: string
+  routing_mode:
+    description: |
+      The routing mode allows you to specify how Traefik going to generate
+      routes on behalf of the requesters.
+
+      Valid values are "path" and "subdomain".
+
+      With the "path" routing mode, Traefik will use its externally-visible url,
+      and create a route for the requester that will be structure like:
+
+      `<external_url>/<requester_model_name>-<requester_application_name>-<requester-unit-index>`
+
+      For example, an ingress-per-unit provider with `http://foo` external URL,
+      will provide to the unit `my-unit/2` in the `my-model` model the
+      following URL:
+
+      `http://foo/my-model-my-unit-2`
+
+      With the "subdomain" routing mode, Traefik will use its externally-visible url,
+      and create a route for the requester that will be structure like:
+
+      `<protocol>://<requester_model_name>-<requester_application_name>-<requester-unit-index>.<external_hostname>:<port>/`
+
+      For example, an ingress-per-unit provider with `http://foo:8080` external URL,
+      will provide to the unit `my-unit/2` in the `my-model` model the following URL:
+
+      `http://my-model-my-unit-2.foo:8080`
+    type: string
+    default: path

--- a/src/charm.py
+++ b/src/charm.py
@@ -193,7 +193,14 @@ class TraefikIngressCharm(CharmBase):
 
             self._wipe_ingress_for_all_relations()
 
-            self.unit.status = BlockedStatus(f"'{routing_mode}' is not a valid routing_mode value")
+            self.unit.status = BlockedStatus(
+                f"'{routing_mode}' is not a valid routing_mode value; see debug logs for more information"
+            )
+            logger.error(
+                "'%s' is not a valid routing_mode value; valid values are: %s",
+                routing_mode,
+                [e.value for e in _RoutingMode],
+            )
             return
 
         if not self._external_host:
@@ -204,7 +211,6 @@ class TraefikIngressCharm(CharmBase):
             self._wipe_ingress_for_all_relations()
 
             self.unit.status = WaitingStatus("gateway address not available")
-
             return
 
         if not self._is_traefik_service_running():

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,7 +6,7 @@
 import unittest
 from unittest.mock import patch
 
-from ops.model import ActiveStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
 from test_lib_helpers import MockIPURequirer
 
@@ -20,7 +20,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
 
     @patch("charm.KubernetesServicePatch", lambda **unused: None)
-    def test_pebble_ready_with_gateway_address_from_config(self):
+    def test_pebble_ready_with_gateway_address_from_config_and_path_routing_mode(self):
         """Test round-trip bootstrap and relation with a consumer."""
         self.harness.update_config({"external_hostname": "testhostname"})
         self.harness.set_leader(True)
@@ -62,6 +62,87 @@ class TestTraefikIngressCharm(unittest.TestCase):
                 "ingress-per-unit-remote/0": "http://testhostname:80/test-model-ingress-per-unit-remote-0"
             },
         )
+        self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
+
+    @patch("charm.KubernetesServicePatch", lambda **unused: None)
+    def test_pebble_ready_with_gateway_address_from_config_and_subdomain_routing_mode(self):
+        """Test round-trip bootstrap and relation with a consumer."""
+        self.harness.update_config({"external_hostname": "testhostname"})
+        self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
+
+        self.harness.update_config(
+            {
+                "external_hostname": "testhostname",
+                "routing_mode": "subdomain",
+            }
+        )
+
+        self.harness.container_pebble_ready("traefik")
+
+        self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
+
+        requirer = MockIPURequirer(self.harness)
+        relation = requirer.relate()
+        requirer.request(host="10.1.10.1", port=9000)
+
+        assert requirer.is_available(relation)
+
+        traefik_container = self.harness.charm.unit.get_container("traefik")
+        self.assertEqual(
+            traefik_container.pull(
+                f"/opt/traefik/juju/juju_ingress_{relation.name}_{relation.id}_{relation.app.name}.yaml"
+            ).read(),
+            """http:
+  routers:
+    juju-test-model-ingress-per-unit-remote-0-router:
+      entryPoints:
+      - web
+      rule: Host(`test-model-ingress-per-unit-remote-0.testhostname`)
+      service: juju-test-model-ingress-per-unit-remote-0-service
+  services:
+    juju-test-model-ingress-per-unit-remote-0-service:
+      loadBalancer:
+        servers:
+        - url: http://10.1.10.1:9000
+""",
+        )
+
+        self.assertEqual(
+            requirer.urls,
+            {
+                "ingress-per-unit-remote/0": "http://test-model-ingress-per-unit-remote-0.testhostname:80/"
+            },
+        )
+        self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
+
+    @patch("charm.KubernetesServicePatch", lambda **unused: None)
+    def test_bad_routing_mode_config_and_recovery(self):
+        """Test round-trip bootstrap and relation with a consumer."""
+        self.harness.update_config({"external_hostname": "testhostname"})
+        self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
+
+        self.harness.update_config(
+            {
+                "external_hostname": "testhostname",
+                "routing_mode": "FOOBAR",
+            }
+        )
+
+        self.harness.container_pebble_ready("traefik")
+
+        self.assertEqual(
+            self.harness.charm.unit.status,
+            BlockedStatus("'FOOBAR' is not a valid routing_mode value"),
+        )
+
+        self.harness.update_config(
+            {
+                "routing_mode": "path",
+            }
+        )
+
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
 
     @patch("charm._get_loadbalancer_status", lambda **unused: None)
@@ -182,7 +263,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
         )
 
     def test_relation_broken(self):
-        self.test_pebble_ready_with_gateway_address_from_config()
+        self.test_pebble_ready_with_gateway_address_from_config_and_path_routing_mode()
 
         relation = self.harness.model.relations["ingress-per-unit"][0]
         self.harness.remove_relation(relation.id)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -134,7 +134,9 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         self.assertEqual(
             self.harness.charm.unit.status,
-            BlockedStatus("'FOOBAR' is not a valid routing_mode value"),
+            BlockedStatus(
+                "'FOOBAR' is not a valid routing_mode value; see debug logs for more information"
+            ),
         )
 
         self.harness.update_config(


### PR DESCRIPTION
Introduce a `routing_mode` charm option, structured as an enumeration, that allows you to select how Traefik will generate routes:

* `path`: Traefik will use its externally-visible url and create a route for the requester that will be structure like:

   `<external_url>/<requester_model_name>-<requester_application_name>-<requester-unit-index>`

   For example, an ingress-per-unit provider with `http://foo` external URL, will provide to the unit `my-unit/2` in the `my-model` model the following URL:

   `http://foo/my-model-my-unit-2`

* `subdomain`: Traefik will use its externally-visible url, and create a route for the requester that will be structure like:

  `<protocol>://<requester_model_name>-<requester_application_name>-<requester-unit-index>.<external_hostname>:<port>/`

  For example, an ingress-per-unit provider with `http://foo:8080` external URL, will provide to the unit `my-unit/2` in the `my-model` model the following URL:

  `http://my-model-my-unit-2.foo:8080`