### PR TITLE
Add stripPrefix middleware for path based routing

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -294,6 +294,16 @@ class TraefikIngressCharm(CharmBase):
                 return None
             return gateway_address
 
+    def _generate_middleware_config(self, prefix: str) -> dict:
+        """Generate a stripPrefix middleware for path based routing."""
+        return {
+            "middlewares": {
+                "juju-sidecar-noprefix": {
+                    "stripPrefix": {"prefixes": [f"/{prefix}"], "forceSlash": False}
+                }
+            }
+        }
+
     def _generate_per_unit_config(self, request, gateway_address, unit) -> Tuple[dict, str]:
         """Generate a config dict for a given unit for IngressPerUnit."""
         config = {"http": {"routers": {}, "services": {}}}
@@ -315,6 +325,11 @@ class TraefikIngressCharm(CharmBase):
             "service": traefik_service_name,
             "entryPoints": ["web"],
         }
+
+        if self._routing_mode == _RoutingMode.path:
+            config["http"]["routers"][traefik_router_name].update(
+                self._generate_middleware_config(prefix)
+            )
 
         config["http"]["services"][traefik_service_name] = {
             "loadBalancer": {
@@ -355,6 +370,11 @@ class TraefikIngressCharm(CharmBase):
                 },
             }
         }
+
+        if self._routing_mode == _RoutingMode.path:
+            config["http"]["routers"][traefik_router_name].update(
+                self._generate_middleware_config(prefix)
+            )
 
         return config, app_url
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -55,6 +55,14 @@ class TestTraefikIngressCharm(unittest.TestCase):
                         "entryPoints": ["web"],
                         "rule": "PathPrefix(`/test-model-ingress-per-unit-remote-0`)",
                         "service": "juju-test-model-ingress-per-unit-remote-0-service",
+                        "middlewares": {
+                            "juju-sidecar-noprefix": {
+                                "stripPrefix": {
+                                    "prefixes": ["/test-model-ingress-per-unit-remote-0"],
+                                    "forceSlash": False,
+                                }
+                            }
+                        },
                     }
                 },
                 "services": {
@@ -101,6 +109,14 @@ class TestTraefikIngressCharm(unittest.TestCase):
                         "entryPoints": ["web"],
                         "rule": "PathPrefix(`/test-model-ingress-remote`)",
                         "service": "juju-test-model-ingress-remote-service",
+                        "middlewares": {
+                            "juju-sidecar-noprefix": {
+                                "stripPrefix": {
+                                    "prefixes": ["/test-model-ingress-remote"],
+                                    "forceSlash": False,
+                                }
+                            }
+                        },
                     }
                 },
                 "services": {
@@ -208,7 +224,6 @@ class TestTraefikIngressCharm(unittest.TestCase):
                 },
             }
         }
-
         self.assertEqual(conf, expected)
 
         self.assertEqual(


### PR DESCRIPTION
Some applications (notably Prometheus in this case) may not
correctly resolve endpoints if the prefix is passed through to
the application, as the "expected" endpoint per-unit is simply
`/` (for Prometheus `web.external-url`, including a prefix will
result in the Prometheus webroot itself also being at that URL).

Some flexibility will be required here, since other charms
(Grafana in particular) expect to see at least part of the prefix
if that is where they are hosted, or they will redirect users in
an infinite loop.

This is a first pass to unbreak Prometheus, and we can options from
there (whether it is dropping `web.external-url` from Prometheus,
keeping it as a constructor argument in Traefik, or other)