### PR TITLE
Fix various bugs in ingress-per-unit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-ops >= 1.3.0
+ops == 1.3.0  # 1.4.0 breaks SDI-based tests
+deepmerge
 lightkube >= 0.8.1
 lightkube-models >= 1.22.0.4
 serialized-data-interface>=0.4.0

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,6 +5,7 @@ import json
 import unittest
 from unittest.mock import Mock, patch
 
+import ops.testing
 import yaml
 from ops.charm import ActionEvent
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
@@ -12,6 +13,8 @@ from ops.testing import Harness
 from test_lib_helpers import MockIPARequirer, MockIPURequirer
 
 from charm import TraefikIngressCharm
+
+ops.testing.SIMULATE_CAN_CONNECT = True
 
 
 class TestTraefikIngressCharm(unittest.TestCase):


### PR DESCRIPTION
## Issue

1. SDI does not seem to handle correctly scale-down of units, and especially scale-to-zero.
2. Avoid writing out spurious routes when the requesters have not yet written their part od the data (unit_name, model, host), but traefik-k8s already receives a RelationChanged event that is "paired" to the RelationJoined event.

## Solution

Various hardenings, mostly work-around for broken SDI behaviours.

## Context

The code seems to work well on actual Juju.
The unit tests, OTOH, are plenty borked.
The fix to check for _actual_ unit count in the relation rather than relying on the `is_ready` of SDI has broken the tests, as the Mocks of SDI do not seem to correctly create units...

## Testing Instructions

Saboteur tests by adding relations with Prometheus, removing those relations, scaling Prometheus to 0, scaling Prometheus to n and then to zero again, while keeping an eye on the ingress configuration files and their contents under `opt/traefik/juju` in the `traefik` container of the `traefik-k8s` units.


## Release Notes

* Fix spurious routes left behind for `ingress-per-unit` relations in which the proxied application is scaled to zero.
* Fix transient spurious route for `ingress-per-unit` relations URLs when the proxied units have not yet set data required on their side of the relation.