### PR TITLE
Purge sdi polish

### DIFF
--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -76,10 +76,7 @@ LIBPATCH = 8
 
 log = logging.getLogger(__name__)
 
-# ======================= #
-#      LIBRARY GLOBS      #
-# ======================= #
-
+# LIBRARY GLOBS
 RELATION_INTERFACE = "ingress_per_unit"
 DEFAULT_RELATION_NAME = RELATION_INTERFACE.replace("_", "-")
 
@@ -115,22 +112,13 @@ INGRESS_PROVIDES_APP_SCHEMA = {
     "required": ["ingress"],
 }
 
-
-# ======================= #
-#          TYPES          #
-# ======================= #
-
-
+# TYPES
 KeyValueMapping = Dict[str, str]
 RequirerUnitData = Dict[Unit, KeyValueMapping]
 ProviderApplicationData = Dict[str, KeyValueMapping]
 
 
-# ======================= #
-#  SERIALIZATION UTILS    #
-# ======================= #
-
-
+# SERIALIZATION UTILS
 def _deserialize_data(data):
     return yaml.safe_load(data)
 
@@ -146,11 +134,7 @@ def _validate_data(data, schema):
         raise DataValidationError(data, schema) from e
 
 
-# ======================= #
-#       EXCEPTIONS        #
-# ======================= #
-
-
+# EXCEPTIONS
 class IngressPerUnitException(RuntimeError):
     """Base class for errors raised by Ingress Per Unit."""
 
@@ -199,11 +183,7 @@ class RelationPermissionError(IngressPerUnitException):
         self.relation = relation
 
 
-# ======================= #
-#         EVENTS          #
-# ======================= #
-
-
+# EVENTS
 class RelationAvailableEvent(RelationEvent):
     """Event triggered when a relation is ready for requests."""
 

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -72,7 +72,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 log = logging.getLogger(__name__)
 

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -547,12 +547,12 @@ class IngressRequest:
         self._requirer_unit_data = requirer_unit_data
 
     @property
-    def model(self) -> str:
+    def model(self) -> Optional[str]:
         """The name of the model the request was made from."""
         return self._get_data_from_first_unit("model")
 
     @property
-    def app_name(self) -> str:
+    def app_name(self) -> Optional[str]:
         """The name of the remote app.
 
         Note: This is not the same for the other charm as `self.app.name`
@@ -576,27 +576,27 @@ class IngressRequest:
         """Whether the given unit has provided its name, model, host and port data."""
         self._check_unit_belongs_to_relation(unit)
 
-        return bool(
-            self.get_unit_host(unit)
-            and self.get_unit_name(unit)
-            and self.get_unit_model(unit)
-            and self.get_unit_port(unit)
+        return all(
+            (self.get_unit_host(unit),
+            self.get_unit_name(unit),
+            self.get_unit_model(unit),
+            self.get_unit_port(unit))
         )
 
     @property
-    def port(self) -> int:
+    def port(self) -> Optional[int]:
         """The backend port."""
         return self._get_data_from_first_unit("port")
 
     # deprecated
-    def get_host(self, unit: Unit):
+    def get_host(self, unit: Unit) -> Optional[str]:
         """The hostname (DNS address, ip) of the given unit."""
         warnings.warn(
             "The 'get_host' method is deprecated, use 'get_unit_host' instead", DeprecationWarning
         )
         return self.get_unit_host(unit)
 
-    def get_unit_host(self, unit: Unit):
+    def get_unit_host(self, unit: Unit) -> Optional[str]:
         """The hostname (DNS address, ip) of the given unit."""
         self._check_unit_belongs_to_relation(unit)
 
@@ -669,6 +669,7 @@ class IngressRequest:
         self._provider.publish_ingress_data(self._relation, self._provider_app_data)
 
     def _check_unit_belongs_to_relation(self, unit: Unit):
+        """Checks that `unit` belongs to the relation this response manages."""
         if unit not in self._relation.units:
             raise UnknownUnitException(self._relation, unit)
 

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -132,12 +132,10 @@ ProviderApplicationData = Dict[str, KeyValueMapping]
 
 
 def _deserialize_data(data):
-    # return json.loads(data) # TODO port to json
     return yaml.safe_load(data)
 
 
 def _serialize_data(data):
-    # return json.dumps(data) # TODO port to json
     return yaml.safe_dump(data, indent=2)
 
 
@@ -490,7 +488,7 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
 
         return provider_app_data, requirer_unit_data
 
-    def publish_ingress_data(self, relation: Relation, data: Dict[str, Dict[str, str]]):
+    def publish_ingress_data(self, relation: Relation, data: ProviderApplicationData):
         """Publish ingress data to the relation databag."""
         if not self.unit.is_leader():
             raise RelationPermissionError(relation, self.unit, "This unit is not the leader")

--- a/tests/unit/test_lib_helpers.py
+++ b/tests/unit/test_lib_helpers.py
@@ -178,8 +178,8 @@ class MockIngressPerUnitRequest(IngressRequest):
     ):
         super().__init__(provider, relation, provider_app_data, requirers_unit_data)
 
-        self._relation.units = set((provider.harness.charm.unit, ))
         self.app = self._provider.harness.charm.app
+        self._related_units = {self._provider.harness.charm.unit}
 
 
 class MockIPURequirer(MockRemoteIPUMixin, IngressPerUnitRequirer):

--- a/tests/unit/test_lib_helpers.py
+++ b/tests/unit/test_lib_helpers.py
@@ -178,12 +178,8 @@ class MockIngressPerUnitRequest(IngressRequest):
     ):
         super().__init__(provider, relation, provider_app_data, requirers_unit_data)
 
+        self._relation.units = set((provider.harness.charm.unit, ))
         self.app = self._provider.harness.charm.app
-
-    @property
-    def units(self):
-        """The remote units."""
-        return [self._provider.harness.charm.unit]
 
 
 class MockIPURequirer(MockRemoteIPUMixin, IngressPerUnitRequirer):

--- a/tests/unit/test_lib_per_unit_requires.py
+++ b/tests/unit/test_lib_per_unit_requires.py
@@ -162,5 +162,6 @@ def test_ipu_on_new_related_unit_nonready(requirer, provider, harness):
     new_unit = next(u for u in relation.units if u is not requirer.charm.unit)
 
     # we add the unit to the related_units because test_lib_helpers is borked
+    # see https://github.com/canonical/traefik-k8s-operator/issues/39 for more
     request._related_units.add(new_unit)
     assert not request.is_unit_ready(new_unit)

--- a/tests/unit/test_lib_per_unit_requires.py
+++ b/tests/unit/test_lib_per_unit_requires.py
@@ -98,7 +98,6 @@ def test_ingress_unit_requirer_leader(requirer, provider, harness):
 
     request = provider.get_request(relation)
     assert request.units[0] is requirer.charm.unit
-    assert request.units[0] in request._relation.units
     assert request.app_name == requirer.charm.app.name
 
 
@@ -149,8 +148,7 @@ def test_unit_joining_does_not_trigger_ingress_changed(requirer, provider, harne
 def test_ipu_on_new_related_unit_nonready(requirer, provider, harness):
     relation = provider.relate()
     harness.set_leader(True)
-    request = provider.get_request(relation)
-    request.respond(requirer.charm.unit, "http://url/")
+    provider.get_request(relation).respond(requirer.charm.unit, "http://url/")
 
     relation_id = harness._backend._relation_ids_map["ingress-per-unit"][0]
     harness.add_relation_unit(relation_id, remote_unit_name="remote/1")
@@ -163,4 +161,6 @@ def test_ipu_on_new_related_unit_nonready(requirer, provider, harness):
     assert len(relation.units) == 2
     new_unit = next(u for u in relation.units if u is not requirer.charm.unit)
 
+    # we add the unit to the related_units because test_lib_helpers is borked
+    request._related_units.add(new_unit)
     assert not request.is_unit_ready(new_unit)

--- a/tests/unit/test_lib_per_unit_requires.py
+++ b/tests/unit/test_lib_per_unit_requires.py
@@ -98,7 +98,8 @@ def test_ingress_unit_requirer_leader(requirer, provider, harness):
 
     request = provider.get_request(relation)
     assert request.units[0] is requirer.charm.unit
-    assert request.app_name == "test-requirer"
+    assert request.units[0] in request._relation.units
+    assert request.app_name == requirer.charm.app.name
 
 
 def test_ingress_unit_requirer_request_response(requirer, provider, harness):


### PR DESCRIPTION
## Issue
Lib was missing some typing and docstrings, had complex type signatures and redundant code paths.

## Solution
A bit of polishing.


## Testing Instructions
No (production) code paths should have been altered. Utests/itests should be enough.


## Release Notes
Added types and return type annotations throughout.