### PR TITLE
Remove Request/Response mechanism in ingress-per-unit

### DIFF
--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -47,9 +47,7 @@ class SomeCharm(CharmBase):
 ```
 """
 import logging
-import typing
-import warnings
-from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union
+from typing import Dict, Optional, Tuple, TypeVar, Union
 
 import jsonschema
 import ops.model
@@ -129,6 +127,8 @@ except ImportError:
 
 
 class RequirerData(TypedDict):
+    """Model of the data a unit implementing the requirer will need to provide."""
+
     model: str
     name: str
     host: str
@@ -484,7 +484,11 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
         try:
             _validate_data(data, INGRESS_PROVIDES_APP_SCHEMA)
         except DataValidationError as e:
-            log.error(f"unable to publish url to {unit_name}: " f"corrupted application databag")
+            log.error(
+                "unable to publish url to {}: corrupted application databag ({})".format(
+                    unit_name, e
+                )
+            )
             return
         data["ingress"][unit_name] = {"url": url}
         try:

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -636,7 +636,7 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
 
     def _publish_auto_data(self, relation: Relation):
         if self._auto_data and self.is_available(relation):
-            self._publish_ingress_data(*self._auto_data)
+            self._provide_ingress_requirements(*self._auto_data)
 
     @property
     def relation(self) -> Optional[Relation]:
@@ -698,7 +698,7 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
         # TODO Avoid spurious events, emit only when URL changes
         self.on.ingress_changed.emit(self.relation)
 
-    def _publish_ingress_data(self, host: Optional[str], port: int):
+    def _provide_ingress_requirements(self, host: Optional[str], port: int):
         """Publish the data that the provider needs to provide ingress."""
         if not host:
             binding = self.charm.model.get_binding(self.relation_name)
@@ -712,7 +712,7 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
         }
         self.relation.data[self.unit]["data"] = _serialize_data(data)
 
-    def publish_ingress_data(self, *, host: str = None, port: int):
+    def provide_ingress_requirements(self, *, host: str = None, port: int):
         """Publishes the data that Traefik needs to provide ingress.
 
         Args:
@@ -721,7 +721,7 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
              instead
             port: the port of the service (required)
         """
-        self._publish_ingress_data(host, port)
+        self._provide_ingress_requirements(host, port)
 
     @property
     def urls(self) -> dict:

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -460,9 +460,8 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
             return True
         return False
 
-    def get_data(self, relation: Relation, unit: Unit, validate:bool = False) -> RequirerData:
+    def get_data(self, relation: Relation, unit: Unit, validate:bool = False) -> 'RequirerData':
         """Fetch the data shared by this unit via the relation (Requirer side)."""
-        # todo: should we validate here?
         data = _deserialize_data(relation.data[unit]['data'])
         if validate:
             _validate_data(data, INGRESS_REQUIRES_UNIT_SCHEMA)

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -76,10 +76,7 @@ LIBPATCH = 8
 
 log = logging.getLogger(__name__)
 
-# ======================= #
-#      LIBRARY GLOBS      #
-# ======================= #
-
+# LIBRARY GLOBS
 RELATION_INTERFACE = "ingress_per_unit"
 DEFAULT_RELATION_NAME = RELATION_INTERFACE.replace("_", "-")
 
@@ -116,10 +113,7 @@ INGRESS_PROVIDES_APP_SCHEMA = {
 }
 
 
-# ======================= #
-#          TYPES          #
-# ======================= #
-
+# TYPES
 try:
     from typing import TypedDict
 except ImportError:
@@ -140,11 +134,7 @@ KeyValueMapping = Dict[str, str]
 ProviderApplicationData = Dict[str, KeyValueMapping]
 
 
-# ======================= #
-#  SERIALIZATION UTILS    #
-# ======================= #
-
-
+# SERIALIZATION UTILS
 def _deserialize_data(data):
     return yaml.safe_load(data)
 
@@ -160,11 +150,7 @@ def _validate_data(data, schema):
         raise DataValidationError(data, schema) from e
 
 
-# ======================= #
-#       EXCEPTIONS        #
-# ======================= #
-
-
+# EXCEPTIONS
 class IngressPerUnitException(RuntimeError):
     """Base class for errors raised by Ingress Per Unit."""
 
@@ -213,11 +199,7 @@ class RelationPermissionError(IngressPerUnitException):
         self.relation = relation
 
 
-# ======================= #
-#         EVENTS          #
-# ======================= #
-
-
+# EVENTS
 class RelationAvailableEvent(RelationEvent):
     """Event triggered when a relation is ready for requests."""
 

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -333,6 +333,7 @@ class _IngressPerUnitBase(Object):
 
 class IngressPerUnitProvider(_IngressPerUnitBase):
     """Implementation of the provider of ingress_per_unit."""
+
     on = IngressPerUnitEvents()
 
     def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -457,6 +457,8 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
 
     def is_unit_ready(self, relation: Relation, unit: Unit) -> bool:
         """Report whether the given unit has shared data in its unit data bag."""
+        # sanity check: this should not occur in production, but it may happen
+        # during testing: cfr https://github.com/canonical/traefik-k8s-operator/issues/39
         assert (
             unit in relation.units
         ), "attempting to get ready state for unit that does not belong to relation"

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -456,7 +456,7 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
         return False
 
     def is_unit_ready(self, relation: Relation, unit: Unit) -> bool:
-        """Whether the given unit has shared its side of the data."""
+        """Report whether the given unit has shared data in its unit data bag."""
         assert (
             unit in relation.units
         ), "attempting to get ready state for unit that does not belong to relation"

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -466,7 +466,7 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
         return False
 
     def get_data(self, relation: Relation, unit: Unit, validate: bool = False) -> "RequirerData":
-        """Fetch the data shared by this unit via the relation (Requirer side)."""
+        """Fetch the data shared by the specified unit on the relation (Requirer side)."""
         data = _deserialize_data(relation.data[unit]["data"])
         if validate:
             _validate_data(data, INGRESS_REQUIRES_UNIT_SCHEMA)

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -73,7 +73,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 log = logging.getLogger(__name__)
 

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -344,7 +344,9 @@ class _IngressPerUnitBase(Object):
         """
         if relation is None:
             return any(map(self.is_ready, self.relations))
-
+        if relation.app is None:
+            # No idea why, but this happened once.
+            return False
         if not relation.app.name:  # type: ignore
             # Juju doesn't provide JUJU_REMOTE_APP during relation-broken
             # hooks. See https://github.com/canonical/operator/issues/693
@@ -450,11 +452,6 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
 
         return False
 
-    def get_request(self, relation: Relation):
-        """Get the IngressRequest for the given Relation."""
-        provider_app_data, requirer_unit_data = self._fetch_relation_data(relation)
-        return IngressRequest(self, relation, provider_app_data, requirer_unit_data)
-
     def is_unit_ready(self, relation: Relation, unit: Unit) -> bool:
         """Whether the given unit has shared its side of the data."""
         assert unit in relation.units, "attempting to get ready state for unit that does not belong to relation"
@@ -484,8 +481,16 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
         except DataValidationError as e:
             log.error(f"unable to publish url to {unit_name}: "
                       f"corrupted application databag")
+            return
         data['ingress'][unit_name] = {'url': url}
         relation.data[self.app]['data'] = _serialize_data(data)
+
+    def wipe_ingress_data(self, relation):
+        """Remove all published ingress data.
+
+        Assumes that this unit is leader.
+        """
+        relation.data[self.app]['data'] = ""
 
     def _fetch_relation_data(
         self, relation: Relation, validate=False
@@ -569,163 +574,6 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
             results.update(provider_app_data)
 
         return results
-
-
-class IngressRequest:
-    """A request for per-unit ingress."""
-
-    def __init__(
-        self,
-        provider: IngressPerUnitProvider,
-        relation: Relation,
-        provider_app_data: ProviderApplicationData,
-        requirer_unit_data: RequirerUnitData,
-    ):
-        """Construct an IngressRequest."""
-        self._provider = provider
-        self._relation = relation
-        self._provider_app_data = provider_app_data
-        self._requirer_unit_data = requirer_unit_data
-        self._related_units = relation.units
-
-    @property
-    def model(self) -> Optional[str]:
-        """The name of the model the request was made from."""
-        return self._get_data_from_first_unit("model")
-
-    @property
-    def app_name(self) -> Optional[str]:
-        """The name of the remote app.
-
-        Note: This is not the same for the other charm as `self.app.name`
-        when using cross-model relations (CMRs), since `self.app.name` is
-        replaced by a `remote-{UUID}` pattern on the other side of a CMR.
-        """
-        first_unit_name = self._get_data_from_first_unit("name")
-
-        if first_unit_name:
-            return first_unit_name.split("/")[0]
-
-        return None
-
-    @property
-    def units(self) -> List[Unit]:
-        """The remote units that have posted requests, i.e., those that have provided the name."""
-        ready_units = filter(self.is_unit_ready, self._related_units)
-        return sorted(ready_units, key=lambda unit: unit.name)
-
-    def is_unit_ready(self, unit: Unit) -> bool:
-        """Whether the given unit has provided its name, model, host and port data."""
-        self._check_unit_belongs_to_relation(unit)
-
-        return all(
-            (
-                self.get_unit_host(unit),
-                self.get_unit_name(unit),
-                self.get_unit_model(unit),
-                self.get_unit_port(unit),
-            )
-        )
-
-    @property
-    def port(self) -> Optional[int]:
-        """The backend port."""
-        warnings.warn(
-            "The 'port' method is deprecated, as it is not guaranteed that all"
-            "units have the same port. use 'get_unit_port' instead",
-            DeprecationWarning,
-        )
-
-        return self._get_data_from_first_unit("port")
-
-    # deprecated
-    def get_host(self, unit: Unit) -> Optional[str]:
-        """The hostname (DNS address, ip) of the given unit."""
-        warnings.warn(
-            "The 'get_host' method is deprecated, use 'get_unit_host' instead", DeprecationWarning
-        )
-        return self.get_unit_host(unit)
-
-    def get_unit_host(self, unit: Unit) -> Optional[str]:
-        """The hostname (DNS address, ip) of the given unit."""
-        self._check_unit_belongs_to_relation(unit)
-
-        return self._get_unit_data(unit, "host")
-
-    def get_unit_port(self, unit: Unit) -> Optional[int]:
-        """The port of the given unit."""
-        self._check_unit_belongs_to_relation(unit)
-
-        port = self._get_unit_data(unit, "port")
-        return str(port) if port else None
-
-    def get_unit_model(self, unit: Unit) -> Optional[str]:
-        """The model of the remote unit.
-
-        Note: This is not the same as `self.model.name` when using CMR relations,
-        since `self.model.name` is replaced by a `remote-{UUID}` pattern.
-        """
-        self._check_unit_belongs_to_relation(unit)
-
-        return self._get_unit_data(unit, "model")
-
-    def get_unit_name(self, unit: Unit) -> Optional[str]:
-        """The name of the remote unit.
-
-        Note: This is not the same as `self.unit.name` when using CMR relations,
-        since `self.unit.name` is replaced by a `remote-{UUID}` pattern.
-        """
-        self._check_unit_belongs_to_relation(unit)
-
-        return self._get_unit_data(unit, "name")
-
-    def _get_data_from_first_unit(self, key: str) -> Any:
-        # We search among the ready units, which are those known to
-        # have put their side of the data in the relation, see is_unit_ready
-        ready_units = self.units
-        if ready_units:
-            return self._get_unit_data(ready_units[0], key)
-
-    def _get_unit_data(self, unit: Unit, key: str) -> Any:
-        """Fetch from the unit databag the value associated with `key`.
-
-        Typed as Any because it can be any yaml/json serializable entity.
-        For what it could be in practice, refer to INGRESS_REQUIRES_UNIT_SCHEMA.
-        """
-        self._check_unit_belongs_to_relation(unit)
-
-        # Could be that the unit did not share any data yet (not ready),
-        # so we have to guard against `unit` not being in `self._data`.
-        return self._requirer_unit_data.get(unit, {}).get(key, None)
-
-    def respond(self, unit: Unit, url: str):
-        """Send URL back for the given unit.
-
-        Note: only the leader can send URLs.
-        """
-        this_unit = self._provider.charm.unit
-        if not this_unit.is_leader():
-            raise RelationPermissionError(self._relation, this_unit, "This unit is not the leader")
-
-        self._check_unit_belongs_to_relation(unit)
-
-        if not self.is_unit_ready(unit):
-            raise IngressPerUnitException(
-                "Unable to get name of unit {}: this unit has not responded yet.".format(unit)
-            )
-
-        remote_unit_name = self.get_unit_name(unit)
-
-        assert remote_unit_name, "The remote unit has not provided its name in the relation yet"
-
-        self._provider_app_data[remote_unit_name] = {"url": url}
-
-        self._provider.publish_ingress_data(self._relation, self._provider_app_data)
-
-    def _check_unit_belongs_to_relation(self, unit: Unit):
-        """Checks that `unit` belongs to the relation this response manages."""
-        if unit not in self._related_units:
-            raise UnknownUnitException(self._relation, unit)
 
 
 class IngressPerUnitConfigurationChangeEvent(RelationEvent):

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -333,6 +333,7 @@ class _IngressPerUnitBase(Object):
 
 class IngressPerUnitProvider(_IngressPerUnitBase):
     """Implementation of the provider of ingress_per_unit."""
+    on = IngressPerUnitEvents()
 
     def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
         """Constructor for IngressPerUnitProvider.

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -49,7 +49,6 @@ class SomeCharm(CharmBase):
 import logging
 from typing import Dict, Optional, Tuple, TypeVar, Union
 
-import jsonschema
 import ops.model
 import yaml
 from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
@@ -75,6 +74,20 @@ LIBAPI = 0
 LIBPATCH = 8
 
 log = logging.getLogger(__name__)
+
+try:
+    import jsonschema
+
+    DO_VALIDATION = True
+except ModuleNotFoundError:
+    log.warning(
+        "The `ingress_per_unit` library needs the `jsonschema` package to be able "
+        "to do runtime data validation; without it, it will still work but validation "
+        "will be disabled. \n"
+        "It is recommended to add `jsonschema` to the 'requirements.txt' of your charm, "
+        "which will enable this feature."
+    )
+    DO_VALIDATION = False
 
 # LIBRARY GLOBS
 RELATION_INTERFACE = "ingress_per_unit"
@@ -135,15 +148,17 @@ ProviderApplicationData = Dict[str, KeyValueMapping]
 
 
 # SERIALIZATION UTILS
-def _deserialize_data(data):
+def _deserialize_data(data: str):
     return yaml.safe_load(data)
 
 
-def _serialize_data(data):
+def _serialize_data(data) -> str:
     return yaml.safe_dump(data, indent=2)
 
 
 def _validate_data(data, schema):
+    if not DO_VALIDATION:
+        return
     try:
         jsonschema.validate(instance=data, schema=schema)
     except jsonschema.ValidationError as e:
@@ -416,7 +431,7 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
 
         try:
             # grab the data and validate it; might raise
-            _, requirer_unit_data = self._fetch_relation_data(relation, validate=True)
+            _, requirer_unit_data = self._fetch_relation_data(relation)
         except DataValidationError as e:
             log.warning("Failed to validate relation data for {} relation: {}".format(relation, e))
             return True
@@ -449,11 +464,10 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
             return True
         return False
 
-    def get_data(self, relation: Relation, unit: Unit, validate: bool = False) -> "RequirerData":
+    def get_data(self, relation: Relation, unit: Unit) -> "RequirerData":
         """Fetch the data shared by the specified unit on the relation (Requirer side)."""
         data = _deserialize_data(relation.data[unit]["data"])
-        if validate:
-            _validate_data(data, INGRESS_REQUIRES_UNIT_SCHEMA)
+        _validate_data(data, INGRESS_REQUIRES_UNIT_SCHEMA)
         return data
 
     def publish_url(self, relation: Relation, unit_name: str, url: str):
@@ -493,7 +507,7 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
         relation.data[self.app]["data"] = ""
 
     def _fetch_relation_data(
-        self, relation: Relation, validate=False
+        self, relation: Relation
     ) -> Tuple[ProviderApplicationData, RequirerUnitData]:
         """Fetch and validate the databags.
 
@@ -517,8 +531,7 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
             deserialized = {}
             if data:
                 deserialized = _deserialize_data(data)
-                if validate:
-                    _validate_data(deserialized, INGRESS_PROVIDES_APP_SCHEMA)
+                _validate_data(deserialized, INGRESS_PROVIDES_APP_SCHEMA)
             provider_app_data = deserialized.get("ingress", {})
 
         # then look at the requirer's (thus remote) unit databags
@@ -530,8 +543,7 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
             remote_deserialized = {}
             if remote_data:
                 remote_deserialized = _deserialize_data(remote_data)
-                if validate:
-                    _validate_data(remote_deserialized, INGRESS_REQUIRES_UNIT_SCHEMA)
+                _validate_data(remote_deserialized, INGRESS_REQUIRES_UNIT_SCHEMA)
             requirer_unit_data[remote_unit] = remote_deserialized
 
         return provider_app_data, requirer_unit_data
@@ -636,7 +648,8 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
 
     def _publish_auto_data(self, relation: Relation):
         if self._auto_data and self.is_available(relation):
-            self._provide_ingress_requirements(*self._auto_data)
+            host, port = self._auto_data
+            self.provide_ingress_requirements(host=host, port=port)
 
     @property
     def relation(self) -> Optional[Relation]:
@@ -698,8 +711,15 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
         # TODO Avoid spurious events, emit only when URL changes
         self.on.ingress_changed.emit(self.relation)
 
-    def _provide_ingress_requirements(self, host: Optional[str], port: int):
-        """Publish the data that the provider needs to provide ingress."""
+    def provide_ingress_requirements(self, *, host: str = None, port: int):
+        """Publishes the data that Traefik needs to provide ingress.
+
+        Args:
+            host: Hostname to be used by the ingress provider to address the
+             requirer unit; if unspecified, the pod ip of the unit will be used
+             instead
+            port: the port of the service (required)
+        """
         if not host:
             binding = self.charm.model.get_binding(self.relation_name)
             host = str(binding.network.bind_address)
@@ -710,18 +730,8 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
             "host": host,
             "port": port,
         }
+        _validate_data(data, INGRESS_REQUIRES_UNIT_SCHEMA)
         self.relation.data[self.unit]["data"] = _serialize_data(data)
-
-    def provide_ingress_requirements(self, *, host: str = None, port: int):
-        """Publishes the data that Traefik needs to provide ingress.
-
-        Args:
-            host: Hostname to be used by the ingress provider to address the
-             requirer unit; if unspecified, the pod ip of the unit will be used
-             instead
-            port: the port of the service (required)
-        """
-        self._provide_ingress_requirements(host, port)
 
     @property
     def urls(self) -> dict:

--- a/src/charm.py
+++ b/src/charm.py
@@ -304,7 +304,7 @@ class TraefikIngressCharm(CharmBase):
             # if the unit is ready, it's implied that the data is there.
             # but we should still ensure it's valid, hence...
             try:
-                data: RequirerData = provider.get_data(relation, unit, validate=True)
+                data: 'RequirerData' = provider.get_data(relation, unit, validate=True)
             except DataValidationError as e:
                 # is_unit_ready should guard against no data being there yet,
                 # but if the data is invalid...
@@ -335,21 +335,15 @@ class TraefikIngressCharm(CharmBase):
             self._wipe_ingress_for_relation(relation)
 
     def _generate_per_unit_config(
-        self, unit: Unit, data: RequirerData
+        self, unit: Unit, data: 'RequirerData'
     ) -> Tuple[Optional[dict], Optional[str]]:
         """Generate a config dict for a given unit for IngressPerUnit."""
         config = {"http": {"routers": {}, "services": {}}}
-
-        raw_unit_name = data['name']
-        model = data['model']
-
-        unit_name = raw_unit_name.replace("/", "-")
-        prefix = f"{model}-{unit_name}"
-
-        unit_address = data['host']
+        name = data['name'].replace("/", "-")
+        prefix = f"{data['model']}-{name}"
 
         host = self._external_host
-        if self._routing_mode == _RoutingMode.path:
+        if self._routing_mode is _RoutingMode.path:
             route_rule = f"PathPrefix(`/{prefix}`)"
             unit_url = f"http://{host}:{self._port}/{prefix}"
         else:  # _RoutingMode.subdomain
@@ -366,7 +360,7 @@ class TraefikIngressCharm(CharmBase):
         }
 
         config["http"]["services"][traefik_service_name] = {
-            "loadBalancer": {"servers": [{"url": f"http://{unit_address}:{data['port']}"}]}
+            "loadBalancer": {"servers": [{"url": f"http://{data['host']}:{data['port']}"}]}
         }
 
         return config, unit_url

--- a/src/charm.py
+++ b/src/charm.py
@@ -312,7 +312,7 @@ class TraefikIngressCharm(CharmBase):
             # if the unit is ready, it's implied that the data is there.
             # but we should still ensure it's valid, hence...
             try:
-                data: "RequirerData" = provider.get_data(relation, unit, validate=True)
+                data: "RequirerData" = provider.get_data(relation, unit)
             except DataValidationError as e:
                 # is_unit_ready should guard against no data being there yet,
                 # but if the data is invalid...

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,7 +12,6 @@ from typing import Optional, Tuple
 import yaml
 from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
-from charms.traefik_k8s.v0.branching_ops import CharmBase, Branch
 from charms.traefik_k8s.v0.ingress import IngressPerAppProvider
 from charms.traefik_k8s.v0.ingress_per_unit import (
     DataValidationError,
@@ -24,6 +23,7 @@ from lightkube import Client
 from lightkube.resources.core_v1 import Service
 from ops.charm import (
     ActionEvent,
+    CharmBase,
     ConfigChangedEvent,
     PebbleReadyEvent,
     RelationEvent,

--- a/src/charm.py
+++ b/src/charm.py
@@ -288,7 +288,7 @@ class TraefikIngressCharm(CharmBase):
             self._push_configurations(relation, config)
 
         else:
-            self._provide_ingress_per_unit(relation)
+            self._provide_ingress_per_unit(relation, provider)
 
     def _provide_ingress_per_unit(self, relation: Relation,
                                   provider: IngressPerUnitProvider):
@@ -316,7 +316,7 @@ class TraefikIngressCharm(CharmBase):
 
             if unit_url:
                 if self.unit.is_leader():
-                    pass
+                    provider.publish_url(relation, data['name'], unit_url)
 
             if unit_config:
                 always_merger.merge(config, unit_config)

--- a/src/charm.py
+++ b/src/charm.py
@@ -103,7 +103,7 @@ class TraefikIngressCharm(CharmBase):
         self.framework.observe(self.ingress_per_app.on.failed, self._handle_ingress_failure)
         self.framework.observe(self.ingress_per_app.on.broken, self._handle_ingress_broken)
 
-        self.framework.observe(self.ingress_per_unit.on.request, self._handle_ingress_request)
+        self.framework.observe(self.ingress_per_unit.on.ready, self._handle_ingress_request)
         self.framework.observe(self.ingress_per_unit.on.failed, self._handle_ingress_failure)
         self.framework.observe(self.ingress_per_unit.on.broken, self._handle_ingress_broken)
         # Work around SDI not handling scale-down

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,6 +12,7 @@ from typing import Optional, Tuple
 import yaml
 from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
+from charms.traefik_k8s.v0.branching_ops import CharmBase, Branch
 from charms.traefik_k8s.v0.ingress import IngressPerAppProvider
 from charms.traefik_k8s.v0.ingress_per_unit import (
     DataValidationError,
@@ -23,7 +24,6 @@ from lightkube import Client
 from lightkube.resources.core_v1 import Service
 from ops.charm import (
     ActionEvent,
-    CharmBase,
     ConfigChangedEvent,
     PebbleReadyEvent,
     RelationEvent,

--- a/src/charm.py
+++ b/src/charm.py
@@ -282,7 +282,7 @@ class TraefikIngressCharm(CharmBase):
         self.unit.status = MaintenanceStatus(f"updating ingress configuration for '{rel}'")
         logger.debug("Updating ingress for relation '%s'", rel)
 
-        # TODO: once also IngressPerApp is SDI-free,
+        # TODO: once IngressPerApp is also SDI-free,
         #  abstract the common logic here and remove this branch
         if provider is self.ingress_per_app:
             request = provider.get_request(relation)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -44,7 +44,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPURequirer(self.harness)
         relation = requirer.relate()
-        requirer.request(host="10.1.10.1", port=9000)
+        requirer.publish_ingress_data(host="10.1.10.1", port=9000)
         assert requirer.is_available(relation)
 
         traefik_container = self.harness.charm.unit.get_container("traefik")
@@ -188,7 +188,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPURequirer(self.harness)
         relation = requirer.relate()
-        requirer.request(host="10.1.10.1", port=9000)
+        requirer.publish_ingress_data(host="10.1.10.1", port=9000)
         assert requirer.is_available(relation)
 
         traefik_container = self.harness.charm.unit.get_container("traefik")
@@ -246,7 +246,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPURequirer(self.harness)
         relation = requirer.relate()
-        requirer.request(host="10.1.10.1", port=9000)
+        requirer.publish_ingress_data(host="10.1.10.1", port=9000)
         assert requirer.is_available(relation)
 
         traefik_container = self.harness.charm.unit.get_container("traefik")
@@ -318,7 +318,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPURequirer(self.harness)
         relation = requirer.relate()
-        requirer.request(host="10.1.10.1", port=9000)
+        requirer.publish_ingress_data(host="10.1.10.1", port=9000)
 
         assert requirer.is_available(relation)
         assert not requirer.is_ready(relation)
@@ -335,7 +335,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPURequirer(self.harness)
         relation = requirer.relate()
-        requirer.request(host="10.1.10.1", port=9000)
+        requirer.publish_ingress_data(host="10.1.10.1", port=9000)
 
         self.harness.container_pebble_ready("traefik")
 
@@ -359,7 +359,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPURequirer(self.harness)
         relation = requirer.relate()
-        requirer.request(host="10.1.10.1", port=9000)
+        requirer.publish_ingress_data(host="10.1.10.1", port=9000)
 
         self.harness.container_pebble_ready("traefik")
 
@@ -395,7 +395,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPURequirer(self.harness)
         relation = requirer.relate()
-        requirer.request(host="10.1.10.1", port=9000)
+        requirer.publish_ingress_data(host="10.1.10.1", port=9000)
         assert requirer.is_available(relation)
         assert requirer.is_ready(relation)
 
@@ -413,7 +413,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
             self.harness.charm.unit.status, WaitingStatus("gateway address unavailable")
         )
 
-        self.assertEqual(requirer.urls, {"ingress-per-unit-remote/0": ""})
+        self.assertEqual(requirer.urls, {})
 
     def test_relation_broken(self):
         self.test_pebble_ready_with_gateway_address_from_config_and_path_routing_mode()
@@ -472,7 +472,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPURequirer(self.harness)
         requirer.relate()
-        requirer.request(host="10.0.0.1", port=3000)
+        requirer.publish_ingress_data(host="10.0.0.1", port=3000)
 
         self.harness.container_pebble_ready("traefik")
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -44,7 +44,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPURequirer(self.harness)
         relation = requirer.relate()
-        requirer.publish_ingress_data(host="10.1.10.1", port=9000)
+        requirer.provide_ingress_requirements(host="10.1.10.1", port=9000)
         assert requirer.is_available(relation)
 
         traefik_container = self.harness.charm.unit.get_container("traefik")
@@ -188,7 +188,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPURequirer(self.harness)
         relation = requirer.relate()
-        requirer.publish_ingress_data(host="10.1.10.1", port=9000)
+        requirer.provide_ingress_requirements(host="10.1.10.1", port=9000)
         assert requirer.is_available(relation)
 
         traefik_container = self.harness.charm.unit.get_container("traefik")
@@ -246,7 +246,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPURequirer(self.harness)
         relation = requirer.relate()
-        requirer.publish_ingress_data(host="10.1.10.1", port=9000)
+        requirer.provide_ingress_requirements(host="10.1.10.1", port=9000)
         assert requirer.is_available(relation)
 
         traefik_container = self.harness.charm.unit.get_container("traefik")
@@ -318,7 +318,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPURequirer(self.harness)
         relation = requirer.relate()
-        requirer.publish_ingress_data(host="10.1.10.1", port=9000)
+        requirer.provide_ingress_requirements(host="10.1.10.1", port=9000)
 
         assert requirer.is_available(relation)
         assert not requirer.is_ready(relation)
@@ -335,7 +335,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPURequirer(self.harness)
         relation = requirer.relate()
-        requirer.publish_ingress_data(host="10.1.10.1", port=9000)
+        requirer.provide_ingress_requirements(host="10.1.10.1", port=9000)
 
         self.harness.container_pebble_ready("traefik")
 
@@ -359,7 +359,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPURequirer(self.harness)
         relation = requirer.relate()
-        requirer.publish_ingress_data(host="10.1.10.1", port=9000)
+        requirer.provide_ingress_requirements(host="10.1.10.1", port=9000)
 
         self.harness.container_pebble_ready("traefik")
 
@@ -395,7 +395,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPURequirer(self.harness)
         relation = requirer.relate()
-        requirer.publish_ingress_data(host="10.1.10.1", port=9000)
+        requirer.provide_ingress_requirements(host="10.1.10.1", port=9000)
         assert requirer.is_available(relation)
         assert requirer.is_ready(relation)
 
@@ -472,7 +472,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPURequirer(self.harness)
         requirer.relate()
-        requirer.publish_ingress_data(host="10.0.0.1", port=3000)
+        requirer.provide_ingress_requirements(host="10.0.0.1", port=3000)
 
         self.harness.container_pebble_ready("traefik")
 

--- a/tests/unit/test_lib_helpers.py
+++ b/tests/unit/test_lib_helpers.py
@@ -3,7 +3,6 @@
 """Helpers for unit testing charms which use this library."""
 import typing
 from contextlib import contextmanager
-from functools import partial
 from unittest.mock import patch
 
 from charms.traefik_k8s.v0.ingress import (

--- a/tests/unit/test_lib_helpers.py
+++ b/tests/unit/test_lib_helpers.py
@@ -16,7 +16,7 @@ from charms.traefik_k8s.v0.ingress_per_unit import (
     RELATION_INTERFACE,
     IngressPerUnitProvider,
     IngressPerUnitRequirer,
-    IngressRequest,
+    ProviderApplicationData,
 )
 from ops.charm import CharmBase, CharmEvents, CharmMeta
 from ops.model import Relation
@@ -141,45 +141,15 @@ class MockIPUProvider(MockRemoteIPUMixin, IngressPerUnitProvider):
     ROLE = "provides"
     LIMIT = None
 
-    def _mock_respond(self, unit, url, _respond, _relation):
-        with self.remote_context(_relation):
-            _respond(unit, url)
+    def publish_url(self, relation: Relation, unit_name: str, url: str):
+        with self.remote_context(self.relation):
+            super().publish_url(relation, unit_name, url)
+        self.harness._charm.on.ingress_per_unit_relation_changed.emit(self.relation)
 
-    def get_request(self, relation: Relation):
-        """Get the IngressRequest for the given Relation."""
-        # reflect the relation for the request so that it appears remote
-        with self.remote_context(relation):
-            provider_app_data, requirers_unit_data = self._fetch_relation_data(relation)
-            request = MockIngressPerUnitRequest(
-                self, relation, provider_app_data, requirers_unit_data
-            )
-            request.respond = partial(
-                self._mock_respond, _respond=request.respond, _relation=relation
-            )
-            return request
-
-
-class MockIngressPerUnitRequest(IngressRequest):
-    """Testing wrapper for an IngressRequest.
-
-    Exactly the same as the normal IngressRequest but acts as if it's on the
-    remote side of any relation, and it automatically triggers events when
-    responses are sent.
-    """
-
-    _provider: MockIPUProvider
-
-    def __init__(
-        self,
-        provider: MockIPUProvider,
-        relation: Relation,
-        provider_app_data: dict,
-        requirers_unit_data: dict,
-    ):
-        super().__init__(provider, relation, provider_app_data, requirers_unit_data)
-
-        self.app = self._provider.harness.charm.app
-        self._related_units = {self._provider.harness.charm.unit}
+    def publish_ingress_data(self, relation: Relation, data: ProviderApplicationData):
+        with self.remote_context(self.relation):
+            super().publish_url(relation, data)
+        self.harness._charm.on.ingress_per_unit_relation_changed.emit(self.relation)
 
 
 class MockIPURequirer(MockRemoteIPUMixin, IngressPerUnitRequirer):
@@ -198,9 +168,9 @@ class MockIPURequirer(MockRemoteIPUMixin, IngressPerUnitRequirer):
         with self.remote_context(self.relation):
             return super().urls
 
-    def request(self, *, host: str = None, port: int):
+    def publish_ingress_data(self, *, host: str = None, port: int):
         with self.remote_context(self.relation):
-            super().request(host=host, port=port)
+            super().publish_ingress_data(host=host, port=port)
         self.harness._charm.on.ingress_per_unit_relation_changed.emit(self.relation)
 
 

--- a/tests/unit/test_lib_helpers.py
+++ b/tests/unit/test_lib_helpers.py
@@ -145,7 +145,7 @@ class MockIPUProvider(MockRemoteIPUMixin, IngressPerUnitProvider):
             super().publish_url(relation, unit_name, url)
         self.harness._charm.on.ingress_per_unit_relation_changed.emit(self.relation)
 
-    def publish_ingress_data(self, relation: Relation, data: ProviderApplicationData):
+    def provide_ingress_requirements(self, relation: Relation, data: ProviderApplicationData):
         with self.remote_context(self.relation):
             super().publish_url(relation, data)
         self.harness._charm.on.ingress_per_unit_relation_changed.emit(self.relation)
@@ -167,9 +167,9 @@ class MockIPURequirer(MockRemoteIPUMixin, IngressPerUnitRequirer):
         with self.remote_context(self.relation):
             return super().urls
 
-    def publish_ingress_data(self, *, host: str = None, port: int):
+    def provide_ingress_requirements(self, *, host: str = None, port: int):
         with self.remote_context(self.relation):
-            super().publish_ingress_data(host=host, port=port)
+            super().provide_ingress_requirements(host=host, port=port)
         self.harness._charm.on.ingress_per_unit_relation_changed.emit(self.relation)
 
 

--- a/tests/unit/test_lib_per_unit_provides.py
+++ b/tests/unit/test_lib_per_unit_provides.py
@@ -87,7 +87,7 @@ def test_ingress_unit_provider_supported_versions_shim(provider, requirer, harne
 
 def test_ingress_unit_provider_request(provider, requirer, harness):
     relation = requirer.relate()
-    requirer.request(port=80)
+    requirer.publish_ingress_data(port=80)
     assert provider.is_available(relation)
     assert provider.is_ready(relation)
     assert not provider.is_failed(relation)
@@ -96,27 +96,32 @@ def test_ingress_unit_provider_request(provider, requirer, harness):
     assert not requirer.is_failed(relation)
 
 
-def test_ingress_unit_provider_request_response_nonleader(provider, requirer, harness):
+@pytest.mark.parametrize("port, host", ((80, "1.1.1.1"), (81, "10.1.10.1")))
+def test_ingress_unit_provider_request_response_nonleader(provider, requirer, harness, port, host):
+    provider: IngressPerUnitProvider
     relation = requirer.relate()
-    requirer.request(port=80)
-    request = provider.get_request(relation)
-    assert request.units[0] is requirer.charm.unit
-    assert request.app_name == "ingress-per-unit-remote"
-    # fails because unit isn't leader
+    requirer.publish_ingress_data(port=port, host=host)
+
+    unit_data = provider.get_data(relation, requirer.charm.unit, validate=True)
+    assert unit_data["model"] == requirer.charm.model.name
+    assert unit_data["name"] == requirer.charm.unit.name
+    assert unit_data["host"] == host
+    assert unit_data["port"] == port
+
+    # fail because unit isn't leader
     with pytest.raises(RelationPermissionError):
-        request.respond(requirer.charm.unit, "http://url/")
+        provider.publish_url(relation, unit_data["name"], "http://url/")
 
 
-def test_ingress_unit_provider_request_response(provider, requirer, harness):
+@pytest.mark.parametrize("url", ("http://url/", "http://url2/"))
+def test_ingress_unit_provider_request_response(provider, requirer, harness, url):
     relation = requirer.relate()
     harness.set_leader(True)
-    requirer.request(port=80)
-    request = provider.get_request(relation)
-    assert request.units[0] is requirer.charm.unit
-    assert request.app_name == "ingress-per-unit-remote"
-    request.respond(requirer.charm.unit, "http://url/")
+    requirer.publish_ingress_data(port=80)
+
+    provider.publish_url(relation, requirer.unit.name, url)
     assert requirer.is_available(relation)
     assert requirer.is_ready(relation)
     assert not requirer.is_failed(relation)
-    assert requirer.urls == {"ingress-per-unit-remote/0": "http://url/"}
-    assert requirer.url == "http://url/"
+    assert requirer.urls == {"ingress-per-unit-remote/0": url}
+    assert requirer.url == url

--- a/tests/unit/test_lib_per_unit_provides.py
+++ b/tests/unit/test_lib_per_unit_provides.py
@@ -102,7 +102,7 @@ def test_ingress_unit_provider_request_response_nonleader(provider, requirer, ha
     relation = requirer.relate()
     requirer.provide_ingress_requirements(port=port, host=host)
 
-    unit_data = provider.get_data(relation, requirer.charm.unit, validate=True)
+    unit_data = provider.get_data(relation, requirer.charm.unit)
     assert unit_data["model"] == requirer.charm.model.name
     assert unit_data["name"] == requirer.charm.unit.name
     assert unit_data["host"] == host

--- a/tests/unit/test_lib_per_unit_provides.py
+++ b/tests/unit/test_lib_per_unit_provides.py
@@ -87,7 +87,7 @@ def test_ingress_unit_provider_supported_versions_shim(provider, requirer, harne
 
 def test_ingress_unit_provider_request(provider, requirer, harness):
     relation = requirer.relate()
-    requirer.publish_ingress_data(port=80)
+    requirer.provide_ingress_requirements(port=80)
     assert provider.is_available(relation)
     assert provider.is_ready(relation)
     assert not provider.is_failed(relation)
@@ -100,7 +100,7 @@ def test_ingress_unit_provider_request(provider, requirer, harness):
 def test_ingress_unit_provider_request_response_nonleader(provider, requirer, harness, port, host):
     provider: IngressPerUnitProvider
     relation = requirer.relate()
-    requirer.publish_ingress_data(port=port, host=host)
+    requirer.provide_ingress_requirements(port=port, host=host)
 
     unit_data = provider.get_data(relation, requirer.charm.unit, validate=True)
     assert unit_data["model"] == requirer.charm.model.name
@@ -117,7 +117,7 @@ def test_ingress_unit_provider_request_response_nonleader(provider, requirer, ha
 def test_ingress_unit_provider_request_response(provider, requirer, harness, url):
     relation = requirer.relate()
     harness.set_leader(True)
-    requirer.publish_ingress_data(port=80)
+    requirer.provide_ingress_requirements(port=80)
 
     provider.publish_url(relation, requirer.unit.name, url)
     assert requirer.is_available(relation)

--- a/tests/unit/test_lib_per_unit_requires.py
+++ b/tests/unit/test_lib_per_unit_requires.py
@@ -162,5 +162,6 @@ def test_ipu_on_new_related_unit_nonready(requirer, provider, harness):
     new_unit = next(u for u in relation.units if u is not requirer.charm.unit)
 
     # we add the unit to the related_units because test_lib_helpers is borked
+    # see https://github.com/canonical/traefik-k8s-operator/issues/39 for more
     request._related_units.add(new_unit)
     assert not request.is_unit_ready(new_unit)

--- a/tests/unit/test_lib_per_unit_requires.py
+++ b/tests/unit/test_lib_per_unit_requires.py
@@ -99,7 +99,7 @@ def test_ingress_unit_requirer_leader(requirer, provider, harness):
     assert provider.is_ready(relation)
     assert not provider.is_failed(relation)
     provider: IngressPerUnitProvider
-    data = provider.get_data(relation, requirer.charm.unit, True)
+    data = provider.get_data(relation, requirer.charm.unit)
     assert data["name"] == requirer.charm.unit.name
     assert data["model"] == requirer.charm.model.name
 
@@ -110,7 +110,7 @@ def test_ingress_unit_requirer_request_response(requirer, provider, harness, url
     harness.set_leader(True)
     provider: IngressPerUnitProvider
     requirer: IngressPerUnitRequirer
-    data = provider.get_data(relation, requirer.unit, validate=True)
+    data = provider.get_data(relation, requirer.unit)
 
     provider.publish_url(relation, data["name"], url)
 
@@ -131,7 +131,7 @@ def test_unit_joining_does_not_trigger_ingress_changed(requirer, provider, harne
     relation = provider.relate()
     harness.set_leader(True)
 
-    data = provider.get_data(relation, requirer.unit, validate=True)
+    data = provider.get_data(relation, requirer.unit)
     provider.publish_url(relation, data["name"], url)
 
     harness.add_relation_unit(relation.id, "ingress-remote/1")

--- a/tests/unit/test_lib_per_unit_requires.py
+++ b/tests/unit/test_lib_per_unit_requires.py
@@ -6,7 +6,10 @@ from textwrap import dedent
 from unittest.mock import Mock
 
 import pytest
-from charms.traefik_k8s.v0.ingress_per_unit import IngressPerUnitRequirer
+from charms.traefik_k8s.v0.ingress_per_unit import (
+    IngressPerUnitProvider,
+    IngressPerUnitRequirer,
+)
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.model import Binding
@@ -95,67 +98,78 @@ def test_ingress_unit_requirer_leader(requirer, provider, harness):
     assert provider.is_available(relation)
     assert provider.is_ready(relation)
     assert not provider.is_failed(relation)
+    provider: IngressPerUnitProvider
+    data = provider.get_data(relation, requirer.charm.unit, True)
+    assert data["name"] == requirer.charm.unit.name
+    assert data["model"] == requirer.charm.model.name
 
-    request = provider.get_request(relation)
-    assert request.units[0] is requirer.charm.unit
-    assert request.app_name == requirer.charm.app.name
 
-
-def test_ingress_unit_requirer_request_response(requirer, provider, harness):
+@pytest.mark.parametrize("url", ("http://url/", "http://url2/"))
+def test_ingress_unit_requirer_request_response(requirer, provider, harness, url):
     relation = provider.relate()
     harness.set_leader(True)
+    provider: IngressPerUnitProvider
+    requirer: IngressPerUnitRequirer
+    data = provider.get_data(relation, requirer.unit, validate=True)
 
-    request = provider.get_request(relation)
+    provider.publish_url(relation, data["name"], url)
 
-    request.respond(requirer.charm.unit, "http://url/")
     # FIXME Change to 2 when https://github.com/canonical/operator/pull/705 ships
-    assert harness.charm._stored.num_events == 0
+    assert harness.charm._stored.num_events == 1
     assert requirer.is_available(relation)
     assert requirer.is_ready(relation)
     assert not requirer.is_failed(relation)
-    assert requirer.urls == {"test-requirer/0": "http://url/"}
-    assert requirer.url == "http://url/"
+    assert requirer.urls == {"test-requirer/0": url}
+    assert requirer.url == url
 
 
-def test_unit_joining_does_not_trigger_ingress_changed(requirer, provider, harness):
+@pytest.mark.parametrize("url", ("http://url/", "http://url2/"))
+def test_unit_joining_does_not_trigger_ingress_changed(requirer, provider, harness, url):
+    provider: IngressPerUnitProvider
+    requirer: IngressPerUnitRequirer
+
     relation = provider.relate()
     harness.set_leader(True)
-    request = provider.get_request(relation)
-    request.respond(requirer.charm.unit, "http://url/2")
+
+    data = provider.get_data(relation, requirer.unit, validate=True)
+    provider.publish_url(relation, data["name"], url)
 
     harness.add_relation_unit(relation.id, "ingress-remote/1")
     # FIXME Change to 2 when https://github.com/canonical/operator/pull/705 ships
-    assert harness.charm._stored.num_events == 0
+    assert harness.charm._stored.num_events == 1
 
     # respond with new url: should trigger data changed.
-    request.respond(requirer.charm.unit, "http://url/2")
+    provider.publish_url(relation, requirer.charm.unit.name, url)
     # FIXME Change to 3 when https://github.com/canonical/operator/pull/705 ships
     assert (
-        harness.charm._stored.num_events == 0
+        harness.charm._stored.num_events == 2
     )  # FIXME we should see some relation data change here, shouldn't we?
     assert requirer.is_available(relation)
     assert requirer.is_ready(relation)
     assert not requirer.is_failed(relation)
-    assert requirer.urls == {"test-requirer/0": "http://url/2"}
-    assert requirer.url == "http://url/2"
+    assert requirer.urls == {"test-requirer/0": url}
+    assert requirer.url == url
 
     # respond with same url: should not trigger another event
-    request.respond(requirer.charm.unit, "http://url/2")
+    provider.publish_url(relation, requirer.charm.unit.name, url)
     # FIXME Change to 3 when https://github.com/canonical/operator/pull/705 ships
-    assert harness.charm._stored.num_events == 0
+    assert harness.charm._stored.num_events == 3
 
 
-def test_ipu_on_new_related_unit_nonready(requirer, provider, harness):
+@pytest.mark.parametrize("url", ("http://url/", "http://url2/"))
+def test_ipu_on_new_related_unit_nonready(requirer, provider, harness, url):
     relation = provider.relate()
     harness.set_leader(True)
-    provider.get_request(relation).respond(requirer.charm.unit, "http://url/")
+    provider: IngressPerUnitProvider
+    requirer: IngressPerUnitRequirer
+
+    provider.publish_url(relation, requirer.charm.unit.name, url)
 
     relation_id = harness._backend._relation_ids_map["ingress-per-unit"][0]
     harness.add_relation_unit(relation_id, remote_unit_name="remote/1")
 
     # refresh relation and request vars because we just added a new unit.
     relation = harness.charm.model.relations["ingress-per-unit"][0]
-    request = provider.get_request(relation)
     # provider reports ready even though remote/1 has shared no ingress data yet
     assert provider.is_ready()
     assert len(relation.units) == 2
@@ -163,5 +177,4 @@ def test_ipu_on_new_related_unit_nonready(requirer, provider, harness):
 
     # we add the unit to the related_units because test_lib_helpers is borked
     # see https://github.com/canonical/traefik-k8s-operator/issues/39 for more
-    request._related_units.add(new_unit)
-    assert not request.is_unit_ready(new_unit)
+    assert not provider.is_unit_ready(relation, new_unit)


### PR DESCRIPTION
## Issue
The IngressRequest object is unnecessarily complicated and introduces a confusing layer of request/response mechanics that is hard to reason about.

## Solution
Get rid of that object, replace the existing request/response terminology for 'publish' on the one and the other side.

## Testing Instructions
Unittest

## NB
it depends on the purge-sdi-polish PR, base will change to main as soon as that PR is merged

## Release Notes
Simplified the ingress-per-unit api and internals.

Fixes https://github.com/canonical/traefik-k8s-operator/issues/43