### PR TITLE
Purge SDI from ingress (per app)

### DIFF
--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -110,11 +110,13 @@ class TraefikRouteRequirerReadyEvent(RelationEvent):
 
 class TraefikRouteRequirerEvents(CharmEvents):
     """Container for TraefikRouteRequirer events."""
+
     ready = EventSource(TraefikRouteRequirerReadyEvent)
 
 
 class TraefikRouteProviderEvents(CharmEvents):
     """Container for TraefikRouteProvider events."""
+
     ready = EventSource(TraefikRouteProviderReadyEvent)
 
 
@@ -128,9 +130,10 @@ class TraefikRouteProvider(Object):
     is there.
     The TraefikRouteProvider provides api to do this easily.
     """
+
     on = TraefikRouteProviderEvents()
 
-    def __init__(self, charm: CharmBase, relation_name: str = 'traefik-route'):
+    def __init__(self, charm: CharmBase, relation_name: str = "traefik-route"):
         """Constructor for TraefikRouteProvider.
 
         Args:
@@ -140,8 +143,9 @@ class TraefikRouteProvider(Object):
         """
         super().__init__(charm, relation_name)
         self.charm = charm
-        self.framework.observe(self.charm.on[relation_name].relation_changed,
-                               self._on_relation_changed)
+        self.framework.observe(
+            self.charm.on[relation_name].relation_changed, self._on_relation_changed
+        )
 
     def _on_relation_changed(self, event: RelationEvent):
         if self.is_ready(event.relation):
@@ -151,13 +155,13 @@ class TraefikRouteProvider(Object):
     @staticmethod
     def is_ready(relation: Relation) -> bool:
         """Whether TraefikRoute is ready on this relation: i.e. the remote app shared the config."""
-        return 'config' in relation.data[relation.app]
+        return "config" in relation.data[relation.app]
 
     @staticmethod
     def get_config(relation: Relation) -> Optional[str]:
         """Retrieve the config published by the remote application."""
         # todo validate this config
-        return relation.data[relation.app].get('config')
+        return relation.data[relation.app].get("config")
 
 
 class TraefikRouteRequirer(Object):
@@ -173,10 +177,10 @@ class TraefikRouteRequirer(Object):
     The TraefikRouteRequirer provides api to store this config in the
     application databag.
     """
+
     on = TraefikRouteRequirerEvents()
 
-    def __init__(self, charm: CharmBase, relation: Relation,
-                 relation_name: str = 'traefik-route'):
+    def __init__(self, charm: CharmBase, relation: Relation, relation_name: str = "traefik-route"):
         super(TraefikRouteRequirer, self).__init__(charm, relation_name)
         self._charm = charm
         self._relation = relation
@@ -197,4 +201,4 @@ class TraefikRouteRequirer(Object):
         app_databag = self._relation.data[self._charm.app]
 
         # Traefik thrives on yaml, feels pointless to talk json to Route
-        app_databag['config'] = yaml.safe_dump(config)
+        app_databag["config"] = yaml.safe_dump(config)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,7 +24,7 @@ resources:
     type: oci-image
     description: OCI image for traefik (https://hub.docker.com/_/traefik/)
     # Included for simplicity in integration tests
-    upstream-source: docker.io/jnsgruk/traefik:2.6.1 ### Update this when we settle which image we want to use
+    upstream-source: docker.io/jnsgruk/traefik:2.7.0 ### Update this when we settle which image we want to use
 
 storage:
   # We need to store the configurations in a volume, as Traefik's directory

--- a/src/charm.py
+++ b/src/charm.py
@@ -47,8 +47,8 @@ from ops.model import (
 from ops.pebble import APIError, PathError
 
 if typing.TYPE_CHECKING:
-    from charms.traefik_k8s.v0.ingress_per_unit import RequirerData as RequirerData_IPU
     from charms.traefik_k8s.v0.ingress import RequirerData as RequirerData_IPA
+    from charms.traefik_k8s.v0.ingress_per_unit import RequirerData as RequirerData_IPU
 
 logger = logging.getLogger(__name__)
 
@@ -107,8 +107,12 @@ class TraefikIngressCharm(CharmBase):
         self.framework.observe(self.on.update_status, self._on_update_status)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
 
-        self.framework.observe(self.ingress_per_app.on.data_provided, self._handle_ingress_data_provided)
-        self.framework.observe(self.ingress_per_app.on.data_removed, self._handle_ingress_data_removed)
+        self.framework.observe(
+            self.ingress_per_app.on.data_provided, self._handle_ingress_data_provided
+        )
+        self.framework.observe(
+            self.ingress_per_app.on.data_removed, self._handle_ingress_data_removed
+        )
 
         self.framework.observe(self.ingress_per_unit.on.ready, self._handle_ingress_request)
         self.framework.observe(self.ingress_per_unit.on.failed, self._handle_ingress_failure)
@@ -246,7 +250,7 @@ class TraefikIngressCharm(CharmBase):
     def ready(self) -> bool:
         """Check whether we have an external host set, and traefik is running."""
         if not self._external_host:
-            self._wipe_ingress_for_all_relations() # fixme: no side-effects in prop
+            self._wipe_ingress_for_all_relations()  # fixme: no side-effects in prop
             self.unit.status = WaitingStatus("gateway address unavailable")
             return False
         if not self._is_traefik_service_running():

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,6 +7,7 @@
 import enum
 import json
 import logging
+import typing
 from typing import Tuple
 
 import yaml
@@ -16,7 +17,6 @@ from charms.traefik_k8s.v0.ingress import IngressPerAppProvider
 from charms.traefik_k8s.v0.ingress_per_unit import (
     DataValidationError,
     IngressPerUnitProvider,
-    RequirerData,
 )
 from charms.traefik_route_k8s.v0.traefik_route import (
     TraefikRouteProvider,
@@ -45,6 +45,10 @@ from ops.model import (
     WaitingStatus,
 )
 from ops.pebble import APIError, PathError
+
+if typing.TYPE_CHECKING:
+    from charms.traefik_k8s.v0.ingress_per_unit import RequirerData as RequirerData_IPU
+    from charms.traefik_k8s.v0.ingress import RequirerData as RequirerData_IPA
 
 logger = logging.getLogger(__name__)
 
@@ -103,9 +107,8 @@ class TraefikIngressCharm(CharmBase):
         self.framework.observe(self.on.update_status, self._on_update_status)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
 
-        self.framework.observe(self.ingress_per_app.on.request, self._handle_ingress_request)
-        self.framework.observe(self.ingress_per_app.on.failed, self._handle_ingress_failure)
-        self.framework.observe(self.ingress_per_app.on.broken, self._handle_ingress_broken)
+        self.framework.observe(self.ingress_per_app.on.data_provided, self._handle_ingress_data_provided)
+        self.framework.observe(self.ingress_per_app.on.data_removed, self._handle_ingress_data_removed)
 
         self.framework.observe(self.ingress_per_unit.on.ready, self._handle_ingress_request)
         self.framework.observe(self.ingress_per_unit.on.failed, self._handle_ingress_failure)
@@ -239,15 +242,34 @@ class TraefikIngressCharm(CharmBase):
             self.unit.status = BlockedStatus("setup of some ingress relation failed")
             logger.error("The setup of some ingress relation failed, see previous logs")
 
-    def _handle_ingress_request(self, event: RelationEvent):
+    @property
+    def ready(self) -> bool:
+        """Check whether we have an external host set, and traefik is running."""
         if not self._external_host:
-            self._wipe_ingress_for_all_relations()
+            self._wipe_ingress_for_all_relations() # fixme: no side-effects in prop
             self.unit.status = WaitingStatus("gateway address unavailable")
-            event.defer()
-            return
-
+            return False
         if not self._is_traefik_service_running():
             self.unit.status = WaitingStatus(f"waiting for service: '{_TRAEFIK_SERVICE_NAME}'")
+            return False
+        return True
+
+    def _handle_ingress_data_provided(self, event: RelationEvent):
+        """A unit has provided data requesting ipu."""
+        if not self.ready:
+            event.defer()
+            return
+        self._process_ingress_relation(event.relation)
+
+        if isinstance(self.unit.status, MaintenanceStatus):
+            self.unit.status = ActiveStatus()
+
+    def _handle_ingress_data_removed(self, event: RelationEvent):
+        """A unit has removed the data we need to provide ipu."""
+        self._wipe_ingress_for_relation(event.relation)
+
+    def _handle_ingress_request(self, event: RelationEvent):
+        if not self.ready:
             event.defer()
             return
 
@@ -294,11 +316,7 @@ class TraefikIngressCharm(CharmBase):
         # TODO: once IngressPerApp is also SDI-free,
         #  abstract the common logic here and remove this branch
         if provider is self.ingress_per_app:
-            request = provider.get_request(relation)
-            config, app_url = self._generate_per_app_config(request, gateway_address)
-            if self.unit.is_leader():
-                request.respond(app_url)
-            self._push_configurations(relation, config)
+            self._provide_ingress_per_app(relation)
         elif provider is self.traefik_route:
             self._provide_routed_ingress(relation)
         else:
@@ -310,6 +328,24 @@ class TraefikIngressCharm(CharmBase):
             logger.info("traefik-route not ready on %s", relation)
             return
         config = self.traefik_route.get_config(relation)
+        self._push_configurations(relation, config)
+
+    def _provide_ingress_per_app(self, relation: Relation):
+        # to avoid long-gone units from lingering in the ingress, we wipe it
+        provider = self.ingress_per_app
+        if self.unit.is_leader():
+            provider.wipe_ingress_data(relation)
+
+        try:
+            data: "RequirerData_IPA" = provider.get_data(relation)
+        except DataValidationError as e:
+            logger.error(f"invalid data shared through {relation}... Error: {e}.")
+            return
+
+        config, app_url = self._generate_per_app_config(data)
+        if self.unit.is_leader():
+            provider.publish_url(relation, app_url)
+
         self._push_configurations(relation, config)
 
     def _provide_ingress_per_unit(self, relation: Relation):
@@ -330,20 +366,17 @@ class TraefikIngressCharm(CharmBase):
             # if the unit is ready, it's implied that the data is there.
             # but we should still ensure it's valid, hence...
             try:
-                data: "RequirerData" = provider.get_data(relation, unit)
+                data: "RequirerData_IPU" = provider.get_data(relation, unit)
             except DataValidationError as e:
                 # is_unit_ready should guard against no data being there yet,
                 # but if the data is invalid...
                 logger.error(f"invalid data shared through {relation} by {unit}... Error: {e}.")
                 continue
+
             unit_config, unit_url = self._generate_per_unit_config(data)
-
-            if unit_url:
-                if self.unit.is_leader():
-                    provider.publish_url(relation, data["name"], unit_url)
-
-            if unit_config:
-                always_merger.merge(config, unit_config)
+            if self.unit.is_leader():
+                provider.publish_url(relation, data["name"], unit_url)
+            always_merger.merge(config, unit_config)
 
         # Note: We might be pushing an empty configuration if, for example,
         # none of the units has yet written their part of the data into the
@@ -358,7 +391,7 @@ class TraefikIngressCharm(CharmBase):
         else:
             self._wipe_ingress_for_relation(relation)
 
-    def _generate_per_unit_config(self, data: "RequirerData") -> Tuple[dict, str]:
+    def _generate_per_unit_config(self, data: "RequirerData_IPU") -> Tuple[dict, str]:
         """Generate a config dict for a given unit for IngressPerUnit."""
         config = {"http": {"routers": {}, "services": {}}}
         name = data["name"].replace("/", "-")
@@ -385,16 +418,17 @@ class TraefikIngressCharm(CharmBase):
         }
         return config, unit_url
 
-    # todo reuse types from TraefikRoute
-    def _generate_per_app_config(self, request, gateway_address) -> Tuple[dict, str]:
-        prefix = f"{request.model}-{request.app_name}"
+    def _generate_per_app_config(self, data: "RequirerData_IPA") -> Tuple[dict, str]:
+        host = self._external_host
+        port = self._port
+        prefix = f"{data['model']}-{data['name']}"
 
         if self._routing_mode == _RoutingMode.path:
             route_rule = f"PathPrefix(`/{prefix}`)"
-            app_url = f"http://{gateway_address}:{self._port}/{prefix}"
+            app_url = f"http://{host}:{port}/{prefix}"
         else:  # _RoutingMode.subdomain
-            route_rule = f"Host(`{prefix}.{self._external_host}`)"
-            app_url = f"http://{prefix}.{gateway_address}:{self._port}/"
+            route_rule = f"Host(`{prefix}.{host}`)"
+            app_url = f"http://{prefix}.{host}:{port}/"
 
         traefik_router_name = f"juju-{prefix}-router"
         traefik_service_name = f"juju-{prefix}-service"
@@ -411,7 +445,7 @@ class TraefikIngressCharm(CharmBase):
                 "services": {
                     traefik_service_name: {
                         "loadBalancer": {
-                            "servers": [{"url": f"http://{request.host}:{request.port}"}]
+                            "servers": [{"url": f"http://{data['host']}:{data['port']}"}]
                         }
                     }
                 },

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import asyncio
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import PIPE, Popen
@@ -86,8 +85,8 @@ def get_unit_info(unit_name: str) -> dict:
         )
 
     data = yaml.safe_load(raw_data)
-    if not unit_name in data:
-        raise KeyError(unit_name, f'not in {data!r}')
+    if unit_name not in data:
+        raise KeyError(unit_name, f"not in {data!r}")
 
     unit_data = data[unit_name]
     _JUJU_DATA_CACHE[unit_name] = unit_data
@@ -122,9 +121,7 @@ class UnitRelationData:
     unit_data: dict
 
 
-def get_content(
-    obj: str, other_obj, include_default_juju_keys: bool = False
-) -> UnitRelationData:
+def get_content(obj: str, other_obj, include_default_juju_keys: bool = False) -> UnitRelationData:
     """Get the content of the databag of `obj`, as seen from `other_obj`."""
     unit_name, endpoint = obj.split(":")
     other_unit_name, other_endpoint = other_obj.split(":")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,157 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from subprocess import PIPE, Popen
+
+import pytest
+import yaml
+
+_JUJU_DATA_CACHE = {}
+_JUJU_KEYS = ("egress-subnets", "ingress-address", "private-address")
+
+
+@pytest.fixture(autouse=True, scope="session")
+def traefik_charm():
+    Popen(["charmcraft", "pack"]).wait()
+    charms = tuple(map(str, Path().glob("*.charm")))
+    assert len(charms) == 1, (
+        f"too many charms {charms}" if charms else f"no charm found at {Path().absolute()}"
+    )
+
+    charm = charms[0]
+    charm_path = Path(charm).absolute()
+
+    assert charm_path.exists()
+
+    yield charm_path
+
+    # Popen(['rm', str(charm_path)])
+
+
+def purge(data: dict):
+    for key in _JUJU_KEYS:
+        if key in data:
+            del data[key]
+
+
+async def grab_unit_info(unit_name: str) -> dict:
+    """Returns unit-info data structure.
+
+     for example:
+
+    traefik-k8s/0:
+      opened-ports: []
+      charm: local:focal/traefik-k8s-1
+      leader: true
+      relation-info:
+      - endpoint: ingress-per-unit
+        related-endpoint: ingress
+        application-data:
+          _supported_versions: '- v1'
+        related-units:
+          prometheus-k8s/0:
+            in-scope: true
+            data:
+              egress-subnets: 10.152.183.150/32
+              ingress-address: 10.152.183.150
+              private-address: 10.152.183.150
+      provider-id: traefik-k8s-0
+      address: 10.1.232.144
+    """
+    if cached_data := _JUJU_DATA_CACHE.get(unit_name):
+        return cached_data
+
+    proc = Popen(f"juju show-unit {unit_name}".split(" "), stdout=PIPE)
+    raw_data = proc.stdout.read().decode("utf-8").strip()
+    if not raw_data:
+        raise ValueError(
+            f"no unit info could be grabbed for {unit_name}; "
+            f"are you sure it's a valid unit name?"
+        )
+
+    data = yaml.safe_load(raw_data)
+    _JUJU_DATA_CACHE[unit_name] = data
+    return data
+
+
+def get_relation_by_endpoint(relations, endpoint, remote_obj):
+    relations = [
+        r for r in relations if r["endpoint"] == endpoint and remote_obj in r["related-units"]
+    ]
+    if not relations:
+        raise ValueError(f"no relations found with endpoint==" f"{endpoint}")
+    if len(relations) > 1:
+        raise ValueError("multiple relations found with endpoint==" f"{endpoint}")
+    return relations[0]
+
+
+@dataclass
+class UnitRelationData:
+    unit_name: str
+    endpoint: str
+    leader: bool
+    application_data: dict
+    unit_data: dict
+
+
+async def get_content(
+    obj: str, other_obj, include_default_juju_keys: bool = False
+) -> UnitRelationData:
+    """Get the content of the databag of `obj`, relative to `other_obj`."""
+    endpoint = None
+    other_unit_name = other_obj.split(":")[0] if ":" in other_obj else other_obj
+    if ":" in obj:
+        unit_name, endpoint = obj.split(":")
+    else:
+        unit_name = obj
+    data = (await grab_unit_info(unit_name))[unit_name]
+    is_leader = data["leader"]
+
+    relation_infos = data.get("relation-info")
+    if not relation_infos:
+        raise RuntimeError(f"{unit_name} has no relations")
+
+    if not endpoint:
+        relation_data_raw = relation_infos[0]
+        endpoint = relation_data_raw["endpoint"]
+    else:
+        relation_data_raw = get_relation_by_endpoint(relation_infos, endpoint, other_unit_name)
+
+    related_units_data_raw = relation_data_raw["related-units"]
+
+    other_unit_name = next(iter(related_units_data_raw.keys()))
+    other_unit_info = await grab_unit_info(other_unit_name)
+    other_unit_relation_infos = other_unit_info[other_unit_name]["relation-info"]
+    remote_data_raw = get_relation_by_endpoint(
+        other_unit_relation_infos, relation_data_raw["related-endpoint"], unit_name
+    )
+    this_unit_data = remote_data_raw["related-units"][unit_name]["data"]
+    this_app_data = remote_data_raw["application-data"]
+
+    if not include_default_juju_keys:
+        purge(this_unit_data)
+
+    return UnitRelationData(unit_name, endpoint, is_leader, this_app_data, this_unit_data)
+
+
+@dataclass
+class RelationData:
+    provider: UnitRelationData
+    requirer: UnitRelationData
+
+
+async def get_relation_data(
+    *, provider_endpoint: str, requirer_endpoint: str, include_default_juju_keys: bool = False
+):
+    """Get relation databags for a juju relation.
+
+    >>> get_relation_data('prometheus/0:ingress', 'traefik/1:ingress-per-unit')
+    """
+    provider_data, requirer_data = await asyncio.gather(
+        get_content(provider_endpoint, requirer_endpoint, include_default_juju_keys),
+        get_content(requirer_endpoint, provider_endpoint, include_default_juju_keys),
+    )
+    return RelationData(provider_data, requirer_data)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,12 +20,14 @@ def traefik_charm():
     proc = Popen(["charmcraft", "pack"], stdout=PIPE, stderr=PIPE)
     proc.wait()
     while proc.returncode is None:  # wait() does not quite wait
-        print(proc.stdout.read().decode('utf-8'))
+        print(proc.stdout.read().decode("utf-8"))
         sleep(1)
     if proc.returncode != 0:
-        raise ValueError('charmcraft pack failed with code: ',
-                         proc.returncode,
-                         proc.stderr.read().decode('utf-8'))
+        raise ValueError(
+            "charmcraft pack failed with code: ",
+            proc.returncode,
+            proc.stderr.read().decode("utf-8"),
+        )
 
     charms = tuple(map(str, Path().glob("*.charm")))
     assert len(charms) == 1, (
@@ -39,7 +41,7 @@ def traefik_charm():
 
     yield charm_path
 
-    Popen(['rm', str(charm_path)]).wait()
+    Popen(["rm", str(charm_path)]).wait()
 
 
 def purge(data: dict):
@@ -93,11 +95,17 @@ def get_relation_by_endpoint(relations, endpoint, remote_obj):
         r for r in relations if r["endpoint"] == endpoint and remote_obj in r["related-units"]
     ]
     if not relations:
-        raise ValueError(f"no relations found with endpoint==" f"{endpoint} "
-                         f"in {remote_obj} (relations={relations})")
+        raise ValueError(
+            f"no relations found with endpoint=="
+            f"{endpoint} "
+            f"in {remote_obj} (relations={relations})"
+        )
     if len(relations) > 1:
-        raise ValueError("multiple relations found with endpoint==" f"{endpoint} "
-                         f"in {remote_obj} (relations={relations})")
+        raise ValueError(
+            "multiple relations found with endpoint=="
+            f"{endpoint} "
+            f"in {remote_obj} (relations={relations})"
+        )
     return relations[0]
 
 
@@ -122,15 +130,16 @@ async def get_content(
     if not include_default_juju_keys:
         purge(unit_data)
 
-    return UnitRelationData(unit_name, endpoint,
-                            leader, app_data, unit_data)
+    return UnitRelationData(unit_name, endpoint, leader, app_data, unit_data)
 
 
 async def get_databags(local_unit, remote_unit, remote_endpoint):
-    """Gets the databags of local unit and its leadership status; given a remote unit and the
-    remote endpoint name."""
+    """Gets the databags of local unit and its leadership status.
+
+    Given a remote unit and the remote endpoint name.
+    """
     local_data = (await grab_unit_info(local_unit))[local_unit]
-    leader = local_data['leader']
+    leader = local_data["leader"]
 
     data = (await grab_unit_info(remote_unit))[remote_unit]
     relation_infos = data.get("relation-info")
@@ -141,6 +150,7 @@ async def get_databags(local_unit, remote_unit, remote_endpoint):
     unit_data = raw_data["related-units"][local_unit]["data"]
     app_data = raw_data["application-data"]
     return unit_data, app_data, leader
+
 
 @dataclass
 class RelationData:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -4,7 +4,6 @@
 
 
 import logging
-import urllib.request
 from pathlib import Path
 
 import pytest
@@ -17,36 +16,18 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
-@pytest.mark.xfail
-@pytest.mark.abort_on_fail  # doesn't work w/ xfail: pytest-operator #46
-async def test_build_and_deploy(ops_test: OpsTest):
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, traefik_charm):
     """Build the charm-under-test and deploy it together with related charms.
 
     Assert on the unit status before any relations/configurations take place.
     """
     # build and deploy charm from local source folder
-    charm = await ops_test.build_charm(".")
     resources = {"httpbin-image": METADATA["resources"]["httpbin-image"]["upstream-source"]}
-    await ops_test.model.deploy(charm, resources=resources, application_name=APP_NAME)
+    await ops_test.model.deploy(traefik_charm, resources=resources, application_name=APP_NAME)
+    await ops_test.model.applications[APP_NAME].set_config({"external_hostname": "foo.bar"})
 
     # issuing dummy update_status just to trigger an event
-    await ops_test.model.set_config({"update-status-hook-interval": "10s"})
-
-    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
-    assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"
-
-    # effectively disable the update status from firing
-    await ops_test.model.set_config({"update-status-hook-interval": "60m"})
-
-
-@pytest.mark.xfail
-@pytest.mark.abort_on_fail
-async def test_application_is_up(ops_test: OpsTest):
-    status = await ops_test.model.get_status()  # noqa: F821
-    address = status["applications"][APP_NAME]["units"][f"{APP_NAME}/0"]["address"]
-
-    url = f"http://{address}"
-
-    logger.info("querying app address: %s", url)
-    response = urllib.request.urlopen(url, data=None, timeout=2.0)
-    assert response.code == 200
+    with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
+        assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -23,11 +23,11 @@ async def test_build_and_deploy(ops_test: OpsTest, traefik_charm):
     Assert on the unit status before any relations/configurations take place.
     """
     # build and deploy charm from local source folder
-    resources = {"httpbin-image": METADATA["resources"]["httpbin-image"]["upstream-source"]}
+    resources = {"traefik-image": METADATA["resources"]["traefik-image"]["upstream-source"]}
     await ops_test.model.deploy(traefik_charm, resources=resources, application_name=APP_NAME)
     await ops_test.model.applications[APP_NAME].set_config({"external_hostname": "foo.bar"})
 
     # issuing dummy update_status just to trigger an event
-    with ops_test.fast_forward():
+    async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=1000)
         assert ops_test.model.applications[APP_NAME].units[0].workload_status == "active"

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -21,9 +21,7 @@ async def deployment(ops_test: OpsTest, traefik_charm):
     await ops_test.model.applications["traefik-k8s"].set_config({"external_hostname": "foo.bar"})
     await ops_test.juju("deploy", "spring-music", "--channel=edge")
     async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(['traefik-k8s', 'spring-music'],
-                                           status="active")
-
+        await ops_test.model.wait_for_idle(["traefik-k8s", "spring-music"], status="active")
 
 
 @pytest.mark.abort_on_fail
@@ -36,8 +34,7 @@ async def test_relate(ops_test: OpsTest):
 # @retry(wait=wait_exponential(multiplier=1, min=0, max=10))
 async def test_relation_data_shape(ops_test: OpsTest):
     data = await get_relation_data(
-        requirer_endpoint="spring-music/0:ingress",
-        provider_endpoint="traefik-k8s/0:ingress"
+        requirer_endpoint="spring-music/0:ingress", provider_endpoint="traefik-k8s/0:ingress"
     )
 
     requirer_app_data = yaml.safe_load(data.requirer.unit_data["data"])

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -19,7 +19,10 @@ async def deployment(ops_test: OpsTest, traefik_charm):
     if not ops_test.model.applications.get("traefik-k8s"):
         await ops_test.model.deploy(traefik_charm, resources=resources)
     await ops_test.model.applications["traefik-k8s"].set_config({"external_hostname": "foo.bar"})
-    await ops_test.juju("deploy", "spring-music", "--channel=edge")
+
+    # we pin the revision to prevent upstream changes breaking our itests,
+    #   bump this version sometime in the future.
+    await ops_test.juju("deploy", "spring-music", "--channel=edge", "--revision=3")
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(["traefik-k8s", "spring-music"], status="active")
 

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -31,7 +31,6 @@ async def test_relate(ops_test: OpsTest):
         await ops_test.model.wait_for_idle(["traefik-k8s", "spring-music"])
 
 
-# @retry(wait=wait_exponential(multiplier=1, min=0, max=10))
 async def test_relation_data_shape(ops_test: OpsTest):
     data = get_relation_data(
         requirer_endpoint="spring-music/0:ingress", provider_endpoint="traefik-k8s/0:ingress"

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -33,11 +33,12 @@ async def test_relate(ops_test: OpsTest):
 
 # @retry(wait=wait_exponential(multiplier=1, min=0, max=10))
 async def test_relation_data_shape(ops_test: OpsTest):
-    data = await get_relation_data(
-        requirer_endpoint="spring-music/0:ingress", provider_endpoint="traefik-k8s/0:ingress"
+    data = get_relation_data(
+        requirer_endpoint="spring-music/0:ingress",
+        provider_endpoint="traefik-k8s/0:ingress"
     )
 
-    requirer_app_data = yaml.safe_load(data.requirer.unit_data["data"])
+    requirer_app_data = yaml.safe_load(data.requirer.application_data["data"])
     # example:
     # host: spring-music.foo.svc.cluster.local
     # model: foo

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -1,0 +1,55 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pytest_operator.plugin import OpsTest
+
+from tests.integration.conftest import get_relation_data
+
+meta = yaml.safe_load((Path() / "metadata.yaml").read_text())
+resources = {name: val["upstream-source"] for name, val in meta["resources"].items()}
+
+
+@pytest.fixture(autouse=True)
+async def deployment(ops_test: OpsTest, traefik_charm):
+    if not ops_test.model.applications.get("traefik-k8s"):
+        await ops_test.model.deploy(traefik_charm, resources=resources)
+    await ops_test.model.applications["traefik-k8s"].set_config({"external_hostname": "foo.bar"})
+    await ops_test.juju("deploy", "spring-music", "--channel=edge")
+
+
+async def test_relate(ops_test: OpsTest):
+    await ops_test.juju("relate", "spring-music:ingress", "traefik-k8s:ingress")
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(["traefik-k8s", "spring-music"])
+
+
+# @retry(wait=wait_exponential(multiplier=1, min=0, max=10))
+async def test_relation_data_shape(ops_test: OpsTest):
+    data = await get_relation_data(
+        requirer_endpoint="spring-music/0:ingress", provider_endpoint="traefik-k8s/0:ingress"
+    )
+
+    requirer_app_data = yaml.safe_load(data.requirer.application_data["data"])
+    # example:
+    # host: spring-music.foo.svc.cluster.local
+    # model: foo
+    # name: spring-music/0
+    # port: 8080
+    model = requirer_app_data["model"]
+    assert requirer_app_data == {
+        "host": f"spring-music.{model}.svc.cluster.local",
+        "model": model,
+        "name": "spring-music/0",
+        "port": "8080",
+    }
+
+    provider_app_data = yaml.safe_load(data.provider.application_data["data"])
+    # example:
+    #  ingress:
+    #    url: http://foo.bar:80/foo-spring-music/0
+
+    assert provider_app_data == {"ingress": {"url": f"http://foo.bar:80/{model}-spring-music/0"}}

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -34,8 +34,7 @@ async def test_relate(ops_test: OpsTest):
 # @retry(wait=wait_exponential(multiplier=1, min=0, max=10))
 async def test_relation_data_shape(ops_test: OpsTest):
     data = get_relation_data(
-        requirer_endpoint="spring-music/0:ingress",
-        provider_endpoint="traefik-k8s/0:ingress"
+        requirer_endpoint="spring-music/0:ingress", provider_endpoint="traefik-k8s/0:ingress"
     )
 
     requirer_app_data = yaml.safe_load(data.requirer.application_data["data"])

--- a/tests/integration/test_charm_ipu.py
+++ b/tests/integration/test_charm_ipu.py
@@ -21,9 +21,9 @@ async def deployment(ops_test: OpsTest, traefik_charm):
     await ops_test.model.applications["traefik-k8s"].set_config({"external_hostname": "foo.bar"})
     await ops_test.juju("deploy", "prometheus-k8s", "--channel=edge")
     async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(['traefik-k8s', 'prometheus-k8s'],
-                                           status="active", timeout=1000)
-
+        await ops_test.model.wait_for_idle(
+            ["traefik-k8s", "prometheus-k8s"], status="active", timeout=1000
+        )
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_charm_ipu.py
+++ b/tests/integration/test_charm_ipu.py
@@ -36,20 +36,20 @@ async def test_relate(ops_test: OpsTest):
 # @retry(wait=wait_exponential(multiplier=1, min=0, max=10))
 @pytest.mark.abort_on_fail
 async def test_relation_data_shape():
-    data = await get_relation_data(
+    data = get_relation_data(
         requirer_endpoint="prometheus-k8s/0:ingress",
         provider_endpoint="traefik-k8s/0:ingress-per-unit",
     )
 
-    requirer_app_data = yaml.safe_load(data.requirer.unit_data["data"])
+    requirer_unit_data = yaml.safe_load(data.requirer.unit_data["data"])
     # example:
     # host: 10.1.232.176
     # model: foo
     # name: prometheus-k8s/0
     # port: 9090
-    model = requirer_app_data["model"]
-    host = requirer_app_data["host"]
-    assert requirer_app_data == {
+    model = requirer_unit_data["model"]
+    host = requirer_unit_data["host"]
+    assert requirer_unit_data == {
         "host": host,
         "model": model,
         "name": "prometheus-k8s/0",

--- a/tests/integration/test_charm_ipu.py
+++ b/tests/integration/test_charm_ipu.py
@@ -33,7 +33,6 @@ async def test_relate(ops_test: OpsTest):
         await ops_test.model.wait_for_idle(["traefik-k8s", "prometheus-k8s"])
 
 
-# @retry(wait=wait_exponential(multiplier=1, min=0, max=10))
 @pytest.mark.abort_on_fail
 async def test_relation_data_shape():
     data = get_relation_data(

--- a/tests/integration/test_charm_ipu.py
+++ b/tests/integration/test_charm_ipu.py
@@ -1,0 +1,60 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from pathlib import Path
+
+import pytest
+import yaml
+from pytest_operator.plugin import OpsTest
+
+from tests.integration.conftest import get_relation_data
+
+meta = yaml.safe_load((Path() / "metadata.yaml").read_text())
+resources = {name: val["upstream-source"] for name, val in meta["resources"].items()}
+
+
+@pytest.fixture(autouse=True)
+async def deployment(ops_test: OpsTest, traefik_charm):
+    if not ops_test.model.applications.get("traefik-k8s"):
+        await ops_test.model.deploy(traefik_charm, resources=resources)
+    await ops_test.model.applications["traefik-k8s"].set_config({"external_hostname": "foo.bar"})
+    await ops_test.juju("deploy", "prometheus-k8s", "--channel=edge")
+
+
+async def test_relate(ops_test: OpsTest):
+    await ops_test.juju("relate", "prometheus-k8s:ingress", "traefik-k8s:ingress-per-unit")
+    async with ops_test.fast_forward():
+        await ops_test.model.wait_for_idle(["traefik-k8s", "prometheus-k8s"])
+
+
+# @retry(wait=wait_exponential(multiplier=1, min=0, max=10))
+async def test_relation_data_shape(ops_test: OpsTest):
+    data = await get_relation_data(
+        requirer_endpoint="prometheus-k8s/0:ingress",
+        provider_endpoint="traefik-k8s/0:ingress-per-unit",
+    )
+
+    requirer_app_data = yaml.safe_load(data.requirer.application_data["data"])
+    # example:
+    # host: 10.1.232.176
+    # model: foo
+    # name: prometheus-k8s/0
+    # port: 9090
+    model = requirer_app_data["model"]
+    host = requirer_app_data["host"]
+    assert requirer_app_data == {
+        "host": host,
+        "model": model,
+        "name": "prometheus-k8s/0",
+        "port": "9090",
+    }
+
+    provider_app_data = yaml.safe_load(data.provider.application_data["data"])
+    # example:
+    #  ingress:
+    #   prometheus-k8s/0:
+    #     url: http://foo.bar:80/foo-prometheus-k8s-0
+
+    assert provider_app_data == {
+        "ingress": {"prometheus-k8s/0": {"url": f"http://foo.bar:80/{model}-prometheus-k8s-0"}}
+    }

--- a/tests/integration/test_charm_ipu.py
+++ b/tests/integration/test_charm_ipu.py
@@ -19,7 +19,10 @@ async def deployment(ops_test: OpsTest, traefik_charm):
     if not ops_test.model.applications.get("traefik-k8s"):
         await ops_test.model.deploy(traefik_charm, resources=resources)
     await ops_test.model.applications["traefik-k8s"].set_config({"external_hostname": "foo.bar"})
-    await ops_test.juju("deploy", "prometheus-k8s", "--channel=edge")
+
+    # we pin revision 36 to prevent upstream changes breaking our itests,
+    #   bump this version sometime in the future.
+    await ops_test.juju("deploy", "prometheus-k8s", "--channel=edge", "--revision=36")
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
             ["traefik-k8s", "prometheus-k8s"], status="active", timeout=1000

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -90,8 +90,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPARequirer(self.harness)
         relation = requirer.relate()
-        requirer.request(host="foo.bar", port=3000)
-        assert requirer.is_available(relation)
+        requirer.provide_ingress_requirements(host="foo.bar", port=3000)
 
         traefik_container = self.harness.charm.unit.get_container("traefik")
         file = f"/opt/traefik/juju/juju_ingress_{relation.name}_{relation.id}_{relation.app.name}.yaml"
@@ -137,8 +136,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPARequirer(self.harness)
         relation = requirer.relate()
-        requirer.request(host="foo.bar", port=3000)
-        assert requirer.is_available(relation)
+        requirer.provide_ingress_requirements(host="foo.bar", port=3000)
 
         traefik_container = self.harness.charm.unit.get_container("traefik")
         file = f"/opt/traefik/juju/juju_ingress_{relation.name}_{relation.id}_{relation.app.name}.yaml"
@@ -449,7 +447,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
         requirer = MockIPARequirer(self.harness)
         requirer.relate()
-        requirer.request(host="10.0.0.1", port=3000)
+        requirer.provide_ingress_requirements(host="10.0.0.1", port=3000)
 
         self.harness.container_pebble_ready("traefik")
 

--- a/tests/unit/test_lib_helpers.py
+++ b/tests/unit/test_lib_helpers.py
@@ -7,30 +7,30 @@ from unittest.mock import patch
 
 from charms.traefik_k8s.v0.ingress import (
     IngressPerAppProvider,
-    IngressPerAppRequest,
     IngressPerAppRequirer,
+    RELATION_INTERFACE as IPA_RELATION_INTERFACE,
+    DEFAULT_RELATION_NAME as IPA_RELATION_NAME
 )
 from charms.traefik_k8s.v0.ingress_per_unit import (
-    DEFAULT_RELATION_NAME,
-    RELATION_INTERFACE,
+    DEFAULT_RELATION_NAME as IPU_RELATION_NAME,
+    RELATION_INTERFACE as IPU_RELATION_INTERFACE,
     IngressPerUnitProvider,
     IngressPerUnitRequirer,
     ProviderApplicationData,
 )
 from ops.charm import CharmBase, CharmEvents, CharmMeta
-from ops.model import Relation
-from serialized_data_interface import MockRemoteRelationMixin as MockRemoteIPAMixin
+from ops.model import Relation, Application, Unit
 
 
 class MockRemoteIPUMixin:
-    """Adds unit testing helpers to EndpointWrapper."""
+    """Unit testing helper class."""
 
     ROLE: str
     LIMIT: typing.Optional[int]
 
     def __init__(self, harness):
         """Initialize the mock provider / requirer."""
-        self.app_name = f"{DEFAULT_RELATION_NAME}-remote"
+        self.app_name = f"{IPU_RELATION_NAME}-remote"
         self.unit_name = f"{self.app_name}/0"
 
         class MRRMTestEvents(CharmEvents):
@@ -42,9 +42,9 @@ class MockRemoteIPUMixin:
             meta = CharmMeta(
                 {
                     self.ROLE: {
-                        DEFAULT_RELATION_NAME: {
+                        IPU_RELATION_NAME: {
                             "role": self.ROLE,
-                            "interface": RELATION_INTERFACE,
+                            "interface": IPU_RELATION_INTERFACE,
                             "limit": self.LIMIT,
                         },
                     },
@@ -106,21 +106,21 @@ class MockRemoteIPUMixin:
         self.num_units += 1
 
     def is_available(self, relation: Relation = None):
-        """Same as EndpointWrapper.is_available, but with the remote context."""
+        """Same as super().is_available, but with the remote context."""
         if relation is None:
             return any(self.is_available(relation) for relation in self.relations)
         with self.remote_context(relation):
             return super().is_available(relation)
 
     def is_ready(self, relation: Relation = None):
-        """Same as EndpointWrapper.is_ready, but with the remote context."""
+        """Same as super().is_ready, but with the remote context."""
         if relation is None:
             return any(self.is_ready(relation) for relation in self.relations)
         with self.remote_context(relation):
             return super().is_ready(relation)
 
     def is_failed(self, relation: Relation = None):
-        """Same as EndpointWrapper.is_failed, but with the remote context."""
+        """Same as super().is_failed, but with the remote context."""
         if not self.relations:
             return False
         if relation is None:
@@ -173,6 +173,92 @@ class MockIPURequirer(MockRemoteIPUMixin, IngressPerUnitRequirer):
         self.harness._charm.on.ingress_per_unit_relation_changed.emit(self.relation)
 
 
+class MockRemoteIPAMixin:
+    """Unit testing helper class."""
+
+    ROLE: str
+    LIMIT: typing.Optional[int]
+    relation_name: str
+    app: Application
+    unit: Unit
+
+    def __init__(self, harness):
+        """Initialize the mock provider / requirer."""
+        self.app_name = f"{IPA_RELATION_NAME}-remote"
+        self.unit_name = f"{self.app_name}/0"
+
+        class MRRMTestEvents(CharmEvents):
+            __name__ = self.app_name
+
+        class MRRMTestCharm(CharmBase):
+            __name__ = self.app_name
+            on = MRRMTestEvents()
+            meta = CharmMeta(
+                {
+                    self.ROLE: {
+                        IPA_RELATION_NAME: {
+                            "interface": IPA_RELATION_INTERFACE,
+                            "limit": self.LIMIT,
+                        },
+                    },
+                }
+            )
+            app = harness.model.get_app(self.app_name)
+            unit = harness.model.get_unit(self.unit_name)
+
+        if harness.model.name is None:
+            harness._backend.model_name = "test-model"
+
+        super().__init__(MRRMTestCharm(harness.framework))
+        self.harness = harness
+        self.relation_id = None
+        self.num_units = 0
+
+    @property
+    def relation(self):
+        """The Relation instance, if created."""
+        return self.harness.model.get_relation(self.relation_name, self.relation_id)
+
+    def relate(self, relation_name: str = None):
+        """Create a relation to the charm under test.
+
+        Starts the version negotiation, and returns the Relation instance.
+        """
+        if not relation_name:
+            relation_name = self.relation_name
+        self.relation_id = self.harness.add_relation(relation_name, self.app_name)
+        self.add_unit()
+        return self.relation
+
+    @contextmanager
+    def remote_context(self, relation: Relation):
+        """Temporarily change the context to the remote side of the relation.
+
+        The test runs within the context of the local charm under test.  This
+        means that the relation data on the remote side cannot be written, the
+        app and units references are from the local charm's perspective, etc.
+        This temporarily patches things to behave as if we were running on the
+        remote charm instead.
+        """
+        with patch.multiple(
+            self.harness._backend,
+            app_name=self.app.name,
+            unit_name=getattr(self.unit, "name", None),
+            is_leader=lambda: True,
+        ):
+            with patch.multiple(
+                relation, app=self.harness.charm.app, units={self.harness.charm.unit}
+            ):
+                with patch.object(self.unit, "_is_our_unit", True):
+                    yield
+
+    def add_unit(self):
+        """Add a unit to the relation."""
+        unit_name = f"{self.app_name}/{self.num_units}"
+        self.harness.add_relation_unit(self.relation_id, unit_name)
+        self.num_units += 1
+
+
 class MockIPAProvider(MockRemoteIPAMixin, IngressPerAppProvider):
     """Class to help with unit testing ingress requirer charms.
 
@@ -180,25 +266,20 @@ class MockIPAProvider(MockRemoteIPAMixin, IngressPerAppProvider):
     the remote side of any relation, and it automatically triggers events when
     responses are sent.
     """
+    ROLE = 'provides'
+    LIMIT = None
 
-    def get_request(self, relation: Relation):
-        """Get the IngressRequest for the given Relation."""
-        # reflect the relation for the request so that it appears remote
-        return MockIngressPerAppRequest(self, relation)
+    def is_ready(self, relation: Relation = None):
+        """Same as super().is_ready, but with the remote context."""
+        if relation is None:
+            return any(self.is_ready(relation) for relation in self.relations)
+        with self.remote_context(relation):
+            return super().is_ready(relation)
 
-
-class MockIngressPerAppRequest(IngressPerAppRequest):
-    """Testing wrapper for an IngressPerAppRequest.
-
-    Exactly the same as the normal IngressPerAppRequest but acts as if it's on
-    the remote side of any relation, and it automatically triggers events when
-    responses are sent.
-    """
-
-    @property
-    def app(self):
-        """The remote application."""
-        return self._provider.harness.charm.app
+    def publish_url(self, relation: Relation, url: str):
+        with self.remote_context(self.relation):
+            super().publish_url(relation, url)
+        self.harness._charm.on.ingress_relation_changed.emit(self.relation)
 
 
 class MockIPARequirer(MockRemoteIPAMixin, IngressPerAppRequirer):
@@ -208,6 +289,8 @@ class MockIPARequirer(MockRemoteIPAMixin, IngressPerAppRequirer):
     the remote side of any relation, and it automatically triggers events when
     requests are sent.
     """
+    ROLE = 'requires'
+    LIMIT = 1
 
     @property
     def url(self):
@@ -215,5 +298,20 @@ class MockIPARequirer(MockRemoteIPAMixin, IngressPerAppRequirer):
 
         May return None is the URL is not available yet.
         """
+        if not self.relation:
+            return None
         with self.remote_context(self.relation):
             return super().url
+
+    def provide_ingress_requirements(self, *, host: str = None, port: int):
+        with self.remote_context(self.relation):
+            super().provide_ingress_requirements(host=host, port=port)
+        self.harness._charm.on.ingress_relation_changed.emit(self.relation)
+
+    def is_ready(self, relation: Relation = None):
+        """Same as super().is_ready, but with the remote context."""
+        if not relation:
+            return super().is_ready()
+
+        with self.remote_context(relation):
+            return super().is_ready()

--- a/tests/unit/test_lib_helpers.py
+++ b/tests/unit/test_lib_helpers.py
@@ -5,21 +5,22 @@ import typing
 from contextlib import contextmanager
 from unittest.mock import patch
 
-from charms.traefik_k8s.v0.ingress import (
-    IngressPerAppProvider,
-    IngressPerAppRequirer,
-    RELATION_INTERFACE as IPA_RELATION_INTERFACE,
-    DEFAULT_RELATION_NAME as IPA_RELATION_NAME
-)
+from charms.traefik_k8s.v0.ingress import DEFAULT_RELATION_NAME as IPA_RELATION_NAME
+from charms.traefik_k8s.v0.ingress import RELATION_INTERFACE as IPA_RELATION_INTERFACE
+from charms.traefik_k8s.v0.ingress import IngressPerAppProvider, IngressPerAppRequirer
 from charms.traefik_k8s.v0.ingress_per_unit import (
     DEFAULT_RELATION_NAME as IPU_RELATION_NAME,
+)
+from charms.traefik_k8s.v0.ingress_per_unit import (
     RELATION_INTERFACE as IPU_RELATION_INTERFACE,
+)
+from charms.traefik_k8s.v0.ingress_per_unit import (
     IngressPerUnitProvider,
     IngressPerUnitRequirer,
     ProviderApplicationData,
 )
 from ops.charm import CharmBase, CharmEvents, CharmMeta
-from ops.model import Relation, Application, Unit
+from ops.model import Application, Relation, Unit
 
 
 class MockRemoteIPUMixin:
@@ -266,7 +267,8 @@ class MockIPAProvider(MockRemoteIPAMixin, IngressPerAppProvider):
     the remote side of any relation, and it automatically triggers events when
     responses are sent.
     """
-    ROLE = 'provides'
+
+    ROLE = "provides"
     LIMIT = None
 
     def is_ready(self, relation: Relation = None):
@@ -289,7 +291,8 @@ class MockIPARequirer(MockRemoteIPAMixin, IngressPerAppRequirer):
     the remote side of any relation, and it automatically triggers events when
     requests are sent.
     """
-    ROLE = 'requires'
+
+    ROLE = "requires"
     LIMIT = 1
 
     @property

--- a/tests/unit/test_lib_per_app_provides.py
+++ b/tests/unit/test_lib_per_app_provides.py
@@ -5,11 +5,9 @@ from textwrap import dedent
 from unittest.mock import Mock
 
 import pytest
-from ops.model import Binding
-
-from charms.traefik_k8s.v0.ingress import IngressPerAppProvider, \
-    IngressPerAppRequirer
+from charms.traefik_k8s.v0.ingress import IngressPerAppProvider
 from ops.charm import CharmBase
+from ops.model import Binding
 from ops.testing import Harness
 from test_lib_helpers import MockIPARequirer
 
@@ -54,30 +52,31 @@ def provider(harness):
     return provider
 
 
-def test_ingress_app_provider_uninitialized(provider: IngressPerAppProvider,
-                                            requirer: MockIPARequirer):
+def test_ingress_app_provider_uninitialized(
+    provider: IngressPerAppProvider, requirer: MockIPARequirer
+):
     assert not provider.relations
     assert not provider.is_ready()
     assert not requirer.relations
     assert not requirer.is_ready()
 
 
-def test_ingress_app_provider_related(provider: IngressPerAppProvider,
-                                      requirer: MockIPARequirer):
+def test_ingress_app_provider_related(provider: IngressPerAppProvider, requirer: MockIPARequirer):
     relation = requirer.relate()
     assert not provider.is_ready(relation)
     assert not requirer.is_ready(relation)
 
 
-def test_ingress_app_provider_relate_provide(provider: IngressPerAppProvider,
-                                             requirer: MockIPARequirer, harness):
+def test_ingress_app_provider_relate_provide(
+    provider: IngressPerAppProvider, requirer: MockIPARequirer, harness
+):
     harness.set_leader(True)
     relation = requirer.relate()
-    requirer.provide_ingress_requirements(host='host', port=42)
+    requirer.provide_ingress_requirements(host="host", port=42)
     assert provider.is_ready(relation)
     assert not requirer.is_ready(relation)
 
-    provider.publish_url(relation, 'foo.com')
+    provider.publish_url(relation, "foo.com")
     assert requirer.is_ready(relation)
 
 

--- a/tests/unit/test_lib_per_app_provides.py
+++ b/tests/unit/test_lib_per_app_provides.py
@@ -2,8 +2,13 @@
 # See LICENSE file for licensing details.
 
 from textwrap import dedent
+from unittest.mock import Mock
 
-from charms.traefik_k8s.v0.ingress import IngressPerAppProvider
+import pytest
+from ops.model import Binding
+
+from charms.traefik_k8s.v0.ingress import IngressPerAppProvider, \
+    IngressPerAppRequirer
 from ops.charm import CharmBase
 from ops.testing import Harness
 from test_lib_helpers import MockIPARequirer
@@ -25,49 +30,58 @@ class MockProviderCharm(CharmBase):
         self.ipa = IngressPerAppProvider(self)
 
 
-def test_ingress_app_provider():
+@pytest.fixture(autouse=True, scope="function")
+def patch_network(monkeypatch):
+    monkeypatch.setattr(Binding, "network", Mock(bind_address="10.10.10.10"))
+
+
+@pytest.fixture(scope="function")
+def harness():
     harness = Harness(MockProviderCharm, meta=MockProviderCharm.META)
     harness._backend.model_name = "test-model"
-    harness.set_leader(False)
     harness.begin_with_initial_hooks()
+    return harness
+
+
+@pytest.fixture(scope="function")
+def requirer(harness):
+    return MockIPARequirer(harness)
+
+
+@pytest.fixture(scope="function")
+def provider(harness):
     provider = harness.charm.ipa
-    requirer = MockIPARequirer(harness)
+    return provider
 
-    assert not provider.is_available()
+
+def test_ingress_app_provider_uninitialized(provider: IngressPerAppProvider,
+                                            requirer: MockIPARequirer):
+    assert not provider.relations
     assert not provider.is_ready()
-    assert not provider.is_failed()
-    assert not requirer.is_available()
+    assert not requirer.relations
     assert not requirer.is_ready()
-    assert not requirer.is_failed()
 
+
+def test_ingress_app_provider_related(provider: IngressPerAppProvider,
+                                      requirer: MockIPARequirer):
     relation = requirer.relate()
-    assert provider.is_available(relation)
     assert not provider.is_ready(relation)
-    assert not provider.is_failed(relation)
-    assert not requirer.is_available(relation)
     assert not requirer.is_ready(relation)
-    assert requirer.is_failed(relation)  # because it has no versions
 
+
+def test_ingress_app_provider_relate_provide(provider: IngressPerAppProvider,
+                                             requirer: MockIPARequirer, harness):
     harness.set_leader(True)
-    assert provider.is_available(relation)
-    assert not provider.is_ready(relation)
-    assert not provider.is_failed(relation)
-    assert requirer.is_available(relation)
-    assert not requirer.is_ready(relation)
-    assert not requirer.is_failed(relation)
-
-    requirer.request(port=80)
-    assert provider.is_available(relation)
+    relation = requirer.relate()
+    requirer.provide_ingress_requirements(host='host', port=42)
     assert provider.is_ready(relation)
-    assert not provider.is_failed(relation)
-    assert requirer.is_available(relation)
     assert not requirer.is_ready(relation)
-    assert not requirer.is_failed(relation)
 
-    request = provider.get_request(relation)
-    assert request.app_name == "ingress-remote"
-    request.respond("http://url/")
-    assert requirer.is_available(relation)
+    provider.publish_url(relation, 'foo.com')
     assert requirer.is_ready(relation)
-    assert not requirer.is_failed(relation)
-    assert requirer.url == "http://url/"
+
+
+def test_ingress_app_provider_supported_versions_shim(provider, requirer, harness):
+    harness.set_leader(True)
+    relation = requirer.relate()
+    assert relation.data[provider.charm.app]["_supported_versions"] == "- v1"

--- a/tests/unit/test_lib_per_app_requires.py
+++ b/tests/unit/test_lib_per_app_requires.py
@@ -5,11 +5,10 @@ from textwrap import dedent
 from unittest.mock import Mock
 
 import pytest
-from ops.model import Binding
-
 from charms.traefik_k8s.v0.ingress import IngressPerAppRequirer
 from ops.charm import CharmBase
 from ops.framework import StoredState
+from ops.model import Binding
 from ops.testing import Harness
 from test_lib_helpers import MockIPAProvider
 
@@ -63,9 +62,8 @@ def requirer(harness):
 
 
 def test_ingress_app_requirer_uninitialized(
-        requirer: IngressPerAppRequirer,
-        provider: MockIPAProvider,
-        harness):
+    requirer: IngressPerAppRequirer, provider: MockIPAProvider, harness
+):
     assert not requirer.is_ready()
     assert not provider.is_ready()
 
@@ -73,9 +71,8 @@ def test_ingress_app_requirer_uninitialized(
 
 
 def test_ingress_app_requirer_related(
-        requirer: IngressPerAppRequirer,
-        provider: MockIPAProvider,
-        harness):
+    requirer: IngressPerAppRequirer, provider: MockIPAProvider, harness
+):
     harness.set_leader(True)
     relation = provider.relate()
 
@@ -84,23 +81,23 @@ def test_ingress_app_requirer_related(
     # auto-data feature...
     assert provider.is_ready(relation)
 
-    requirer.provide_ingress_requirements(host='foo', port=42)
+    requirer.provide_ingress_requirements(host="foo", port=42)
     assert provider.is_ready(relation)
     assert not requirer.is_ready()
 
     assert harness.charm._stored.num_events == 0
-    provider.publish_url(relation, 'url')
+    provider.publish_url(relation, "url")
     assert harness.charm._stored.num_events == 1
 
     assert provider.is_ready(relation)
     assert requirer.is_ready()
 
-    assert requirer.url == 'url'
+    assert requirer.url == "url"
 
     assert harness.charm._stored.num_events == 1
-    provider.publish_url(relation, 'url2')
+    provider.publish_url(relation, "url2")
     assert harness.charm._stored.num_events == 2
 
     assert provider.is_ready(relation)
     assert requirer.is_ready()
-    assert requirer.url == 'url2'
+    assert requirer.url == "url2"

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,8 @@ description = Run integration tests
 deps =
     pytest
     juju
-    pytest-operator
+    pytest-operator>=0.13.0
+    tenacity
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
Removed SDI from ingress (per app)


## Context
See #37 


## Testing Instructions
- Added integration tests for 
  - ingress: spring-music
  - ingress-per-unit: prometheus-k8s

The relation interface is compatible with older versions of `ingress`, but the API is different. Similarly to ingress-per-unit, the `request/response` language was stripped in favour of a more semantically close one. See #42 and #48

the Requirer has `ready` and `revoked` events: reflecting the fact that the only thing that can happen to ingress is: it can be provided (with a given url), or it can be revoked (i.e. the url is no longer available).
`ready` also includes when ingress was already ready; i.e. when the url has changed.

the Provider has now 'data_provided` and `data_removed` events, following a similar principle: either the requirer has published the data we need to provide ingress, (or changed it), or it has wiped it.

Fixes #37 
Fixes #28 

## Release Notes
- Stripped SDI from ingress interface
- Refactored and simplified the ingress API
- Added itests that check that ingress is compatible with old SDI-based ingress (as implemented by spring-music)
- Added itests that check that ingress-per-unit is compatible with old SDI-based ingress-per-unit (as implemented by prometheus-k8s)