### PR TITLE
bumped lib versions

### DIFF
--- a/lib/charms/traefik_k8s/v0/ingress.py
+++ b/lib/charms/traefik_k8s/v0/ingress.py
@@ -68,7 +68,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 DEFAULT_RELATION_NAME = "ingress"
 RELATION_INTERFACE = "ingress"

--- a/lib/charms/traefik_k8s/v0/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v0/ingress_per_unit.py
@@ -71,7 +71,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 9
+LIBPATCH = 10
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Issue
Bumped IPA and IPU libpatch versions following changes in the previous PRs.

## Release Notes
- ingress is now at 0.6
- ingress-per-unit is now at 0.10
