### PR TITLE
added k8s api assumes

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,7 +4,8 @@
 # For a complete list of supported options, see:
 # https://discourse.charmhub.io/t/charm-metadata-v2/3674/15
 name: traefik-k8s
-assumes: k8s-api
+assumes:
+  - k8s-api
 
 display-name: |
   Traefik Ingress Operator for Kubernetes

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,6 +4,8 @@
 # For a complete list of supported options, see:
 # https://discourse.charmhub.io/t/charm-metadata-v2/3674/15
 name: traefik-k8s
+assumes: k8s-api
+
 display-name: |
   Traefik Ingress Operator for Kubernetes
 summary: |


### PR DESCRIPTION
## Issue
Help JUJU fail earlier if one tries to deploy traefik-k8s on a VM cloud.
See: #62 

## Release Notes
- added assumes: k8s-api
