### PR TITLE
POC diff for pydantic port

### DIFF
--- a/lib/charms/traefik_k8s/v0/ingress.py
+++ b/lib/charms/traefik_k8s/v0/ingress.py
@@ -247,7 +247,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
     def publish_url(self, relation: Relation, url: str):
         """Publish to the app databag the ingress url."""
         ingress = ProviderIngressData(url=url)
-        relation.data[self.app]["data"] = ProviderData(ingress=ingress)
+        relation.data[self.app]["data"] = ProviderData(ingress=ingress).json()
 
     @property
     def proxied_endpoints(self):


### PR DESCRIPTION
DO NOT MERGE

This is a proof-of-concept diff to see what the code would look like if we were to replace jsonschema with pydantic in ingress.py.
Code is untested and probably buggy, I expect it to be 90% production-ready. Goal is to see the (rough) diff and have a discussion before finalizing.

- Dropped the conditional dependency: to use the lib you NEED to install pydantic. Before: jsonschema was optional. Could keep that logic (pydantic integrates with TypedDict)
- Pydantic models offer a lot of validation flexibility, I just skimmed the surface here to show what's possible
- Pydantic models can replace the typeddict-based orm I had before: pydantic models have nice pythonic dot-notation access.
- Note the Json field: we can document explicitly what encoding we're using for nested data fields. Nice!