### PR TITLE
fixed departed hooks for ipu and ipa

### DIFF
--- a/lib/charms/traefik_k8s/v1/ingress.py
+++ b/lib/charms/traefik_k8s/v1/ingress.py
@@ -67,7 +67,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 DEFAULT_RELATION_NAME = "ingress"
 RELATION_INTERFACE = "ingress"

--- a/lib/charms/traefik_k8s/v1/ingress.py
+++ b/lib/charms/traefik_k8s/v1/ingress.py
@@ -57,7 +57,7 @@ from typing import Any, Dict, Optional, Tuple
 import yaml
 from ops.charm import CharmBase, RelationEvent
 from ops.framework import EventSource, Object, ObjectEvents, StoredState
-from ops.model import Relation, ModelError
+from ops.model import ModelError, Relation
 
 # The unique Charmhub library identifier, never change it
 LIBID = "e6de2a5cd5b34422a204668f3b8f90d2"
@@ -505,8 +505,10 @@ class IngressPerAppRequirer(_IngressPerAppBase):
         try:
             raw = relation.data.get(relation.app, {}).get("ingress")
         except ModelError as e:
-            log.debug(f"Error {e} attempting to read remote app data; "
-                      f"probably we are in a relation_departed hook")
+            log.debug(
+                f"Error {e} attempting to read remote app data; "
+                f"probably we are in a relation_departed hook"
+            )
             return None
 
         if not raw:

--- a/lib/charms/traefik_k8s/v1/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v1/ingress_per_unit.py
@@ -65,7 +65,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 log = logging.getLogger(__name__)
 

--- a/lib/charms/traefik_k8s/v1/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v1/ingress_per_unit.py
@@ -55,7 +55,7 @@ from typing import Any, Dict, Optional, Tuple, Union
 import yaml
 from ops.charm import CharmBase, RelationEvent
 from ops.framework import EventSource, Object, ObjectEvents, StoredState
-from ops.model import Application, Relation, Unit, ModelError
+from ops.model import Application, ModelError, Relation, Unit
 
 # The unique Charmhub library identifier, never change it
 LIBID = "7ef06111da2945ed84f4f5d4eb5b353a"
@@ -125,11 +125,17 @@ except ImportError:
 
 
 # Model of the data a unit implementing the requirer will need to provide.
-RequirerData = TypedDict("RequirerData",
-                         {"model": str, "name": str,
-                          "host": str, "port": int,
-                          "mode": Optional[Literal['tcp', 'http']]},
-                         total=False)
+RequirerData = TypedDict(
+    "RequirerData",
+    {
+        "model": str,
+        "name": str,
+        "host": str,
+        "port": int,
+        "mode": Optional[Literal["tcp", "http"]],
+    },
+    total=False,
+)
 
 
 RequirerUnitData = Dict[Unit, "RequirerData"]
@@ -606,7 +612,7 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
         *,
         host: Optional[str] = None,
         port: Optional[int] = None,
-        mode: Literal['tcp', 'http'] = 'http',
+        mode: Literal["tcp", "http"] = "http",
         listen_to: Literal["only-this-unit", "all-units", "both"] = "only-this-unit",
     ):
         """Constructor for IngressPerUnitRequirer.
@@ -753,8 +759,10 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
         try:
             raw = relation.data.get(relation.app, {}).get("ingress")
         except ModelError as e:
-            log.debug(f"Error {e} attempting to read remote app data; "
-                      f"probably we are in a relation_departed hook")
+            log.debug(
+                f"Error {e} attempting to read remote app data; "
+                f"probably we are in a relation_departed hook"
+            )
             return {}
 
         if not raw:

--- a/lib/charms/traefik_k8s/v1/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v1/ingress_per_unit.py
@@ -760,8 +760,8 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
             raw = relation.data.get(relation.app, {}).get("ingress")
         except ModelError as e:
             log.debug(
-                f"Error {e} attempting to read remote app data; "
-                f"probably we are in a relation_departed hook"
+                "Error {} attempting to read remote app data; "
+                "probably we are in a relation_departed hook".format(e)
             )
             return {}
 

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -37,7 +37,7 @@ async def deployment(ops_test: OpsTest, traefik_charm, ipa_tester_charm):
 
 
 @pytest.mark.abort_on_fail
-async def test_relate(ops_test: OpsTest):
+async def test_relate(ops_test: OpsTest, deployment):
     await ops_test.model.add_relation("ipa-tester:ingress", "traefik-k8s:ingress")
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(["traefik-k8s", "ipa-tester"])

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -4,6 +4,7 @@ import shutil
 from pathlib import Path
 
 import pytest
+import pytest_asyncio
 import yaml
 from pytest_operator.plugin import OpsTest
 
@@ -14,30 +15,28 @@ meta = yaml.safe_load((Path() / "metadata.yaml").read_text())
 resources = {name: val["upstream-source"] for name, val in meta["resources"].items()}
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def ipa_tester_charm(ops_test: OpsTest):
     lib_source = Path() / "lib" / "charms" / "traefik_k8s" / "v1" / "ingress.py"
     libs_folder = ipa_charm_root / "lib" / "charms" / "traefik_k8s" / "v1"
     libs_folder.mkdir(parents=True, exist_ok=True)
     shutil.copy(lib_source, libs_folder)
-    yield await ops_test.build_charm(ipa_charm_root)
-    shutil.rmtree(ipa_charm_root / "lib")
+    return await ops_test.build_charm(ipa_charm_root)
 
 
-@pytest.fixture(autouse=True)
 @pytest.mark.abort_on_fail
-async def deployment(ops_test: OpsTest, traefik_charm, ipa_tester_charm):
+async def test_deployment(ops_test: OpsTest, traefik_charm, ipa_tester_charm):
     if not ops_test.model.applications.get("traefik-k8s"):
         await ops_test.model.deploy(traefik_charm, resources=resources)
     await ops_test.model.applications["traefik-k8s"].set_config({"external_hostname": "foo.bar"})
 
-    await ops_test.juju("deploy", ipa_tester_charm, "ipa-tester")
+    await ops_test.model.deploy(ipa_tester_charm, "ipa-tester")
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(["traefik-k8s", "ipa-tester"], status="active")
 
 
 @pytest.mark.abort_on_fail
-async def test_relate(ops_test: OpsTest, deployment):
+async def test_relate(ops_test: OpsTest):
     await ops_test.model.add_relation("ipa-tester:ingress", "traefik-k8s:ingress")
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(["traefik-k8s", "ipa-tester"])

--- a/tests/integration/test_charm_ipu.py
+++ b/tests/integration/test_charm_ipu.py
@@ -39,7 +39,7 @@ async def deployment(ops_test: OpsTest, traefik_charm, ipu_tester_charm):
 
 
 @pytest.mark.abort_on_fail
-async def test_relate(ops_test: OpsTest):
+async def test_relate(ops_test: OpsTest, deployment):
     await ops_test.model.add_relation(
         "ipu-tester:ingress-per-unit", "traefik-k8s:ingress-per-unit"
     )


### PR DESCRIPTION
## Issue
On relation-departed hooks, some charms (e.g. prometheus-k8s) attempt to unconditionally get the `url/urls` attrs of ipu/ipa requirer. That results in ModelError in the unguarded case in which we are in a relation departed hook or whenever 1) the relation is there 2) relation.app is not None but yet 3) we can't read the relation data anymore.

## Solution
Guarded that case with a try/except clause.

## Testing Instructions
Deploy with prom (this branch) (manually copy over the fixed ingress_per_unit.py from this PR)

## Release Notes
-  Fixed bug in IPU/IPA where unguarded attempts to read "url/urls" during relation-departed hooks would raise uncaught ModelError