### PR TITLE
removed --model arg in itests workflows

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -63,13 +63,7 @@ jobs:
           provider: microk8s
       
       - name: Run integration tests
-        run: tox -e integration -- --model testing
-
-      - name: Dump logs
-        uses: canonical/charm-logdump-action@main
-        if: failure()
-        with:
-          app: traefik-k8s
+        run: tox -vve integration
 
   static-checks:
     name: Static code analysis

--- a/.github/workflows/release-edge.yaml
+++ b/.github/workflows/release-edge.yaml
@@ -49,13 +49,7 @@ jobs:
           provider: microk8s
       
       - name: Run integration tests
-        run: tox -e integration -- --model testing
-
-      - name: Dump logs
-        uses: canonical/charm-logdump-action@main
-        if: failure()
-        with:
-          app: traefik-k8s
+        run: tox -vve integration
 
   release-to-charmhub:
     name: Release to CharmHub


### PR DESCRIPTION
Removed the `--model testing` and logdump action to make it easier to map local testing env to the CI's