### PR TITLE
workaround for ghost-relations bug

### DIFF
--- a/lib/charms/traefik_k8s/v1/ingress.py
+++ b/lib/charms/traefik_k8s/v1/ingress.py
@@ -59,7 +59,7 @@ from typing import Any, Dict, Optional, Tuple, Union
 import yaml
 from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
 from ops.framework import EventSource, Object, ObjectEvents, StoredState
-from ops.model import ModelError, Relation
+from ops.model import ModelError, Relation, Unit
 
 # The unique Charmhub library identifier, never change it
 LIBID = "e6de2a5cd5b34422a204668f3b8f90d2"
@@ -69,7 +69,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 DEFAULT_RELATION_NAME = "ingress"
 RELATION_INTERFACE = "ingress"
@@ -140,12 +140,35 @@ def _validate_data(data, schema):
         raise DataValidationError(data, schema) from e
 
 
+def _relation_data_exists(relation: Relation):
+    """Helper to verify that relation data exists.
+
+    In some cases when we receive a relation event, the relation data
+    is not ready (yet).
+    """
+    try:
+        _ = relation.data
+        return True
+    except ModelError as e:
+        log.debug("relation data access failed with {!r}".format(e))
+        return False
+
+
 class DataValidationError(RuntimeError):
     """Raised when data validation fails on IPU relation data."""
 
 
+class LeadershipError(RuntimeError):
+    """Raised when a follower unit attempts an operation that requires leadership."""
+
+
+def _leader_check(unit: Unit):
+    if not unit.is_leader():
+        raise LeadershipError(unit)
+
+
 class _IngressPerAppBase(Object):
-    """Base class for IngressPerUnit interface classes."""
+    """Base class for IngressPerApp interface classes."""
 
     def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
         super().__init__(charm, relation_name)
@@ -167,7 +190,10 @@ class _IngressPerAppBase(Object):
     @property
     def relations(self):
         """The list of Relation instances associated with this endpoint."""
-        return list(self.charm.model.relations[self.relation_name])
+        all_relations = self.charm.model.relations[self.relation_name]
+        # we filter out relations whose data is unaccessible, these are
+        # probably ghost relations (TODO: reference juju bug?)
+        return list(filter(_relation_data_exists, all_relations))
 
     def _handle_relation(self, event):
         """Subclasses should implement this method to handle a relation update."""
@@ -281,7 +307,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
 
     def wipe_ingress_data(self, relation: Relation):
         """Clear ingress data from relation."""
-        assert self.unit.is_leader(), "only leaders can do this"
+        _leader_check(self.unit)
         try:
             relation.data
         except ModelError as e:
@@ -453,6 +479,9 @@ class IngressPerAppRequirer(_IngressPerAppBase):
             self._auto_data = None
 
     def _handle_relation(self, event):
+        if not _relation_data_exists(event.relation):
+            return event.defer()
+
         # created, joined or changed: if we have auto data: publish it
         self._publish_auto_data(event.relation)
 
@@ -487,9 +516,9 @@ class IngressPerAppRequirer(_IngressPerAppBase):
     def _publish_auto_data(self, relation: Relation):
         if self._auto_data and self.unit.is_leader():
             host, port = self._auto_data
-            self.provide_ingress_requirements(host=host, port=port)
+            self.provide_ingress_requirements(host=host, port=port, relation=relation)
 
-    def provide_ingress_requirements(self, *, host: Optional[str] = None, port: int):
+    def provide_ingress_requirements(self, *, host: Optional[str] = None, port: int, relation: Optional[Relation] = None):
         """Publishes the data that Traefik needs to provide ingress.
 
         NB only the leader unit is supposed to do this.
@@ -498,12 +527,17 @@ class IngressPerAppRequirer(_IngressPerAppBase):
             host: Hostname to be used by the ingress provider to address the
              requirer unit; if unspecified, FQDN will be used instead
             port: the port of the service (required)
+            relation: the relation via which ingress should be provided.
+            If unspecified, will default to the (unique) established
+            'ingress' relation.
         """
         # get only the leader to publish the data since we only
         # require one unit to publish it -- it will not differ between units,
         # unlike in ingress-per-unit.
-        assert self.unit.is_leader(), "only leaders should do this."
-        assert self.relation, "no relation"
+        _leader_check(self.unit)
+        rel = relation or self.relation
+        if not rel:
+            raise RuntimeError("no relation; cannot provide ingress requirements")
 
         if not host:
             host = socket.getfqdn()
@@ -524,7 +558,12 @@ class IngressPerAppRequirer(_IngressPerAppBase):
     @property
     def relation(self):
         """The established Relation instance, or None."""
-        return self.relations[0] if self.relations else None
+        relations = self.relations
+        if not relations:
+            return None
+        if len(relations) > 2:
+            raise RuntimeError("Too many ingress relations: {}".format(relations))
+        return relations[0]
 
     def _get_url_from_relation_data(self) -> Optional[str]:
         """The full ingress URL to reach the current unit.

--- a/tests/unit/test_lib_per_unit_provides.py
+++ b/tests/unit/test_lib_per_unit_provides.py
@@ -5,7 +5,8 @@ from textwrap import dedent
 
 import pytest
 import yaml
-from charms.traefik_k8s.v1.ingress_per_unit import IngressPerUnitProvider
+from charms.traefik_k8s.v1.ingress_per_unit import IngressPerUnitProvider, \
+    LeadershipError
 from ops.charm import CharmBase
 from ops.model import Relation
 from ops.testing import Harness
@@ -111,7 +112,7 @@ def test_ingress_unit_provider_request_response_nonleader(
     assert unit_data["port"] == port
 
     # fail because unit isn't leader
-    with pytest.raises(AssertionError):
+    with pytest.raises(LeadershipError):
         provider.publish_url(relation, unit_data["name"], "http://url/")
 
 

--- a/tests/unit/test_lib_per_unit_requires.py
+++ b/tests/unit/test_lib_per_unit_requires.py
@@ -250,3 +250,20 @@ class TestInterlibDependency(unittest.TestCase):
         # THEN the dependee (defined in the charm's constructor before ingress-ready is emitted),
         # still has up-to-date value regardless of code ordering.
         self.assertEqual(self.harness.charm.dependee, self.harness.charm.ipu.url)
+
+
+def _requirer_revoke_ingress(harness: Harness[MockRequirerCharm], relation: Relation):
+    harness.update_relation_data(relation.id, "remote", {"ingress": ""})
+
+
+def test_ingress_unit_provider_cleanup(requirer, harness: Harness[MockRequirerCharm]):
+    # test that requirer.url is falsy if traefik revokes ingress
+    relation = relate(harness)
+    harness.set_leader(True)
+    _requirer_provide_ingress(harness, harness.charm.unit.name, "foo.com", relation)
+
+    assert harness.charm.ipu.url == "foo.com"
+
+    _requirer_revoke_ingress(harness, relation)
+    assert not harness.charm.ipu.url
+


### PR DESCRIPTION
## Issue
Fixes  #81

## Solution
1) add a `_relation_data_exists` helper that checks that `relation.data` is accessible
2) use that helper to filter `model.relations['ingress']` when trying to determine what are the ingress relations (both in IPA and IPU)
3) add a safety check in `self.relation` to verify that `self.relations` contains exactly one relation in [IPU/IPA]Requirer.

Little feature creep:
consolidated leadership checks and raise LeadershipError instead of assertion errors on leader guard fails.

## Testing Instructions
A utest wouldn't catch this.
I could test that this works to fix #81 by:
1) reproduce #81 
2) juju scp ingress_per_unit to both charms
3) juju resolve prometheus-k8s/0

--> 

![image](https://user-images.githubusercontent.com/6230162/185580891-65d6a850-a1b2-459a-bf65-5043e37ad20e.png)


Unclear whether we should be integration-testing this and how.

## Release Notes
* fixed bug where accessing relation data would raise PermissionErrors because the relation was defunct.