### PR TITLE
[IPA] Make sure `ingress.url` returns an up-to-date value

### DIFF
--- a/lib/charms/traefik_k8s/v1/ingress.py
+++ b/lib/charms/traefik_k8s/v1/ingress.py
@@ -69,7 +69,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 DEFAULT_RELATION_NAME = "ingress"
 RELATION_INTERFACE = "ingress"

--- a/tests/unit/test_lib_per_app_requires.py
+++ b/tests/unit/test_lib_per_app_requires.py
@@ -1,5 +1,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
+import unittest
 from textwrap import dedent
 
 import pytest
@@ -89,3 +90,69 @@ def test_validator(requirer: IngressPerAppRequirer, harness, auto_data, ok):
     else:
         host, port = auto_data
         requirer.provide_ingress_requirements(host=host, port=port)
+
+
+class TestIPAEventsEmission(unittest.TestCase):
+    class _RequirerCharm(CharmBase):
+        META = dedent(
+            """\
+            name: ipa-requirer
+            requires:
+              ingress:
+                interface: ingress
+                limit: 1
+            """
+        )
+
+        ready_event_count: int = 0
+        revoked_event_count: int = 0
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.ipa = IngressPerAppRequirer(self, relation_name="ingress", port=80)
+            self.framework.observe(self.ipa.on.ready, self._on_ready)
+            self.framework.observe(self.ipa.on.revoked, self._on_revoked)
+
+        def _on_ready(self, _event):
+            self.ready_event_count += 1
+
+        def _on_revoked(self, _event):
+            self.revoked_event_count += 1
+
+    def setUp(self):
+        self.harness = Harness(self._RequirerCharm, meta=self._RequirerCharm.META)
+        self.addCleanup(self.harness.cleanup)
+
+        self.harness.set_model_name(self.__class__.__name__)
+        self.harness.begin_with_initial_hooks()
+
+    def test_ipa_events(self):
+        # WHEN an ingress relation is formed
+        before = self.harness.charm.ready_event_count
+        self.rel_id = self.harness.add_relation("ingress", "traefik-app")
+        self.harness.add_relation_unit(self.rel_id, "traefik-app/0")
+
+        # AND an ingress is in effect
+        data = {"url": "http://a.b/c"}
+        self.harness.update_relation_data(
+            self.rel_id, "traefik-app", {"ingress": yaml.safe_dump(data)}
+        )
+        self.assertEqual(self.harness.charm.ipa.url, "http://a.b/c")
+
+        # THEN the ready event is emitted
+        after = self.harness.charm.ready_event_count
+        self.assertGreater(after, before)
+
+        # WHEN a relation with traefik is removed
+        before = self.harness.charm.revoked_event_count
+        self.harness.remove_relation_unit(self.rel_id, "traefik-app/0")
+        self.harness.remove_relation(self.rel_id)
+
+        # NOTE intentionally not emptying out relation data manually
+
+        # THEN ingress.url returns a false-y value
+        self.assertFalse(self.harness.charm.ipa.url)
+
+        # AND a revoked event fires
+        after = self.harness.charm.revoked_event_count
+        self.assertGreater(after, before)


### PR DESCRIPTION
An IPA analogue to #80.

## Context
https://github.com/canonical/alertmanager-k8s-operator/pull/94


## Release Notes
[IPA] Make sure `ingress.url` returns an up-to-date value
