### PR TITLE
waiting status on missing hostname

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -49,22 +49,6 @@ jobs:
       - name: Run tests
         run: tox -e unit
   
-  integration-test:
-    name: Integration tests (microk8s)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: microk8s
-      
-      - name: Run integration tests
-        run: tox -vve integration
-
   static-checks:
     name: Static code analysis
     runs-on: ubuntu-latest
@@ -79,3 +63,23 @@ jobs:
 
       - name: IPU
         run: tox -e static-ipu
+
+  integration-test:
+    name: Integration tests (microk8s)
+    runs-on: ubuntu-latest
+    needs:
+      - lint
+      - unit-test
+      - static-checks
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup operator environment
+        uses: charmed-kubernetes/actions-operator@main
+        with:
+          provider: microk8s
+
+      - name: Run integration tests
+        run: tox -vve integration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+asyncio_mode = "auto"
 
 # Formatting tools configuration
 [tool.black]

--- a/src/charm.py
+++ b/src/charm.py
@@ -126,6 +126,9 @@ class TraefikIngressCharm(CharmBase):
         observe(self.on.show_proxied_endpoints_action, self._on_show_proxied_endpoints)
 
     def _on_show_proxied_endpoints(self, event: ActionEvent):
+        if not self.ready:
+            return
+
         try:
             result = {}
             result.update(self.ingress_per_unit.proxied_endpoints)
@@ -369,8 +372,8 @@ class TraefikIngressCharm(CharmBase):
         # before continuing. However, the provider will NOT be ready if there are no units on the
         # other side, which is the case for the RelationDeparted for the last unit (i.e., the
         # proxied application scales to zero).
-        gateway_address = self._external_host
-        assert gateway_address, "No gateway address available"
+        if not self.ready:
+            return
 
         provider = self._provider_from_relation(relation)
         if not provider.is_ready(relation):

--- a/src/charm.py
+++ b/src/charm.py
@@ -377,17 +377,9 @@ class TraefikIngressCharm(CharmBase):
 
         provider = self._provider_from_relation(relation)
         if not provider.is_ready(relation):
-            # TODO Cleanup: the provider for ingress_per_unit will NOT be ready
-            #  if there are no units on the other side, which is the case for
-            #  the RelationDeparted for the last unit (i.e., the proxied
-            #  application scales to zero).
-
-            if provider == self.ingress_per_unit and not relation.units:
-                logger.debug(
-                    "No units found in the ingress-per-unit relation; "
-                    "resetting ingress configurations"
-                )
-                self._wipe_ingress_for_relation(relation)
+            logger.debug(f"Provider {provider} not ready; resetting ingress configurations.")
+            self._wipe_ingress_for_relation(relation)
+            return
 
         rel = f"{relation.name}:{relation.id}"
         self.unit.status = MaintenanceStatus(f"updating ingress configuration for '{rel}'")
@@ -400,9 +392,6 @@ class TraefikIngressCharm(CharmBase):
 
     def _provide_routed_ingress(self, relation: Relation):
         """Provide ingress to a unit related through TraefikRoute."""
-        if not self.traefik_route.is_ready(relation):
-            logger.info("traefik-route not ready on %s", relation)
-            return
         config = self.traefik_route.get_config(relation)
         self._push_configurations(relation, config)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -655,9 +655,8 @@ class TraefikIngressCharm(CharmBase):
         If the gateway isn't available or doesn't have a load balancer address yet,
         returns None.
         """
-        if "external_hostname" in self.model.config:
-            if external_hostname := self.model.config["external_hostname"]:
-                return external_hostname
+        if external_hostname := self.model.config.get("external_hostname"):
+            return external_hostname
 
         return _get_loadbalancer_status(namespace=self.model.name, service_name=self.app.name)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,10 +1,13 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
+import functools
+import logging
 import os
+from collections import defaultdict
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from subprocess import PIPE, Popen
-from time import sleep
 
 import pytest
 import yaml
@@ -17,35 +20,51 @@ trfk_resources = {name: val["upstream-source"] for name, val in trfk_meta["resou
 _JUJU_DATA_CACHE = {}
 _JUJU_KEYS = ("egress-subnets", "ingress-address", "private-address")
 
+logger = logging.getLogger(__name__)
 
-@pytest.fixture(autouse=True, scope="session")
-@pytest.mark.abort_on_fail
-def traefik_charm():
-    proc = Popen(["charmcraft", "pack"], stdout=PIPE, stderr=PIPE, cwd=charm_root)
-    proc.wait()
-    while proc.returncode is None:  # wait() does not quite wait
-        print(proc.stdout.read().decode("utf-8"))
-        sleep(1)
-    if proc.returncode != 0:
-        raise ValueError(
-            "charmcraft pack failed with code: ",
-            proc.returncode,
-            proc.stderr.read().decode("utf-8"),
-        )
 
-    charms = tuple(map(str, charm_root.glob("*.charm")))
-    assert len(charms) == 1, (
-        f"too many charms {charms}" if charms else f"no charm found at {Path().absolute()}"
-    )
+class Store(defaultdict):
+    def __init__(self):
+        super(Store, self).__init__(Store)
 
-    charm = charms[0]
-    charm_path = Path(charm).absolute()
+    def __getattr__(self, key):
+        """Override __getattr__ so dot syntax works on keys."""
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(key)
 
-    assert charm_path.exists()
+    def __setattr__(self, key, value):
+        """Override __setattr__ so dot syntax works on keys."""
+        self[key] = value
 
-    yield charm_path
 
-    Popen(["rm", str(charm_path)], cwd=charm_root).wait()
+store = Store()
+
+
+def timed_memoizer(func):
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        fname = func.__qualname__
+        logger.info("Started: %s" % fname)
+        start_time = datetime.now()
+        if fname in store.keys():
+            ret = store[fname]
+        else:
+            logger.info("Return for {} not cached".format(fname))
+            ret = await func(*args, **kwargs)
+            store[fname] = ret
+        logger.info("Finished: {} in: {} seconds".format(fname, datetime.now() - start_time))
+        return ret
+
+    return wrapper
+
+
+@pytest.fixture(scope="module")
+@timed_memoizer
+async def traefik_charm(ops_test: OpsTest):
+    charm = await ops_test.build_charm(".")
+    return charm
 
 
 def purge(data: dict):

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,36 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import asyncio
+import subprocess
+
+
+async def disable_metallb():
+    try:
+        cmd = ["sg", "microk8s", "-c", "microk8s disable metallb"]
+        subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    except Exception as e:
+        print(e)
+        raise
+
+    await asyncio.sleep(30)  # why? just because, for now
+
+
+async def enable_metallb():
+    cmd = [
+        "sh",
+        "-c",
+        "ip -4 -j route get 2.2.2.2 | jq -r '.[] | .prefsrc'",
+    ]
+    result = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    ip = result.stdout.decode("utf-8").strip()
+
+    try:
+        cmd = ["sg", "microk8s", "-c", f"microk8s enable metallb:{ip}-{ip}"]
+        subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    except Exception as e:
+        print(e)
+        raise
+
+    await asyncio.sleep(30)  # why? just because, for now
+    return ip

--- a/tests/integration/test_traefik_deployed_after_metallb.py
+++ b/tests/integration/test_traefik_deployed_after_metallb.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""This module tests that traefik ends up in active state when deployed AFTER metallb.
+
+...And without the help of update-status.
+
+1. Enable metallb (in case it's disabled).
+2. Deploy traefik + one charm per relation type (as if deployed as part of a bundle).
+
+NOTE: This module implicitly relies on in-order execution (test running in the order they are
+ written).
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+from helpers import disable_metallb, enable_metallb
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+resources = {"traefik-image": METADATA["resources"]["traefik-image"]["upstream-source"]}
+trfk = SimpleNamespace(name="traefik", resources=resources)
+
+ipu = SimpleNamespace(charm="ch:prometheus-k8s", name="prometheus")  # per unit
+ipa = SimpleNamespace(charm="ch:alertmanager-k8s", name="alertmanager")  # per app
+ipr = SimpleNamespace(charm="ch:grafana-k8s", name="grafana")  # traefik route
+
+idle_period = 90
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, traefik_charm):
+    logger.info("First, disable metallb, in case it's enabled")
+    await disable_metallb()
+    logger.info("Now enable metallb")
+    ip = await enable_metallb()
+
+    await asyncio.gather(
+        ops_test.model.deploy(
+            traefik_charm,
+            resources=trfk.resources,
+            application_name=trfk.name,
+        ),
+        ops_test.model.deploy(
+            ipu.charm,
+            application_name=ipu.name,
+            channel="edge",  # TODO change to "stable" once available
+            trust=True,
+        ),
+        ops_test.model.deploy(
+            ipa.charm,
+            application_name=ipa.name,
+            channel="edge",  # TODO change to "stable" once available
+            trust=True,
+        ),
+        ops_test.model.deploy(
+            ipr.charm,
+            application_name=ipr.name,
+            channel="edge",  # TODO change to "stable" once available
+            trust=True,
+        ),
+    )
+
+    await asyncio.gather(
+        ops_test.model.add_relation(f"{ipu.name}:ingress", trfk.name),
+        ops_test.model.add_relation(f"{ipa.name}:ingress", trfk.name),
+        ops_test.model.add_relation(f"{ipr.name}:ingress", trfk.name),
+    )
+
+    await ops_test.model.wait_for_idle(status="active", timeout=600, idle_period=idle_period)
+
+    endpoints = [
+        f"{ip}/{path}"
+        for path in [
+            f"{ops_test.model_name}-{ipr.name}",
+            f"{ops_test.model_name}-{ipu.name}-0",
+            f"{ops_test.model_name}-{ipa.name}",
+        ]
+    ]
+    for ep in endpoints:
+        # FIXME make sure the response is from the workload and not from traefik
+        pass

--- a/tests/integration/test_traefik_deployed_before_metallb.py
+++ b/tests/integration/test_traefik_deployed_before_metallb.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""This module tests that traefik ends up in active state when deployed BEFORE metallb.
+
+...And without the help of update-status.
+
+1. Disable metallb (in case it's enabled).
+2. Deploy traefik + one charm per relation type (as if deployed as part of a bundle).
+3. Enable metallb.
+
+NOTE: This module implicitly relies on in-order execution (test running in the order they are
+ written).
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+from helpers import disable_metallb, enable_metallb
+from pytest_operator.plugin import OpsTest
+
+logger = logging.getLogger(__name__)
+
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+resources = {"traefik-image": METADATA["resources"]["traefik-image"]["upstream-source"]}
+trfk = SimpleNamespace(name="traefik", resources=resources)
+
+ipu = SimpleNamespace(charm="ch:prometheus-k8s", name="prometheus")  # per unit
+ipa = SimpleNamespace(charm="ch:alertmanager-k8s", name="alertmanager")  # per app
+ipr = SimpleNamespace(charm="ch:grafana-k8s", name="grafana")  # traefik route
+
+idle_period = 90
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, traefik_charm):
+    logger.info("First, disable metallb, in case it's enabled")
+    await disable_metallb()
+
+    await asyncio.gather(
+        ops_test.model.deploy(
+            traefik_charm,
+            resources=trfk.resources,
+            application_name=trfk.name,
+        ),
+        ops_test.model.deploy(
+            ipu.charm,
+            application_name=ipu.name,
+            channel="edge",  # TODO change to "stable" once available
+            trust=True,
+        ),
+        ops_test.model.deploy(
+            ipa.charm,
+            application_name=ipa.name,
+            channel="edge",  # TODO change to "stable" once available
+            trust=True,
+        ),
+        ops_test.model.deploy(
+            ipr.charm,
+            application_name=ipr.name,
+            channel="edge",  # TODO change to "stable" once available
+            trust=True,
+        ),
+    )
+
+    await asyncio.gather(
+        ops_test.model.add_relation(f"{ipu.name}:ingress", trfk.name),
+        ops_test.model.add_relation(f"{ipa.name}:ingress", trfk.name),
+        ops_test.model.add_relation(f"{ipr.name}:ingress", trfk.name),
+    )
+
+    await ops_test.model.wait_for_idle(timeout=600, idle_period=idle_period)
+
+
+@pytest.mark.abort_on_fail
+async def test_ingressed_endpoints_reachable_after_metallb_enabled(ops_test: OpsTest):
+    logger.info("Now enable metallb")
+    ip = await enable_metallb()
+
+    await ops_test.model.wait_for_idle(status="active", timeout=600, idle_period=idle_period)
+
+    endpoints = [
+        f"{ip}/{path}"
+        for path in [
+            f"{ops_test.model_name}-{ipr.name}",
+            f"{ops_test.model_name}-{ipu.name}-0",
+            f"{ops_test.model_name}-{ipa.name}",
+        ]
+    ]
+    for ep in endpoints:
+        # FIXME make sure the response is from the workload and not from traefik
+        pass

--- a/tests/integration/testers/.gitignore
+++ b/tests/integration/testers/.gitignore
@@ -1,3 +1,3 @@
-./ipa/lib/
-./ipu/lib/
-./tcp/lib/
+/ipa/lib/charms/traefik_k8s/v1/ingress.py
+/ipu/lib/charms/traefik_k8s/v1/ingress_per_unit.py
+/tcp/lib/charms/traefik_k8s/v1/ingress_per_unit.py

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -487,11 +487,13 @@ class TestTraefikIngressCharm(unittest.TestCase):
             pass
 
     @patch("charm._get_loadbalancer_status", lambda **unused: None)
+    @patch("charm._traefik_service_running", lambda **unused: True)
     @patch("charm.KubernetesServicePatch", lambda **unused: None)
     def test_show_proxied_endpoints_action_no_relations(self):
         self.harness.begin_with_initial_hooks()
 
         action_event = Mock(spec=ActionEvent)
+        self.harness.charm.model.config._data['external_hostname'] = 'foo'
         self.harness.charm._on_show_proxied_endpoints(action_event)
         action_event.set_results.assert_called_once_with({"proxied-endpoints": "{}"})
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -487,13 +487,13 @@ class TestTraefikIngressCharm(unittest.TestCase):
             pass
 
     @patch("charm._get_loadbalancer_status", lambda **unused: None)
-    @patch("charm._traefik_service_running", lambda **unused: True)
+    @patch("charm.TraefikIngressCharm._traefik_service_running", lambda **unused: True)
     @patch("charm.KubernetesServicePatch", lambda **unused: None)
     def test_show_proxied_endpoints_action_no_relations(self):
         self.harness.begin_with_initial_hooks()
 
         action_event = Mock(spec=ActionEvent)
-        self.harness.charm.model.config._data['external_hostname'] = 'foo'
+        self.harness.charm.model.config._data["external_hostname"] = "foo"
         self.harness.charm._on_show_proxied_endpoints(action_event)
         action_event.set_results.assert_called_once_with({"proxied-endpoints": "{}"})
 


### PR DESCRIPTION
This fixes an error when relating to route before configuring external_hostname. Instead, traefik will go to waiting status