### PR TITLE
Increase the visibility of `_external_host`

### DIFF
--- a/lib/charms/observability_libs/v0/juju_topology.py
+++ b/lib/charms/observability_libs/v0/juju_topology.py
@@ -67,16 +67,15 @@ topology = JujuTopology(
 ```
 
 """
-
-import re
 from collections import OrderedDict
 from typing import Dict, List, Optional
+from uuid import UUID
 
 # The unique Charmhub library identifier, never change it
 LIBID = "bced1658f20f49d28b88f61f83c2d232"
 
 LIBAPI = 0
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 class InvalidUUIDError(Exception):
@@ -126,29 +125,18 @@ class JujuTopology:
         self._unit = unit
 
     def is_valid_uuid(self, uuid):
-        """Validate the supplied UUID against the Juju Model UUID pattern."""
-        # TODO:
-        # Harness is harcoding an UUID that is v1 not v4: f2c1b2a6-e006-11eb-ba80-0242ac130004
-        # See: https://github.com/canonical/operator/issues/779
-        #
-        # >>> uuid.UUID("f2c1b2a6-e006-11eb-ba80-0242ac130004").version
-        # 1
-        #
-        # we changed the validation of the 3ed UUID block: 4[a-f0-9]{3} -> [a-f0-9]{4}
-        # See: https://github.com/canonical/operator/blob/main/ops/testing.py#L1094
-        #
-        # Juju in fact generates a UUID v4: https://github.com/juju/utils/blob/master/uuid.go#L62
-        # but does not validate it is actually v4:
-        # See:
-        # - https://github.com/juju/utils/blob/master/uuid.go#L22
-        # - https://github.com/juju/schema/blob/master/strings.go#L79
-        #
-        # Once Harness fixes this, we should remove this comment and refactor the regex or
-        # the entire method using the uuid module to validate UUIDs
-        regex = re.compile(
-            "^[a-f0-9]{8}-?[a-f0-9]{4}-?[a-f0-9]{4}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}$"
-        )
-        return bool(regex.match(uuid))
+        """Validate the supplied UUID against the Juju Model UUID pattern.
+
+        Args:
+            uuid: string that needs to be checked if it is valid v4 UUID.
+
+        Returns:
+            True if parameter is a valid v4 UUID, False otherwise.
+        """
+        try:
+            return str(UUID(uuid, version=4)) == uuid
+        except (ValueError, TypeError):
+            return False
 
     @classmethod
     def from_charm(cls, charm):

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -322,14 +322,16 @@ import re
 import socket
 import subprocess
 import tempfile
-import uuid
+from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
+from urllib.parse import urlparse
 
 import yaml
 from charms.observability_libs.v0.juju_topology import JujuTopology
 from ops.charm import CharmBase, RelationRole
 from ops.framework import BoundEvent, EventBase, EventSource, Object, ObjectEvents
+from ops.model import Relation
 
 # The unique Charmhub library identifier, never change it
 LIBID = "bc84295fef5f4049878f07b131968ee2"
@@ -339,7 +341,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 21
+LIBPATCH = 23
 
 logger = logging.getLogger(__name__)
 
@@ -356,7 +358,10 @@ ALLOWED_KEYS = {
     "sample_limit",
     "label_limit",
     "label_name_length_limit",
-    "label_value_lenght_limit",
+    "label_value_length_limit",
+    "scheme",
+    "basic_auth",
+    "tls_config",
 }
 DEFAULT_JOB = {
     "metrics_path": "/metrics",
@@ -368,6 +373,216 @@ DEFAULT_RELATION_NAME = "metrics-endpoint"
 RELATION_INTERFACE_NAME = "prometheus_scrape"
 
 DEFAULT_ALERT_RULES_RELATIVE_PATH = "./src/prometheus_alert_rules"
+
+
+class PrometheusConfig:
+    """A namespace for utility functions for manipulating the prometheus config dict."""
+
+    # relabel instance labels so that instance identifiers are globally unique
+    # stable over unit recreation
+    topology_relabel_config = {
+        "source_labels": ["juju_model", "juju_model_uuid", "juju_application"],
+        "separator": "_",
+        "target_label": "instance",
+        "regex": "(.*)",
+    }
+
+    topology_relabel_config_wildcard = {
+        "source_labels": ["juju_model", "juju_model_uuid", "juju_application", "juju_unit"],
+        "separator": "_",
+        "target_label": "instance",
+        "regex": "(.*)",
+    }
+
+    @staticmethod
+    def sanitize_scrape_config(job: dict) -> dict:
+        """Restrict permissible scrape configuration options.
+
+        If job is empty then a default job is returned. The
+        default job is
+
+        ```
+        {
+            "metrics_path": "/metrics",
+            "static_configs": [{"targets": ["*:80"]}],
+        }
+        ```
+
+        Args:
+            job: a dict containing a single Prometheus job
+                specification.
+
+        Returns:
+            a dictionary containing a sanitized job specification.
+        """
+        sanitized_job = DEFAULT_JOB.copy()
+        sanitized_job.update({key: value for key, value in job.items() if key in ALLOWED_KEYS})
+        return sanitized_job
+
+    @staticmethod
+    def sanitize_scrape_configs(scrape_configs: List[dict]) -> List[dict]:
+        """A vectorized version of `sanitize_scrape_config`."""
+        return [PrometheusConfig.sanitize_scrape_config(job) for job in scrape_configs]
+
+    @staticmethod
+    def prefix_job_names(scrape_configs: List[dict], prefix: str) -> List[dict]:
+        """Adds the given prefix to all the job names in the given scrape_configs list."""
+        modified_scrape_configs = []
+        for scrape_config in scrape_configs:
+            job_name = scrape_config.get("job_name")
+            modified = scrape_config.copy()
+            modified["job_name"] = prefix + "_" + job_name if job_name else prefix
+            modified_scrape_configs.append(modified)
+
+        return modified_scrape_configs
+
+    @staticmethod
+    def expand_wildcard_targets_into_individual_jobs(
+        scrape_jobs: List[dict],
+        hosts: Dict[str, Tuple[str, str]],
+        topology: JujuTopology = None,
+    ) -> List[dict]:
+        """Extract wildcard hosts from the given scrape_configs list into separate jobs.
+
+        Args:
+            scrape_jobs: list of scrape jobs.
+            hosts: a dictionary mapping host names to host address for
+                all units of the relation for which this job configuration
+                must be constructed.
+            topology: optional arg for adding topology labels to scrape targets.
+        """
+        # hosts = self._relation_hosts(relation)
+
+        modified_scrape_jobs = []
+        for job in scrape_jobs:
+            static_configs = job.get("static_configs")
+            if not static_configs:
+                continue
+
+            # When a single unit specified more than one wildcard target, then they are expanded
+            # into a static_config per target
+            non_wildcard_static_configs = []
+
+            for static_config in static_configs:
+                targets = static_config.get("targets")
+                if not targets:
+                    continue
+
+                # All non-wildcard targets remain in the same static_config
+                non_wildcard_targets = []
+
+                # All wildcard targets are extracted to a job per unit. If multiple wildcard
+                # targets are specified, they remain in the same static_config (per unit).
+                wildcard_targets = []
+
+                for target in targets:
+                    match = re.compile(r"\*(?:(:\d+))?").match(target)
+                    if match:
+                        # This is a wildcard target.
+                        # Need to expand into separate jobs and remove it from this job here
+                        wildcard_targets.append(target)
+                    else:
+                        # This is not a wildcard target. Copy it over into its own static_config.
+                        non_wildcard_targets.append(target)
+
+                # All non-wildcard targets remain in the same static_config
+                if non_wildcard_targets:
+                    non_wildcard_static_config = static_config.copy()
+                    non_wildcard_static_config["targets"] = non_wildcard_targets
+
+                    if topology:
+                        # When non-wildcard targets (aka fully qualified hostnames) are specified,
+                        # there is no reliable way to determine the name (Juju topology unit name)
+                        # for such a target. Therefore labeling with Juju topology, excluding the
+                        # unit name.
+                        non_wildcard_static_config["labels"] = {
+                            **non_wildcard_static_config.get("labels", {}),
+                            **topology.label_matcher_dict,
+                        }
+
+                    non_wildcard_static_configs.append(non_wildcard_static_config)
+
+                # Extract wildcard targets into individual jobs
+                if wildcard_targets:
+                    for unit_name, (unit_hostname, unit_path) in hosts.items():
+                        modified_job = job.copy()
+                        modified_job["static_configs"] = [static_config.copy()]
+                        modified_static_config = modified_job["static_configs"][0]
+                        modified_static_config["targets"] = [
+                            target.replace("*", unit_hostname) for target in wildcard_targets
+                        ]
+
+                        unit_num = unit_name.split("/")[-1]
+                        job_name = modified_job.get("job_name", "unnamed-job") + "-" + unit_num
+                        modified_job["job_name"] = job_name
+                        modified_job["metrics_path"] = unit_path + (
+                            job.get("metrics_path") or "/metrics"
+                        )
+
+                        if topology:
+                            # Add topology labels
+                            modified_static_config["labels"] = {
+                                **modified_static_config.get("labels", {}),
+                                **topology.label_matcher_dict,
+                                **{"juju_unit": unit_name},
+                            }
+
+                            # Instance relabeling for topology should be last in order.
+                            modified_job["relabel_configs"] = modified_job.get(
+                                "relabel_configs", []
+                            ) + [PrometheusConfig.topology_relabel_config_wildcard]
+
+                        modified_scrape_jobs.append(modified_job)
+
+            if non_wildcard_static_configs:
+                modified_job = job.copy()
+                modified_job["static_configs"] = non_wildcard_static_configs
+                modified_job["metrics_path"] = modified_job.get("metrics_path") or "/metrics"
+
+                if topology:
+                    # Instance relabeling for topology should be last in order.
+                    modified_job["relabel_configs"] = modified_job.get("relabel_configs", []) + [
+                        PrometheusConfig.topology_relabel_config
+                    ]
+
+                modified_scrape_jobs.append(modified_job)
+
+        return modified_scrape_jobs
+
+    @staticmethod
+    def render_alertmanager_static_configs(alertmanagers: List[str]):
+        """Render the alertmanager static_configs section from a list of URLs.
+
+        Each target must be in the hostname:port format, and prefixes are specified in a separate
+        key. Therefore, with ingress in place, would need to extract the path into the
+        `path_prefix` key, which is higher up in the config hierarchy.
+
+        https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alertmanager_config
+
+        Args:
+            alertmanagers: List of alertmanager URLs.
+
+        Returns:
+            A dict representation for the static_configs section.
+        """
+        # Make sure it's a valid url so urlparse could parse it.
+        scheme = re.compile(r"^https?://")
+        sanitized = [am if scheme.search(am) else "http://" + am for am in alertmanagers]
+
+        # Create a mapping from paths to netlocs
+        # Group alertmanager targets into a dictionary of lists:
+        # {path: [netloc1, netloc2]}
+        paths = defaultdict(list)  # type: Dict[str, List[str]]
+        for parsed in map(urlparse, sanitized):
+            path = parsed.path or "/"
+            paths[path].append(parsed.netloc)
+
+        return {
+            "alertmanagers": [
+                {"path_prefix": path_prefix, "static_configs": [{"targets": netlocs}]}
+                for path_prefix, netlocs in paths.items()
+            ]
+        }
 
 
 class RelationNotFoundError(Exception):
@@ -506,31 +721,6 @@ def _validate_relation_by_interface_and_direction(
         raise Exception("Unexpected RelationDirection: {}".format(expected_relation_role))
 
 
-def _sanitize_scrape_configuration(job) -> dict:
-    """Restrict permissible scrape configuration options.
-
-    If job is empty then a default job is returned. The
-    default job is
-
-    ```
-    {
-        "metrics_path": "/metrics",
-        "static_configs": [{"targets": ["*:80"]}],
-    }
-    ```
-
-    Args:
-        job: a dict containing a single Prometheus job
-            specification.
-
-    Returns:
-        a dictionary containing a sanitized job specification.
-    """
-    sanitized_job = DEFAULT_JOB.copy()
-    sanitized_job.update({key: value for key, value in job.items() if key in ALLOWED_KEYS})
-    return sanitized_job
-
-
 class InvalidAlertRulePathError(Exception):
     """Raised if the alert rules folder cannot be found or is otherwise invalid."""
 
@@ -639,6 +829,12 @@ class AlertRules:
                 logger.error("Failed to read alert rules from %s: %s", file_path.name, e)
                 return []
 
+            if not rule_file:
+                logger.warning("Empty rules file: %s", file_path.name)
+                return []
+            if not isinstance(rule_file, dict):
+                logger.error("Invalid rules file (must be a dict): %s", file_path.name)
+                return []
             if _is_official_alert_rule_format(rule_file):
                 alert_groups = rule_file["groups"]
             elif _is_single_alert_rule_format(rule_file):
@@ -920,7 +1116,7 @@ class MetricsEndpointConsumer(Object):
         for topology_identifier, alert_rule_groups in self.metrics_consumer.alerts().items():
             filename = "juju_" + topology_identifier + ".rules"
             path = os.path.join(PROMETHEUS_RULES_DIR, filename)
-            rules = yaml.dump(alert_rule_groups)
+            rules = yaml.safe_dump(alert_rule_groups)
             container.push(path, rules, make_dirs=True)
         ```
 
@@ -937,7 +1133,6 @@ class MetricsEndpointConsumer(Object):
             if not alert_rules:
                 continue
 
-            identifier = None
             try:
                 scrape_metadata = json.loads(relation.data[relation.app]["scrape_metadata"])
                 identifier = JujuTopology.from_dict(scrape_metadata).identifier
@@ -1036,34 +1231,22 @@ class MetricsEndpointConsumer(Object):
         if not scrape_metadata:
             return scrape_jobs
 
-        job_name_prefix = "juju_{}_prometheus_scrape".format(
-            JujuTopology.from_dict(scrape_metadata).identifier
-        )
+        topology = JujuTopology.from_dict(scrape_metadata)
+
+        job_name_prefix = "juju_{}_prometheus_scrape".format(topology.identifier)
+        scrape_jobs = PrometheusConfig.prefix_job_names(scrape_jobs, job_name_prefix)
+        scrape_jobs = PrometheusConfig.sanitize_scrape_configs(scrape_jobs)
+
         hosts = self._relation_hosts(relation)
 
-        labeled_job_configs = []
-        for job in scrape_jobs:
-            config = self._labeled_static_job_config(
-                _sanitize_scrape_configuration(job),
-                job_name_prefix,
-                hosts,
-                scrape_metadata,
-            )
-            labeled_job_configs.append(config)
+        scrape_jobs = PrometheusConfig.expand_wildcard_targets_into_individual_jobs(
+            scrape_jobs, hosts, topology
+        )
 
-        return labeled_job_configs
+        return scrape_jobs
 
-    def _relation_hosts(self, relation) -> dict:
-        """Fetch unit names and address of all metrics provider units for a single relation.
-
-        Args:
-            relation: An `ops.model.Relation` object for which the unit name to
-                address mapping is required.
-
-        Returns:
-            A dictionary that maps unit names to unit addresses for
-            the specified relation.
-        """
+    def _relation_hosts(self, relation: Relation) -> Dict[str, Tuple[str, str]]:
+        """Returns a mapping from unit names to (address, path) tuples, for the given relation."""
         hosts = {}
         for unit in relation.units:
             # TODO deprecate and remove unit.name
@@ -1072,90 +1255,11 @@ class MetricsEndpointConsumer(Object):
             unit_address = relation.data[unit].get(
                 "prometheus_scrape_unit_address"
             ) or relation.data[unit].get("prometheus_scrape_host")
+            unit_path = relation.data[unit].get("prometheus_scrape_unit_path", "")
             if unit_name and unit_address:
-                hosts.update({unit_name: unit_address})
+                hosts.update({unit_name: (unit_address, unit_path)})
 
         return hosts
-
-    def _labeled_static_job_config(self, job, job_name_prefix, hosts, scrape_metadata) -> dict:
-        """Construct labeled job configuration for a single job.
-
-        Args:
-
-            job: a dictionary representing the job configuration as obtained from
-                `MetricsEndpointProvider` over relation data.
-            job_name_prefix: a string that may either be used as the
-                job name if the job has no associated name or used as a prefix for
-                the job if it does have a job name.
-            hosts: a dictionary mapping host names to host address for
-                all units of the relation for which this job configuration
-                must be constructed.
-            scrape_metadata: scrape configuration metadata obtained
-                from `MetricsEndpointProvider` from the same relation for
-                which this job configuration is being constructed.
-
-        Returns:
-            A dictionary representing a Prometheus job configuration
-            for a single job.
-        """
-        name = job.get("job_name")
-        job_name = "{}_{}".format(job_name_prefix, name) if name else job_name_prefix
-
-        labeled_job = job.copy()
-        labeled_job["job_name"] = job_name
-
-        static_configs = job.get("static_configs")
-        labeled_job["static_configs"] = []
-
-        # relabel instance labels so that instance identifiers are globally unique
-        # stable over unit recreation
-        instance_relabel_config = {
-            "source_labels": ["juju_model", "juju_model_uuid", "juju_application"],
-            "separator": "_",
-            "target_label": "instance",
-            "regex": "(.*)",
-        }
-
-        # label all static configs in the Prometheus job
-        # labeling inserts Juju topology information and
-        # sets a relable config for instance labels
-        for static_config in static_configs:
-            labels = static_config.get("labels", {}) if static_configs else {}
-            all_targets = static_config.get("targets", [])
-
-            # split all targets into those which will have unit labels
-            # and those which will not
-            ports = []
-            unitless_targets = []
-            for target in all_targets:
-                host, port = self._target_parts(target)
-                if host.strip() == "*":
-                    ports.append(port.strip())
-                else:
-                    unitless_targets.append(target)
-
-            # label scrape targets that do not have unit labels
-            if unitless_targets:
-                unitless_config = self._labeled_unitless_config(
-                    unitless_targets, labels, scrape_metadata
-                )
-                labeled_job["static_configs"].append(unitless_config)
-
-            # label scrape targets that do have unit labels
-            for host_name, host_address in hosts.items():
-                static_config = self._labeled_unit_config(
-                    host_name, host_address, ports, labels, scrape_metadata
-                )
-                labeled_job["static_configs"].append(static_config)
-                if "juju_unit" not in instance_relabel_config["source_labels"]:
-                    instance_relabel_config["source_labels"].append("juju_unit")  # type: ignore
-
-        # ensure topology relabeling of instance label is last in order of relabelings
-        relabel_configs = job.get("relabel_configs", [])
-        relabel_configs.append(instance_relabel_config)
-        labeled_job["relabel_configs"] = relabel_configs
-
-        return labeled_job
 
     def _target_parts(self, target) -> list:
         """Extract host and port from a wildcard target.
@@ -1177,92 +1281,11 @@ class MetricsEndpointConsumer(Object):
 
         return parts
 
-    def _set_juju_labels(self, labels, scrape_metadata) -> dict:
-        """Create a copy of metric labels with Juju topology information.
-
-        Args:
-            labels: a dictionary containing Prometheus metric labels.
-            scrape_metadata: scrape related metadata provided by
-                `MetricsEndpointProvider`.
-
-        Returns:
-            a copy of the `labels` dictionary augmented with Juju
-            topology information with the exception of unit name.
-        """
-        juju_labels = labels.copy()  # deep copy not needed
-        juju_labels.update(JujuTopology.from_dict(scrape_metadata).label_matcher_dict)
-
-        return juju_labels
-
-    def _labeled_unitless_config(self, targets, labels, scrape_metadata) -> dict:
-        """Static scrape configuration for fully qualified host addresses.
-
-        Fully qualified hosts are those scrape targets for which the
-        address are specified by the `MetricsEndpointProvider` as part
-        of the scrape job specification set in application relation data.
-        The address specified need not belong to any unit of the
-        `MetricsEndpointProvider` charm. As a result there is no reliable
-        way to determine the name (Juju topology unit name) for such a
-        target.
-
-        Args:
-            targets: a list of addresses of fully qualified hosts.
-            labels: labels specified by `MetricsEndpointProvider` clients
-                 which are associated with `targets`.
-            scrape_metadata: scrape related metadata provided by `MetricsEndpointProvider`.
-
-        Returns:
-            A dictionary containing the static scrape configuration
-            for a list of fully qualified hosts.
-        """
-        juju_labels = self._set_juju_labels(labels, scrape_metadata)
-        unitless_config = {"targets": targets, "labels": juju_labels}
-        return unitless_config
-
-    def _labeled_unit_config(
-        self, unit_name, host_address, ports, labels, scrape_metadata
-    ) -> dict:
-        """Static scrape configuration for a wildcard host.
-
-        Wildcard hosts are those scrape targets whose name (Juju unit
-        name) and address (unit IP address) is set into unit relation
-        data by the `MetricsEndpointProvider` charm, which sets this
-        data for ALL its units.
-
-        Args:
-            unit_name: a string representing the unit name of the wildcard host.
-            host_address: a string representing the address of the wildcard host.
-            ports: list of ports on which this wildcard host exposes its metrics.
-            labels: a dictionary of labels provided by
-                `MetricsEndpointProvider` intended to be associated with
-                this wildcard host.
-            scrape_metadata: scrape related metadata provided by `MetricsEndpointProvider`.
-
-        Returns:
-            A dictionary containing the static scrape configuration
-            for a single wildcard host.
-        """
-        juju_labels = self._set_juju_labels(labels, scrape_metadata)
-
-        juju_labels["juju_unit"] = unit_name
-
-        static_config = {"labels": juju_labels}
-
-        if ports:
-            targets = []
-            for port in ports:
-                targets.append("{}:{}".format(host_address, port))
-            static_config["targets"] = targets  # type: ignore
-        else:
-            static_config["targets"] = [host_address]  # type: ignore
-
-        return static_config
-
 
 def _dedupe_job_names(jobs: List[dict]):
     """Deduplicate a list of dicts by appending a hash to the value of the 'job_name' key.
 
-    Additionally fully dedeuplicate any identical jobs.
+    Additionally, fully de-duplicate any identical jobs.
 
     Args:
         jobs: A list of prometheus scrape jobs
@@ -1345,6 +1368,7 @@ class MetricsEndpointProvider(Object):
         jobs=None,
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
         refresh_event: Optional[Union[BoundEvent, List[BoundEvent]]] = None,
+        external_url: str = None,
     ):
         """Construct a metrics provider for a Prometheus charm.
 
@@ -1430,7 +1454,7 @@ class MetricsEndpointProvider(Object):
 
         Args:
             charm: a `CharmBase` object that manages this
-                `MetricsEndpointProvider` object. Typically this is
+                `MetricsEndpointProvider` object. Typically, this is
                 `self` in the instantiating class.
             relation_name: an optional string name of the relation between `charm`
                 and the Prometheus charmed service. The default is "metrics-endpoint".
@@ -1449,6 +1473,8 @@ class MetricsEndpointProvider(Object):
                 The alert rules are automatically updated on charm upgrade.
             refresh_event: an optional bound event or list of bound events which
                 will be observed to re-set scrape job data (IP address and others)
+            external_url: an optional argument that represents an external url that
+                can be generated by an Ingress or a Proxy.
 
         Raises:
             RelationNotFoundError: If there is no relation in the charm's metadata.yaml
@@ -1481,7 +1507,13 @@ class MetricsEndpointProvider(Object):
         self._relation_name = relation_name
         # sanitize job configurations to the supported subset of parameters
         jobs = [] if jobs is None else jobs
-        self._jobs = [_sanitize_scrape_configuration(job) for job in jobs]
+        self._jobs = PrometheusConfig.sanitize_scrape_configs(jobs)
+
+        if external_url:
+            external_url = (
+                external_url if urlparse(external_url).scheme else ("http://" + external_url)
+            )
+        self.external_url = external_url
 
         events = self._charm.on[self._relation_name]
         self.framework.observe(events.relation_joined, self._set_scrape_job_spec)
@@ -1510,7 +1542,7 @@ class MetricsEndpointProvider(Object):
                 refresh_event = [refresh_event]
 
         for ev in refresh_event:
-            self.framework.observe(ev, self._set_unit_ip)
+            self.framework.observe(ev, self._set_scrape_job_spec)
 
         self.framework.observe(self._charm.on.upgrade_charm, self._set_scrape_job_spec)
 
@@ -1539,7 +1571,7 @@ class MetricsEndpointProvider(Object):
         When a metrics provider charm is related to a prometheus charm, the
         metrics provider sets specification and metadata related to its own
         scrape configuration. This information is set using Juju application
-        data. In addition each of the consumer units also sets its own
+        data. In addition, each of the consumer units also sets its own
         host address in Juju unit relation data.
         """
         self._set_unit_ip(event)
@@ -1568,16 +1600,28 @@ class MetricsEndpointProvider(Object):
         Each time a metrics provider charm container is restarted it updates its own
         host address in the unit relation data for the prometheus charm.
 
-        The only argument specified is an event and it ignored. this is for expediency
+        The only argument specified is an event, and it ignored. This is for expediency
         to be able to use this method as an event handler, although no access to the
         event is actually needed.
         """
         for relation in self._charm.model.relations[self._relation_name]:
             unit_ip = str(self._charm.model.get_binding(relation).network.bind_address)
-            relation.data[self._charm.unit]["prometheus_scrape_unit_address"] = (
-                unit_ip if self._is_valid_unit_address(unit_ip) else socket.getfqdn()
-            )
 
+            # TODO store entire url in relation data, instead of only select url parts.
+
+            if self.external_url:
+                parsed = urlparse(self.external_url)
+                unit_address = parsed.hostname
+                path = parsed.path
+            elif self._is_valid_unit_address(unit_ip):
+                unit_address = unit_ip
+                path = ""
+            else:
+                unit_address = socket.getfqdn()
+                path = ""
+
+            relation.data[self._charm.unit]["prometheus_scrape_unit_address"] = unit_address
+            relation.data[self._charm.unit]["prometheus_scrape_unit_path"] = path
             relation.data[self._charm.unit]["prometheus_scrape_unit_name"] = str(
                 self._charm.model.unit.name
             )
@@ -1634,7 +1678,7 @@ class PrometheusRulesProvider(Object):
         relation_name: Name of the relation in `metadata.yaml` that
             has the `prometheus_scrape` interface.
         dir_path: Root directory for the collection of rule files.
-        recursive: Whether or not to scan for rule files recursively.
+        recursive: Whether to scan for rule files recursively.
     """
 
     def __init__(
@@ -1696,7 +1740,7 @@ class MetricsEndpointAggregator(Object):
 
     `MetricsEndpointAggregator` collects scrape target information from one
     or more related charms and forwards this to a `MetricsEndpointConsumer`
-    charm, which may be in a different Juju model. However it is
+    charm, which may be in a different Juju model. However, it is
     essential that `MetricsEndpointAggregator` itself resides in the same
     model as its scrape targets, as this is currently the only way to
     ensure in Juju that the `MetricsEndpointAggregator` will be able to
@@ -1765,7 +1809,7 @@ class MetricsEndpointAggregator(Object):
     information, just like `MetricsEndpointProvider` and
     `MetricsEndpointConsumer` do.
 
-    By default `MetricsEndpointAggregator` ensures that Prometheus
+    By default, `MetricsEndpointAggregator` ensures that Prometheus
     "instance" labels refer to Juju topology. This ensures that
     instance labels are stable over unit recreation. While it is not
     advisable to change this option, if required it can be done by
@@ -1778,7 +1822,7 @@ class MetricsEndpointAggregator(Object):
 
         Args:
             charm: a `CharmBase` object that manages this
-                `MetricsEndpointAggregator` object. Typically this is
+                `MetricsEndpointAggregator` object. Typically, this is
                 `self` in the instantiating class.
             relation_names: a dictionary with three keys. The value
                 of the "scrape_target" and "alert_rules" keys are
@@ -1843,7 +1887,7 @@ class MetricsEndpointAggregator(Object):
         When there is any change in relation data with any scrape
         target, the Prometheus scrape job, for that specific target is
         updated. Additionally, if this method is called manually, do the
-        sameself.
+        same.
 
         Args:
             targets: a `dict` containing target information
@@ -1985,7 +2029,7 @@ class MetricsEndpointAggregator(Object):
 
         Scrape target information is returned for each unit in the
         relation. This information contains the unit name, network
-        hostname (or address) for that unit, and port on which an
+        hostname (or address) for that unit, and port on which a
         metrics endpoint is exposed in that unit.
 
         Args:
@@ -2142,7 +2186,7 @@ class MetricsEndpointAggregator(Object):
         labels are stable across unit recreation.
 
         Returns:
-            a list of Prometheus relabling configurations. Each item in
+            a list of Prometheus relabeling configurations. Each item in
             this list is one relabel configuration.
         """
         return (
@@ -2216,22 +2260,7 @@ class CosTool:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             rule_path = Path(tmpdir + "/validate_rule.yaml")
-
-            # Smash "our" rules format into what upstream actually uses, which is more like:
-            #
-            # groups:
-            #   - name: foo
-            #     rules:
-            #       - alert: SomeAlert
-            #         expr: up
-            #       - alert: OtherAlert
-            #         expr: up
-            transformed_rules = {"groups": []}  # type: ignore
-            for rule in rules["groups"]:
-                transformed = {"name": str(uuid.uuid4()), "rules": [rule]}
-                transformed_rules["groups"].append(transformed)
-
-            rule_path.write_text(yaml.dump(transformed_rules))
+            rule_path.write_text(yaml.dump(rules))
 
             args = [str(self.path), "validate", str(rule_path)]
             # noinspection PyBroadException
@@ -2240,7 +2269,13 @@ class CosTool:
                 return True, ""
             except subprocess.CalledProcessError as e:
                 logger.debug("Validating the rules failed: %s", e.output)
-                return False, ", ".join([line for line in e.output if "error validating" in line])
+                return False, ", ".join(
+                    [
+                        line
+                        for line in e.output.decode("utf8").splitlines()
+                        if "error validating" in line
+                    ]
+                )
 
     def inject_label_matchers(self, expression, topology) -> str:
         """Add label matchers to an expression."""
@@ -2277,6 +2312,5 @@ class CosTool:
         return None
 
     def _exec(self, cmd) -> str:
-        result = subprocess.run(cmd, check=True, stdout=subprocess.PIPE)
-        output = result.stdout.decode("utf-8").strip()
-        return output
+        result = subprocess.run(cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        return result.stdout.decode("utf-8").strip()

--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -135,7 +135,9 @@ class TraefikRouteProvider(Object):
     on = TraefikRouteProviderEvents()
     _stored = StoredState()
 
-    def __init__(self, charm: CharmBase, relation_name: str = "traefik-route"):
+    def __init__(
+        self, charm: CharmBase, relation_name: str = "traefik-route", external_host: str = ""
+    ):
         """Constructor for TraefikRouteProvider.
 
         Args:
@@ -149,8 +151,8 @@ class TraefikRouteProvider(Object):
         self.charm = charm
         self._relation_name = relation_name
 
-        if self._stored.external_host != charm.external_host:
-            self._stored.external_host = charm.external_host
+        if self._stored.external_host != external_host:
+            self._stored.external_host = external_host
             self._update_requirers_with_external_host()
 
         self.framework.observe(

--- a/src/charm.py
+++ b/src/charm.py
@@ -104,7 +104,7 @@ class TraefikIngressCharm(CharmBase):
 
         self.ingress_per_app = IngressPerAppProvider(charm=self)
         self.ingress_per_unit = IngressPerUnitProvider(charm=self)
-        self.traefik_route = TraefikRouteProvider(charm=self)
+        self.traefik_route = TraefikRouteProvider(charm=self, external_host=self.external_host)
 
         observe = self.framework.observe
         observe(self.on.traefik_pebble_ready, self._on_traefik_pebble_ready)

--- a/src/charm.py
+++ b/src/charm.py
@@ -239,7 +239,7 @@ class TraefikIngressCharm(CharmBase):
     def _on_config_changed(self, _: ConfigChangedEvent):
         # If the external hostname is changed since we last processed it, we need to
         # to reconsider all data sent over the relations and all configs
-        new_external_host = self._external_host
+        new_external_host = self.external_host
         new_routing_mode = self.config["routing_mode"]
 
         if (
@@ -266,7 +266,7 @@ class TraefikIngressCharm(CharmBase):
             )
             return
 
-        hostname = self._external_host
+        hostname = self.external_host
 
         if not hostname:
             self.unit.status = MaintenanceStatus("resetting ingress relations")
@@ -333,7 +333,7 @@ class TraefikIngressCharm(CharmBase):
     @property
     def ready(self) -> bool:
         """Check whether we have an external host set, and traefik is running."""
-        if not self._external_host:
+        if not self.external_host:
             self._wipe_ingress_for_all_relations()  # fixme: no side-effects in prop
             self.unit.status = WaitingStatus("gateway address unavailable")
             return False
@@ -480,7 +480,7 @@ class TraefikIngressCharm(CharmBase):
         """Generate a config dict for a given unit for IngressPerUnit."""
         config = {"http": {"routers": {}, "services": {}}}
         prefix = self._get_prefix(data)
-        host = self._external_host
+        host = self.external_host
         if data["mode"] == "tcp":
             port = data["port"]
             unit_url = f"{host}:{port}"
@@ -525,7 +525,7 @@ class TraefikIngressCharm(CharmBase):
         return config, unit_url
 
     def _generate_per_app_config(self, data: "RequirerData_IPA") -> Tuple[dict, str]:
-        host = self._external_host
+        host = self.external_host
         port = self._port
         prefix = self._get_prefix(data)
 
@@ -635,7 +635,7 @@ class TraefikIngressCharm(CharmBase):
             return self.traefik_route
 
     @property
-    def _external_host(self):
+    def external_host(self):
         """Determine the external address for the ingress gateway.
 
         It will prefer the `external-hostname` config if that is set, otherwise

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -232,7 +232,7 @@ async def get_address(ops_test: OpsTest, app_name: str, unit=0):
 async def deploy_traefik_if_not_deployed(ops_test: OpsTest, traefik_charm):
     if not ops_test.model.applications.get("traefik-k8s"):
         await ops_test.model.deploy(
-            traefik_charm, application_name="traefik-k8s", resources=trfk_resources
+            traefik_charm, application_name="traefik-k8s", resources=trfk_resources, series="focal"
         )
         # if we're running this locally, we need to wait for "waiting"
         # CI however deploys all in a single model, so traefik is active already
@@ -258,7 +258,9 @@ async def deploy_traefik_if_not_deployed(ops_test: OpsTest, traefik_charm):
 
 async def deploy_charm_if_not_deployed(ops_test: OpsTest, charm, app_name: str, resources=None):
     if not ops_test.model.applications.get(app_name):
-        await ops_test.model.deploy(charm, resources=resources, application_name=app_name)
+        await ops_test.model.deploy(
+            charm, resources=resources, application_name=app_name, series="focal"
+        )
 
     # block until app goes to active/idle
     async with ops_test.fast_forward():

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -24,7 +24,9 @@ async def test_build_and_deploy(ops_test: OpsTest, traefik_charm):
     """
     # build and deploy charm from local source folder
     resources = {"traefik-image": METADATA["resources"]["traefik-image"]["upstream-source"]}
-    await ops_test.model.deploy(traefik_charm, resources=resources, application_name=APP_NAME)
+    await ops_test.model.deploy(
+        traefik_charm, resources=resources, application_name=APP_NAME, series="focal"
+    )
     await ops_test.model.applications[APP_NAME].set_config({"external_hostname": "foo.bar"})
 
     # issuing dummy update_status just to trigger an event

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -34,7 +34,7 @@ async def ipa_tester_charm(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_deployment(ops_test: OpsTest, traefik_charm, ipa_tester_charm):
     await deploy_traefik_if_not_deployed(ops_test, traefik_charm)
-    await ops_test.model.deploy(ipa_tester_charm, "ipa-tester")
+    await ops_test.model.deploy(ipa_tester_charm, "ipa-tester", series="focal")
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(["traefik-k8s", "ipa-tester"], status="active")
 

--- a/tests/integration/test_charm_ipu.py
+++ b/tests/integration/test_charm_ipu.py
@@ -34,7 +34,7 @@ async def ipu_tester_charm(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_deployment(ops_test: OpsTest, traefik_charm, ipu_tester_charm):
     await deploy_traefik_if_not_deployed(ops_test, traefik_charm)
-    await ops_test.model.deploy(ipu_tester_charm, "ipu-tester")
+    await ops_test.model.deploy(ipu_tester_charm, "ipu-tester", series="focal")
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
             ["traefik-k8s", "ipu-tester"], status="active", timeout=1000

--- a/tests/integration/test_charm_tcp.py
+++ b/tests/integration/test_charm_tcp.py
@@ -47,7 +47,9 @@ def get_unit_ip(ops_test: OpsTest):
 @pytest.mark.abort_on_fail
 async def test_deployment(ops_test: OpsTest, traefik_charm, tcp_tester_charm):
     await deploy_traefik_if_not_deployed(ops_test, traefik_charm)
-    await ops_test.model.deploy(tcp_tester_charm, "tcp-tester", resources=tcp_charm_resources)
+    await ops_test.model.deploy(
+        tcp_tester_charm, "tcp-tester", resources=tcp_charm_resources, series="focal"
+    )
     async with ops_test.fast_forward():
         await ops_test.model.wait_for_idle(
             ["traefik-k8s", "tcp-tester"], status="active", timeout=1000

--- a/tests/integration/test_traefik_deployed_after_metallb.py
+++ b/tests/integration/test_traefik_deployed_after_metallb.py
@@ -79,6 +79,8 @@ async def test_build_and_deploy(ops_test: OpsTest, traefik_charm):
         ops_test.model.add_relation(f"{ipr.name}:ingress", trfk.name),
     )
 
+    await ops_test.model.wait_for_idle(status="active", timeout=600, idle_period=30)
+
     endpoints = [
         f"{ip}/{path}"
         for path in [

--- a/tests/integration/test_traefik_deployed_after_metallb.py
+++ b/tests/integration/test_traefik_deployed_after_metallb.py
@@ -71,13 +71,13 @@ async def test_build_and_deploy(ops_test: OpsTest, traefik_charm):
         ),
     )
 
+    await ops_test.model.wait_for_idle(status="active", timeout=600, idle_period=30)
+
     await asyncio.gather(
         ops_test.model.add_relation(f"{ipu.name}:ingress", trfk.name),
         ops_test.model.add_relation(f"{ipa.name}:ingress", trfk.name),
         ops_test.model.add_relation(f"{ipr.name}:ingress", trfk.name),
     )
-
-    await ops_test.model.wait_for_idle(status="active", timeout=600, idle_period=idle_period)
 
     endpoints = [
         f"{ip}/{path}"

--- a/tests/integration/test_traefik_deployed_after_metallb.py
+++ b/tests/integration/test_traefik_deployed_after_metallb.py
@@ -46,27 +46,28 @@ async def test_build_and_deploy(ops_test: OpsTest, traefik_charm):
 
     await asyncio.gather(
         ops_test.model.deploy(
-            traefik_charm,
-            resources=trfk.resources,
-            application_name=trfk.name,
+            traefik_charm, resources=trfk.resources, application_name=trfk.name, series="focal"
         ),
         ops_test.model.deploy(
             ipu.charm,
             application_name=ipu.name,
             channel="edge",  # TODO change to "stable" once available
             trust=True,
+            series="focal",
         ),
         ops_test.model.deploy(
             ipa.charm,
             application_name=ipa.name,
             channel="edge",  # TODO change to "stable" once available
             trust=True,
+            series="focal",
         ),
         ops_test.model.deploy(
             ipr.charm,
             application_name=ipr.name,
             channel="edge",  # TODO change to "stable" once available
             trust=True,
+            series="focal",
         ),
     )
 

--- a/tests/integration/test_traefik_deployed_before_metallb.py
+++ b/tests/integration/test_traefik_deployed_before_metallb.py
@@ -70,6 +70,8 @@ async def test_build_and_deploy(ops_test: OpsTest, traefik_charm):
         ),
     )
 
+    await ops_test.model.wait_for_idle(timeout=600, idle_period=30)
+
     await asyncio.gather(
         ops_test.model.add_relation(f"{ipu.name}:ingress", trfk.name),
         ops_test.model.add_relation(f"{ipa.name}:ingress", trfk.name),

--- a/tests/integration/test_traefik_deployed_before_metallb.py
+++ b/tests/integration/test_traefik_deployed_before_metallb.py
@@ -45,27 +45,28 @@ async def test_build_and_deploy(ops_test: OpsTest, traefik_charm):
 
     await asyncio.gather(
         ops_test.model.deploy(
-            traefik_charm,
-            resources=trfk.resources,
-            application_name=trfk.name,
+            traefik_charm, resources=trfk.resources, application_name=trfk.name, series="focal"
         ),
         ops_test.model.deploy(
             ipu.charm,
             application_name=ipu.name,
             channel="edge",  # TODO change to "stable" once available
             trust=True,
+            series="focal",
         ),
         ops_test.model.deploy(
             ipa.charm,
             application_name=ipa.name,
             channel="edge",  # TODO change to "stable" once available
             trust=True,
+            series="focal",
         ),
         ops_test.model.deploy(
             ipr.charm,
             application_name=ipr.name,
             channel="edge",  # TODO change to "stable" once available
             trust=True,
+            series="focal",
         ),
     )
 


### PR DESCRIPTION
## Issue
It is not currently possible to forward `_external_host` as a "known" value back to `TraefikRouteRequirer` without calling private methods, making it unwieldy to inform `TraefikRouteProviders` what the `external_host` may be.

## Solution
Make `_external_host` into `external_host`, and pass it as a constructor argument to `TraefikRouteProvider`

## Context
See this [grafana-k8s issue](https://github.com/canonical/grafana-k8s-operator/issues/143#event-7605411772), for example.

## Release Notes
Increase the visibility of `_external_host`, update `traefik_route` libraries