### PR TITLE
Update `TraefikRoute` again so the external host is passed through on more update conditions

### DIFF
--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -218,7 +218,6 @@ class TraefikRouteRequirer(Object):
     def external_host(self) -> str:
         """Return the external host set by Traefik, if any."""
         self._update_stored_external_host()
-        log.warning("---- EXTERNAL_HOST IS: {}".format(self._stored.external_host))
         return self._stored.external_host or ""
 
     def _update_stored_external_host(self) -> None:


### PR DESCRIPTION
## Issue
Previously, if `traefik` was deployed prior to any `TraefikRouteProviders` and had already acquired an `external_host` (either via `config-set` or from the loadbalancer assigning an address), the comparison to `StoredState` would always be true, and it would not be updated, despite the remote end potentially not knowing what the value is.

## Solution
When `TraefikRouteRequirer` is ready, send the external host over relation data.

## Release Notes
Update `TraefikRoute` again so the external host is passed through on more update conditions