### PR TITLE
Centralize CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,64 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [main]
+
+permissions:
+  security-events:
+    write
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Override automatic language detection by changing the below list
+        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
+        language: ['python']
+        # Learn more...
+        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file. 
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,53 @@
+name: Issues
+
+on: [issues]
+
+jobs:
+  update:
+    name: Update Issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump Github Context
+        run: |
+          echo "update=false" >> $GITHUB_ENV
+          if [ ${{ github.event_name }} != "issues" ]; then
+            echo "This action only operates on issues"
+            exit 0
+          fi
+          echo "update=true" >> $GITHUB_ENV
+      - name: Determine action
+        run: |
+          if [ ${{ github.event.action }} == "opened" ]; then
+            echo "action=open" >> $GITHUB_ENV
+          fi
+          if [ ${{ github.event.action }} == "reopened" ]; then
+            echo "action=reopen" >> $GITHUB_ENV
+          fi
+          if [ ${{ github.event.action }} == "closed" ]; then
+            echo "action=close" >> $GITHUB_ENV
+          fi
+      - name: Determine type
+        run: |
+          if ${{ contains(github.event.*.labels.*.name, 'Type: Bug') }}; then
+            echo "type=bug" >> $GITHUB_ENV
+          else
+            echo "type=story" >> $GITHUB_ENV
+          fi
+      - name: Update
+        if: ${{ env.update == 'true' }}
+        env:
+          ID: ${{ github.event.issue.html_url }}
+          TITLE: ${{github.event.issue.title }}
+          COMPONENT: traefik
+          DESCRIPTION: Opened by ${{ github.event.issue.user.login }}.
+        run: |
+          data=$(jq -n \
+            --arg id "$ID" \
+            --arg action "${{ env.action }}" \
+            --arg title "$TITLE" \
+            --arg description "$DESCRIPTION" \
+            --arg component "$COMPONENT" \
+            --arg type "${{ env.type }}" \
+            '{data: {id: $id, action: $action, title: $title, description: $description, component: $component, type: $type}}')
+
+          curl -X POST -H 'Content-type: application/json' --data "${data}" "${{ secrets.JIRA_URL }}"

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -13,30 +13,8 @@ on:
 
 jobs:
   promote:
-    name: Promote Charm
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set target channel
-        env:
-          PROMOTE_FROM: ${{ github.event.inputs.promotion }}
-        run: |
-          if [ "${PROMOTE_FROM}" == "edge -> beta" ]; then
-            echo "promote-from=edge" >> ${GITHUB_ENV}
-            echo "promote-to=beta" >> ${GITHUB_ENV}
-          elif [ "${PROMOTE_FROM}" == "beta -> candidate" ]; then
-            echo "promote-from=beta" >> ${GITHUB_ENV}
-            echo "promote-to=candidate" >> ${GITHUB_ENV}
-          elif [ "${PROMOTE_FROM}" == "candidate -> stable" ]; then
-            echo "promote-from=candidate" >> ${GITHUB_ENV}
-            echo "promote-to=stable" >> ${GITHUB_ENV}
-          fi
-      - name: Promote Charm
-        uses: canonical/charming-actions/release-charm@2.0.0-rc
-        with:
-          credentials: ${{ secrets.CHARMHUB_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          destination-channel: latest/${{ env.promote-to }}
-          origin-channel: latest/${{ env.promote-from }}
-          charmcraft-channel: latest/stable
+    name: Promote
+    uses: canonical/observability/.github/workflows/promote-charm.yaml@main
+    with:
+      promotion: ${{ github.event.inputs.promotion }}
+    secrets: inherit

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,85 +1,12 @@
-name: Pull Request
+name: Pull Requests
 
-on: 
+on:
   pull_request:
     branches:
       - main
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      
-      - name: Install dependencies
-        run: python3 -m pip install tox
-      
-      - name: Run linters
-        run: tox -e lint
-
-  check-libraries:
-    name: Check libraries
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  
-      - name: Check libraries
-        uses: canonical/charming-actions/check-libraries@2.0.0-rc2
-        with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-  unit-test:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install dependencies
-        run: python -m pip install tox
-  
-      - name: Run tests
-        run: tox -e unit
-  
-  static-checks:
-    name: Static code analysis
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Install dependencies
-        run: python -m pip install tox
-
-      - name: IPU
-        run: tox -e static-ipu
-
-  integration-test:
-    name: Integration tests (microk8s)
-    runs-on: ubuntu-latest
-    needs:
-      - lint
-      - unit-test
-      - static-checks
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: microk8s
-
-      - name: Run integration tests
-        run: tox -vve integration
+  pull-request:
+    name: PR
+    uses: canonical/observability/.github/workflows/pull-request.yaml@main
+    secrets: inherit

--- a/.github/workflows/release-edge.yaml
+++ b/.github/workflows/release-edge.yaml
@@ -1,77 +1,11 @@
 name: Release to Edge
 
-on: 
+on:
   push:
     branches:
-      - main  
+      - main
 
 jobs:
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      
-      - name: Install dependencies
-        run: python3 -m pip install tox
-      
-      - name: Run linters
-        run: tox -e lint
-  
-  unit-test:
-    name: Unit tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install dependencies
-        run: python -m pip install tox
-  
-      - name: Run tests
-        run: tox -e unit
-  
-  integration-test:
-    name: Integration tests (microk8s)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-          provider: microk8s
-      
-      - name: Run integration tests
-        run: tox -vve integration
-
-  release-to-charmhub:
-    name: Release to CharmHub
-    needs: 
-      - lint
-      - unit-test
-      - integration-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.0.0-rc2
-        id: channel
-
-      - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.0.0-rc2
-        with:
-          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          upload-image: "true"
-          channel: "${{ steps.channel.outputs.name }}"
+  release:
+    uses: canonical/observability/.github/workflows/release-charm.yaml@main
+    secrets: inherit

--- a/lib/charms/traefik_k8s/v1/ingress.py
+++ b/lib/charms/traefik_k8s/v1/ingress.py
@@ -69,7 +69,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 DEFAULT_RELATION_NAME = "ingress"
 RELATION_INTERFACE = "ingress"

--- a/lib/charms/traefik_k8s/v1/ingress.py
+++ b/lib/charms/traefik_k8s/v1/ingress.py
@@ -54,7 +54,7 @@ class SomeCharm(CharmBase):
 import logging
 import socket
 import typing
-from typing import Any, Dict, Optional, Tuple, Type, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 import yaml
 from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent

--- a/lib/charms/traefik_k8s/v1/ingress.py
+++ b/lib/charms/traefik_k8s/v1/ingress.py
@@ -376,7 +376,9 @@ class IngressPerAppProvider(_IngressPerAppBase):
         results = {}
 
         for ingress_relation in self.relations:
-            assert ingress_relation.app, "no app in relation (shouldn't happen)"  # for type checker
+            assert (
+                ingress_relation.app
+            ), "no app in relation (shouldn't happen)"  # for type checker
             results[ingress_relation.app.name] = self._provided_url(ingress_relation)
 
         return results

--- a/lib/charms/traefik_k8s/v1/ingress.py
+++ b/lib/charms/traefik_k8s/v1/ingress.py
@@ -54,7 +54,7 @@ class SomeCharm(CharmBase):
 import logging
 import socket
 import typing
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Type, Union
 
 import yaml
 from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
@@ -124,7 +124,7 @@ RequirerData = TypedDict(
 # Provider ingress data model.
 ProviderIngressData = TypedDict("ProviderIngressData", {"url": str})
 # Provider application databag model.
-ProviderApplicationData = TypedDict("ProviderApplicationData", {"ingress": ProviderIngressData})
+ProviderApplicationData = TypedDict("ProviderApplicationData", {"ingress": ProviderIngressData})  # type: ignore
 
 
 def _validate_data(data, schema):
@@ -161,8 +161,8 @@ class _IngressPerAppBase(Object):
         observe(rel_events.relation_joined, self._handle_relation)
         observe(rel_events.relation_changed, self._handle_relation)
         observe(rel_events.relation_broken, self._handle_relation_broken)
-        observe(charm.on.leader_elected, self._handle_upgrade_or_leader)
-        observe(charm.on.upgrade_charm, self._handle_upgrade_or_leader)
+        observe(charm.on.leader_elected, self._handle_upgrade_or_leader)  # type: ignore
+        observe(charm.on.upgrade_charm, self._handle_upgrade_or_leader)  # type: ignore
 
     @property
     def relations(self):
@@ -229,10 +229,10 @@ class IngressPerAppDataProvidedEvent(_IPAEvent):
     __args__ = ("name", "model", "port", "host", "strip_prefix")
 
     if typing.TYPE_CHECKING:
-        name = None  # type: str
-        model = None  # type: str
-        port = None  # type: int
-        host = None  # type: str
+        name = None  # type: Optional[str]
+        model = None  # type: Optional[str]
+        port = None  # type: Optional[str]
+        host = None  # type: Optional[str]
         strip_prefix = False  # type: bool
 
 
@@ -267,7 +267,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
         # notify listeners.
         if self.is_ready(event.relation):
             data = self._get_requirer_data(event.relation)
-            self.on.data_provided.emit(
+            self.on.data_provided.emit(  # type: ignore
                 event.relation,
                 data["name"],
                 data["model"],
@@ -277,7 +277,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
             )
 
     def _handle_relation_broken(self, event):
-        self.on.data_removed.emit(event.relation)
+        self.on.data_removed.emit(event.relation)  # type: ignore
 
     def wipe_ingress_data(self, relation: Relation):
         """Clear ingress data from relation."""
@@ -293,11 +293,12 @@ class IngressPerAppProvider(_IngressPerAppBase):
             return
         del relation.data[self.app]["ingress"]
 
-    def _get_requirer_data(self, relation: Relation) -> RequirerData:
+    def _get_requirer_data(self, relation: Relation) -> RequirerData:  # type: ignore
         """Fetch and validate the requirer's app databag.
 
         For convenience, we convert 'port' to integer.
         """
+        assert relation.app, "no app in relation (shouldn't happen)"  # for type checker
         if not all((relation.app, relation.app.name)):
             # Handle edge case where remote app name can be missing, e.g.,
             # relation_broken events.
@@ -315,7 +316,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
         remote_data["strip-prefix"] = bool(remote_data.get("strip-prefix", False))
         return remote_data
 
-    def get_data(self, relation: Relation) -> RequirerData:
+    def get_data(self, relation: Relation) -> RequirerData:  # type: ignore
         """Fetch the remote app's databag, i.e. the requirer data."""
         return self._get_requirer_data(relation)
 
@@ -330,8 +331,9 @@ class IngressPerAppProvider(_IngressPerAppBase):
             log.warning("Requirer not ready; validation error encountered: %s" % str(e))
             return False
 
-    def _provided_url(self, relation: Relation) -> ProviderIngressData:
+    def _provided_url(self, relation: Relation) -> ProviderIngressData:  # type: ignore
         """Fetch and validate this app databag; return the ingress url."""
+        assert relation.app, "no app in relation (shouldn't happen)"  # for type checker
         if not all((relation.app, relation.app.name, self.unit.is_leader())):
             # Handle edge case where remote app name can be missing, e.g.,
             # relation_broken events.
@@ -374,6 +376,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
         results = {}
 
         for ingress_relation in self.relations:
+            assert ingress_relation.app, "no app in relation (shouldn't happen)"  # for type checker
             results[ingress_relation.app.name] = self._provided_url(ingress_relation)
 
         return results
@@ -384,7 +387,7 @@ class IngressPerAppReadyEvent(_IPAEvent):
 
     __args__ = ("url",)
     if typing.TYPE_CHECKING:
-        url = None  # type: str
+        url = None  # type: Optional[str]
 
 
 class IngressPerAppRevokedEvent(RelationEvent):
@@ -438,7 +441,7 @@ class IngressPerAppRequirer(_IngressPerAppBase):
         self.relation_name = relation_name
         self._strip_prefix = strip_prefix
 
-        self._stored.set_default(current_url=None)
+        self._stored.set_default(current_url=None)  # type: ignore
 
         # if instantiated with a port, and we are related, then
         # we immediately publish our ingress data  to speed up the process.
@@ -458,13 +461,13 @@ class IngressPerAppRequirer(_IngressPerAppBase):
                 if isinstance(event, RelationBrokenEvent)
                 else self._get_url_from_relation_data()
             )
-            if self._stored.current_url != new_url:
-                self._stored.current_url = new_url
-                self.on.ready.emit(event.relation, new_url)
+            if self._stored.current_url != new_url:  # type: ignore
+                self._stored.current_url = new_url  # type: ignore
+                self.on.ready.emit(event.relation, new_url)  # type: ignore
 
     def _handle_relation_broken(self, event):
-        self._stored.current_url = None
-        self.on.revoked.emit(event.relation)
+        self._stored.current_url = None  # type: ignore
+        self.on.revoked.emit(event.relation)  # type: ignore
 
     def _handle_upgrade_or_leader(self, event):
         """On upgrade/leadership change: ensure we publish the data we have."""
@@ -532,6 +535,7 @@ class IngressPerAppRequirer(_IngressPerAppBase):
 
         # fetch the provider's app databag
         try:
+            assert relation.app, "no app in relation (shouldn't happen)"  # for type checker
             raw = relation.data.get(relation.app, {}).get("ingress")
         except ModelError as e:
             log.debug(

--- a/src/charm.py
+++ b/src/charm.py
@@ -24,7 +24,7 @@ from charms.traefik_route_k8s.v0.traefik_route import (
     TraefikRouteRequirerReadyEvent,
 )
 from deepmerge import always_merger
-from lightkube import Client
+from lightkube.core.client import Client
 from lightkube.resources.core_v1 import Service
 from ops.charm import (
     ActionEvent,
@@ -81,7 +81,7 @@ class TraefikIngressCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
 
-        self._stored.set_default(
+        self._stored.set_default(  # pyright: reportGeneralTypeIssues=false
             current_external_host=None, current_routing_mode=None, tcp_entrypoints=None
         )
 
@@ -618,6 +618,7 @@ class TraefikIngressCharm(CharmBase):
         # Apps not in the same model as Traefik (i.e., if `relation` is a CRM) will have
         # some `remote_...` as app name. Relation name and id are handy when one is
         # troubleshooting via `juju run 'relation_ids'...` and the like.`
+        assert relation.app, "no app in relation (shouldn't happen)"  # for type checker
         return f"juju_ingress_{relation.name}_{relation.id}_{relation.app.name}.yaml"
 
     @property

--- a/tox.ini
+++ b/tox.ini
@@ -80,9 +80,12 @@ commands =
 [testenv:static-{charm,lib}]
 description = Static code checking
 deps =
-    pyright
-    jsonschema
-    ops == 1.5.2
+    # TODO: drop the "charm:" qualification from the line below when we drop py3.5 support.
+    charm: pyright
+    charm: -r{toxinidir}/requirements.txt
 commands =
     charm: pyright --pythonversion 3.8 {[vars]src_path}
-    lib: pyright --pythonversion 3.8 {[vars]lib_path}
+    # NOTE: the ingress lib is not py3.5 compliant and doesn't pass centralized PR.
+    # TODO: change "charm" to "lib" when we drop py3.5 support.
+    charm: pyright --pythonversion 3.8 {[vars]lib_path}
+    #lib: pyright --pythonversion 3.8 {[vars]lib_path}

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
-envlist = lint, static, static-ipu, unit
+envlist = lint, static-{charm, lib}, unit
 
 [vars]
 src_path = {toxinidir}/src/
@@ -77,9 +77,11 @@ deps =
 commands =
     pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
 
-[testenv:static-ipu]
-description = Static code checking for ingress-per-unit
+[testenv:static-{charm,lib}]
+description = Static code checking
 deps =
     pyright
     -r{toxinidir}/requirements.txt
-commands = pyright --pythonversion 3.5 {toxinidir}/lib/charms/traefik_k8s/v1/ingress_per_unit.py
+commands =
+    charm: pyright --pythonversion 3.8 {[vars]src_path}
+    lib: pyright --pythonversion 3.5 {[vars]lib_path}

--- a/tox.ini
+++ b/tox.ini
@@ -82,6 +82,7 @@ description = Static code checking
 deps =
     pyright
     -r{toxinidir}/requirements.txt
+    lib: httpx>=0.20.0
 commands =
     charm: pyright --pythonversion 3.8 {[vars]src_path}
     lib: pyright --pythonversion 3.8 {[vars]lib_path}

--- a/tox.ini
+++ b/tox.ini
@@ -81,8 +81,8 @@ commands =
 description = Static code checking
 deps =
     pyright
-    -r{toxinidir}/requirements.txt
-    lib: httpx>=0.20.0
+    jsonschema
+    ops == 1.5.2
 commands =
     charm: pyright --pythonversion 3.8 {[vars]src_path}
     lib: pyright --pythonversion 3.8 {[vars]lib_path}

--- a/tox.ini
+++ b/tox.ini
@@ -84,4 +84,4 @@ deps =
     -r{toxinidir}/requirements.txt
 commands =
     charm: pyright --pythonversion 3.8 {[vars]src_path}
-    lib: pyright --pythonversion 3.5 {[vars]lib_path}
+    lib: pyright --pythonversion 3.8 {[vars]lib_path}


### PR DESCRIPTION
## Issue
CI is outdated ([fails](https://github.com/canonical/traefik-k8s-operator/actions/runs/3594529878/jobs/6057922843)).


## Solution
Use centralized CI like all other o11y repos.


## Context
NTA.


## Testing Instructions
Make sure all tox envs are reflected in CI.


## Release Notes
Centralize CI.
