### PR TITLE
Fix per-app middleware injection

### DIFF
--- a/lib/charms/traefik_k8s/v1/ingress.py
+++ b/lib/charms/traefik_k8s/v1/ingress.py
@@ -69,7 +69,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 DEFAULT_RELATION_NAME = "ingress"
 RELATION_INTERFACE = "ingress"
@@ -559,6 +559,6 @@ class IngressPerAppRequirer(_IngressPerAppBase):
 
         Returns None if the URL isn't available yet.
         """
-        data = self._stored.current_url or None  # type: ignore
+        data = self._stored.current_url or self._get_url_from_relation_data()  # type: ignore
         assert isinstance(data, (str, type(None)))  # for static checker
         return data

--- a/src/charm.py
+++ b/src/charm.py
@@ -566,13 +566,8 @@ class TraefikIngressCharm(CharmBase):
             }
         }
 
-        middlewares = self._generate_middleware_config(data, prefix)
-        if middlewares:
-            router_cfg["middlewares"] = list(middlewares.keys())
-
         config = {
             "http": {
-                "middlewares": middlewares,
                 "routers": router_cfg,
                 "services": {
                     traefik_service_name: {
@@ -583,6 +578,12 @@ class TraefikIngressCharm(CharmBase):
                 },
             }
         }
+
+        middlewares = self._generate_middleware_config(data, prefix)
+
+        if middlewares:
+            config["http"]["middlewares"] = middlewares
+            router_cfg[traefik_router_name]["middlewares"] = list(middlewares.keys())
 
         return config, app_url
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -260,6 +260,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
         relation = relate(self.harness)
         for strip_prefix in (False, True):
             # in subdomain routing mode this should not have any effect
+            # ^^^ there is NO REASON this should be true. They can be combined
             with self.subTest():
                 _requirer_provide_ingress_requirements(
                     harness=self.harness,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -150,7 +150,6 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
                 expected = {
                     "http": {
-                        "middlewares": None,
                         "routers": {
                             "juju-test-model-remote-0-router": {
                                 "entryPoints": ["web"],
@@ -165,6 +164,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
                         },
                     }
                 }
+
                 if strip_prefix:
                     expected["http"].update(middlewares)
                     expected["http"]["routers"]["juju-test-model-remote-0-router"].update(
@@ -337,7 +337,6 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
                 expected = {
                     "http": {
-                        "middlewares": None,
                         "routers": {
                             "juju-test-model-remote-0-router": {
                                 "entryPoints": ["web"],
@@ -400,7 +399,6 @@ class TestTraefikIngressCharm(unittest.TestCase):
 
             expected = {
                 "http": {
-                    "middlewares": None,
                     "routers": {
                         "juju-test-model-remote-0-router": {
                             "entryPoints": ["web"],


### PR DESCRIPTION
## Issue
The indentation rules for `stripPrefix` for per-app ingress were incorrect, and inconsistent with per-unit ingressing.

## Solution
Fix the indentation, so it works as expected.

As part of this, extract the "common" configuration block generation logic to a new function (only the actual `PathPrefix` and list of LB servers once "ingress" is reworked to no longer be only "ingress per leader, which is the only configured LB, whether intentionally or not") to avoid this kind of frustrating indentation error.

Rework the unit tests somewhat so the `*_per_app` tests _actually_ test per-app.

Finally, fix requirer-side fetching of `url` in IPA.

## Additional information
It's pretty annoying unintended behavior from Traefik that a value which is at the wrong level of indentation successfully parses, but does not apply, so long as it can be deserialized/unmarshaled into a `map[str][]string`, but this actually breaks if the "entire" `middlewares` block is moved, because a `map[str]interface{}` (or whatever the backing datatype/struct the middleware configs are supposed to be unmarshalled into) does not, and Traefik would actually fail to route to the charm completely rather than just silently ignoring the "intended" middleware block.

## Release Notes
Fix per-app middleware injection. Unify configuration block generation.