### PR TITLE
alert rules for self-monitoring

### DIFF
--- a/src/prometheus_alert_rules/reload_failure.rule
+++ b/src/prometheus_alert_rules/reload_failure.rule
@@ -5,4 +5,4 @@ labels:
   severity: critical
 annotations:
   summary: Traefik config reload failure (instance {{ $labels.instance }})
-  description: "Traefik config reload failure rate is above 0"
+  description: "Traefik keeps failing to reload its config file"

--- a/src/prometheus_alert_rules/reload_failure.rule
+++ b/src/prometheus_alert_rules/reload_failure.rule
@@ -1,0 +1,8 @@
+alert: TraefikConfigReloadFailure
+expr: rate(traefik_config_reloads_failure_total[3m]) > bool 0
+for: 1m
+labels:
+  severity: critical
+annotations:
+  summary: Traefik config reload failure (instance {{ $labels.instance }})
+  description: "Traefik config reload failure rate is above 0"

--- a/src/prometheus_alert_rules/unit_unavailable.rule
+++ b/src/prometheus_alert_rules/unit_unavailable.rule
@@ -1,5 +1,5 @@
 alert: TraefikIngressUnitIsUnavailable
-expr: up{%%juju_topology%%} < 1
+expr: up < 1
 for: 0m
 labels:
   severity: critical


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR add a new alert rule and fix an older one

## Solution
<!-- A summary of the solution addressing the above issue -->

The new alert rule we are adding checks whether the traefik config reload fails or not.


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Pack the charm, deploy and relate it with prometheus charm.

