### PR TITLE
catch charmcraft pack errors in spellbook

### DIFF
--- a/tests/integration/spellbook/cache.py
+++ b/tests/integration/spellbook/cache.py
@@ -6,7 +6,7 @@ import shutil
 from datetime import datetime
 from hashlib import md5
 from pathlib import Path
-from subprocess import getoutput
+from subprocess import CalledProcessError, check_output, getoutput
 from typing import List, Union
 
 import yaml
@@ -40,7 +40,7 @@ def _get_libpath(base, source):
     return root.absolute()
 
 
-def spellbook_fetch(  # ignore: C901
+def spellbook_fetch(  # noqa: C901
     charm_root: Union[str, Path] = "./",
     charm_name: str = None,
     hash_paths: List[Path] = None,
@@ -75,8 +75,14 @@ def spellbook_fetch(  # ignore: C901
 
     def do_build():
         logging.info(f"building {charm_root}")
-        pack_out = getoutput(f"charmcraft pack -p {charm_root}")
-        return (Path(os.getcwd()) / pack_out.split("\n")[-1].strip()).absolute()
+        try:
+            pack_out = check_output(f"charmcraft pack -p {charm_root}")
+        except CalledProcessError as e:
+            raise RuntimeError(
+                "Charmcraft pack failed. " "Attempt a `charmcraft clean` or inspect the logs."
+            ) from e
+        # if everything went OK, `charmcraft pack`'s last line is the packed charm filename.
+        return (Path(os.getcwd()) / pack_out.decode("utf-8").split("\n")[-1].strip()).absolute()
 
     if not use_cache:
         logging.info("not using cache")

--- a/tests/integration/spellbook/cache.py
+++ b/tests/integration/spellbook/cache.py
@@ -79,7 +79,7 @@ def spellbook_fetch(  # noqa: C901
             pack_out = check_output(("charmcraft", "pack", "-p", str(charm_root)))
         except CalledProcessError as e:
             raise RuntimeError(
-                "Charmcraft pack failed. " "Attempt a `charmcraft clean` or inspect the logs."
+                "Charmcraft pack failed. Attempt a `charmcraft clean` or inspect the logs."
             ) from e
         # if everything went OK, `charmcraft pack`'s last line is the packed charm filename.
         return (Path(os.getcwd()) / pack_out.decode("utf-8").split("\n")[-1].strip()).absolute()

--- a/tests/integration/spellbook/cache.py
+++ b/tests/integration/spellbook/cache.py
@@ -76,7 +76,7 @@ def spellbook_fetch(  # noqa: C901
     def do_build():
         logging.info(f"building {charm_root}")
         try:
-            pack_out = check_output(f"charmcraft pack -p {charm_root}")
+            pack_out = check_output(("charmcraft", "pack", "-p", str(charm_root)))
         except CalledProcessError as e:
             raise RuntimeError(
                 "Charmcraft pack failed. " "Attempt a `charmcraft clean` or inspect the logs."


### PR DESCRIPTION
## Issue
spellbook's `do_build` was naively assuming `charmcraft pack` would succeed.
Also changed tox.ini so that linting is only ran on `src/`, because I was getting errors from charm libs (not owned by traefik)


## Solution
Wrapped the command in a try/catch that aborts on nonzero return codes, raising a helpful message.


## Testing Instructions
Hope the CI passes

## Release Notes
* fixed bug in spellbook cache