### PR TITLE
Fix missing relation app

### DIFF
--- a/lib/charms/traefik_k8s/v1/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v1/ingress_per_unit.py
@@ -82,7 +82,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 log = logging.getLogger(__name__)
 
@@ -801,7 +801,7 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
         if not relation:
             return {}
 
-        if not all((relation.app, relation.app.name)):  # type: ignore
+        if not all([r for r in [relation.app, relation.app.name]]):  # type: ignore
             # FIXME Workaround for https://github.com/canonical/operator/issues/693
             # We must be in a relation_broken hook
             return {}

--- a/lib/charms/traefik_k8s/v1/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v1/ingress_per_unit.py
@@ -801,7 +801,7 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
         if not relation:
             return {}
 
-        if not relation.app and relation.app.name:  # type: ignore
+        if not relation.app and not relation.app.name:  # type: ignore
             # FIXME Workaround for https://github.com/canonical/operator/issues/693
             # We must be in a relation_broken hook
             return {}

--- a/lib/charms/traefik_k8s/v1/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v1/ingress_per_unit.py
@@ -801,7 +801,7 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
         if not relation:
             return {}
 
-        if not all([r for r in [relation.app, relation.app.name]]):  # type: ignore
+        if not relation.app and relation.app.name:  # type: ignore
             # FIXME Workaround for https://github.com/canonical/operator/issues/693
             # We must be in a relation_broken hook
             return {}

--- a/tox.ini
+++ b/tox.ini
@@ -79,12 +79,8 @@ commands =
 [testenv:static-{charm,lib}]
 description = Static code checking
 deps =
-    # TODO: drop the "charm:" qualification from the line below when we drop py3.5 support.
-    charm: pyright
-    charm: -r{toxinidir}/requirements.txt
+    pyright
+    -r{toxinidir}/requirements.txt
 commands =
     charm: pyright --pythonversion 3.8 {[vars]src_path}
-    # NOTE: the ingress lib is not py3.5 compliant and doesn't pass centralized PR.
-    # TODO: change "charm" to "lib" when we drop py3.5 support.
-    charm: pyright --pythonversion 3.8 {[vars]lib_path}
-    #lib: pyright --pythonversion 3.8 {[vars]lib_path}
+    lib: pyright --pythonversion 3.8 {[vars]lib_path}


### PR DESCRIPTION
## Issue
Resolving `all((some, tuple))` or other is not a generator, is not lazily-evalutated, and will immediately throw an `AttributeError` at resolution if something cannot be found.

## Solution
Use a comprehension to provide a generator, and short-circuit on the first failure.

## Context
See [this comment](https://github.com/canonical/grafana-k8s-operator/issues/165#issuecomment-1375436662), reported on Grafana, but in this library.


## Release Notes
Guard for `relation.app = None` in `ingress_per_unit`. Move tox to 3.8