### PR TITLE
Fixes for newer versions of ops (1.5.4 and 2.0.0rc2)

### DIFF
--- a/lib/charms/traefik_k8s/v1/ingress.py
+++ b/lib/charms/traefik_k8s/v1/ingress.py
@@ -69,7 +69,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 DEFAULT_RELATION_NAME = "ingress"
 RELATION_INTERFACE = "ingress"
@@ -202,7 +202,7 @@ class _IPAEvent(RelationEvent):
             obj = kwargs.get(attr, default)
             setattr(self, attr, obj)
 
-    def snapshot(self) -> dict:
+    def snapshot(self):
         dct = super().snapshot()
         for attr in self.__attrs__():
             obj = getattr(self, attr)
@@ -217,7 +217,7 @@ class _IPAEvent(RelationEvent):
 
         return dct
 
-    def restore(self, snapshot: dict) -> None:
+    def restore(self, snapshot) -> None:
         super().restore(snapshot)
         for attr, obj in snapshot.items():
             setattr(self, attr, obj)
@@ -250,7 +250,7 @@ class IngressPerAppProviderEvents(ObjectEvents):
 class IngressPerAppProvider(_IngressPerAppBase):
     """Implementation of the provider of ingress."""
 
-    on = IngressPerAppProviderEvents()
+    on = IngressPerAppProviderEvents()  # type: ignore
 
     def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
         """Constructor for IngressPerAppProvider.
@@ -406,7 +406,8 @@ class IngressPerAppRequirerEvents(ObjectEvents):
 class IngressPerAppRequirer(_IngressPerAppBase):
     """Implementation of the requirer of the ingress relation."""
 
-    on = IngressPerAppRequirerEvents()
+    on = IngressPerAppRequirerEvents()  # type: ignore
+
     # used to prevent spur1ious urls to be sent out if the event we're currently
     # handling is a relation-broken one.
     _stored = StoredState()

--- a/lib/charms/traefik_k8s/v1/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v1/ingress_per_unit.py
@@ -82,7 +82,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 log = logging.getLogger(__name__)
 
@@ -317,7 +317,7 @@ class IngressPerUnitProviderEvents(ObjectEvents):
 class IngressPerUnitProvider(_IngressPerUnitBase):
     """Implementation of the provider of ingress_per_unit."""
 
-    on = IngressPerUnitProviderEvents()
+    on = IngressPerUnitProviderEvents()  # type: ignore
 
     def _handle_relation(self, event):
         relation = event.relation
@@ -563,7 +563,7 @@ class _IPUEvent(RelationEvent):
             obj = kwargs.get(attr, default)
             setattr(self, attr, obj)
 
-    def snapshot(self) -> dict:
+    def snapshot(self):
         dct = super().snapshot()
         for attr in self.__attrs__():
             obj = getattr(self, attr)
@@ -577,7 +577,7 @@ class _IPUEvent(RelationEvent):
                 ) from e
         return dct
 
-    def restore(self, snapshot: dict) -> None:
+    def restore(self, snapshot) -> None:
         super().restore(snapshot)
         for attr, obj in snapshot.items():
             setattr(self, attr, obj)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+asyncio_mode = "auto"
 
 # Formatting tools configuration
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ show_missing = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
-asyncio_mode = "auto"
 
 # Formatting tools configuration
 [tool.black]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -566,13 +566,14 @@ class TestTraefikIngressCharm(unittest.TestCase):
             pass
 
     @patch("charm._get_loadbalancer_status", lambda **unused: None)
+    @patch("charm.TraefikIngressCharm._on_config_changed", lambda self, event: None)
     @patch("charm.TraefikIngressCharm._traefik_service_running", lambda **unused: True)
     @patch("charm.KubernetesServicePatch", lambda **unused: None)
     def test_show_proxied_endpoints_action_no_relations(self):
         self.harness.begin_with_initial_hooks()
 
         action_event = Mock(spec=ActionEvent)
-        self.harness.charm.model.config._data["external_hostname"] = "foo"
+        self.harness.update_config({"external_hostname": "foo"})
         self.harness.charm._on_show_proxied_endpoints(action_event)
         action_event.set_results.assert_called_once_with({"proxied-endpoints": "{}"})
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -566,11 +566,11 @@ class TestTraefikIngressCharm(unittest.TestCase):
             pass
 
     @patch("charm._get_loadbalancer_status", lambda **unused: None)
-    @patch("charm.TraefikIngressCharm._on_config_changed", lambda self, event: None)
     @patch("charm.TraefikIngressCharm._traefik_service_running", lambda **unused: True)
     @patch("charm.KubernetesServicePatch", lambda **unused: None)
     def test_show_proxied_endpoints_action_no_relations(self):
         self.harness.begin_with_initial_hooks()
+        self.harness.container_pebble_ready("traefik")
 
         action_event = Mock(spec=ActionEvent)
         self.harness.update_config({"external_hostname": "foo"})

--- a/tests/unit/test_event_serializers.py
+++ b/tests/unit/test_event_serializers.py
@@ -39,7 +39,7 @@ def charm_cls(event_container):
         event = None
 
         def __init__(self, framework):
-            super().__init__(framework, None)
+            super().__init__(framework)
             self.framework.observe(self.on.event, self._on_event)
 
         def _on_event(self, event):

--- a/tests/unit/test_lib_per_app_provides.py
+++ b/tests/unit/test_lib_per_app_provides.py
@@ -50,7 +50,7 @@ def test_ingress_app_provider_related(harness, provider: IngressPerAppProvider):
     assert not provider.is_ready(relation)
 
 
-@pytest.mark.parametrize("strip_prefix", (True, False))
+@pytest.mark.parametrize("strip_prefix", ("true", "false"))
 def test_ingress_app_provider_relate_provide(
     provider: IngressPerAppProvider, harness, strip_prefix
 ):

--- a/tests/unit/test_lib_per_unit_listen_to.py
+++ b/tests/unit/test_lib_per_unit_listen_to.py
@@ -24,7 +24,7 @@ def listen_to(request):
 def charm_cls(listen_to):
     class MyCharm(CharmBase):
         def __init__(self, framework):
-            super().__init__(framework, None)
+            super().__init__(framework)
             self.ipu = IngressPerUnitRequirer(self, host="foo.com", port=80, listen_to=listen_to)
 
             self.framework.observe(self.ipu.on.ready, self._on_event)

--- a/tests/unit/test_lib_per_unit_listen_to.py
+++ b/tests/unit/test_lib_per_unit_listen_to.py
@@ -108,7 +108,7 @@ def test_ready_other_unit(harness, charm, listen_to, url):
     relation = relate(harness)
     _requirer_provide_ingress(harness, charm.unit.name, url, relation)
 
-    new_unit_name = charm.unit.name + "1"
+    new_unit_name = relation.app.name + "1"
     new_unit_url = url + "/new_unit"
     harness.add_relation_unit(relation.id, new_unit_name)
 

--- a/tests/unit/test_lib_per_unit_requires.py
+++ b/tests/unit/test_lib_per_unit_requires.py
@@ -95,7 +95,7 @@ def test_unit_joining_does_not_trigger_ingress_changed(requirer, harness, url):
     with capture(harness.charm, IngressPerUnitReadyForUnitEvent):
         _requirer_provide_ingress(harness, harness.charm.unit.name, url, relation)
 
-    new_peer = harness.charm.unit.name + "1"
+    new_peer = relation.app.name + "1"
     with capture_events(harness.charm, IngressPerUnitReadyForUnitEvent) as captured:
         # another unit joining shouldn't give this charm any changed event
         harness.add_relation_unit(relation.id, new_peer)


### PR DESCRIPTION
This PR fixes issues with the charm's tests on newer versions of `ops`. Currently ops is pinned to 1.5.2.

**Most of the failures are from changes in 1.5.3 (the latest 1.x version is 1.5.4).** Specifically:

* test_show_proxied_endpoints_action_no_relations previously had error
  "'ConfigData' object does not support item assignment". This was
  caused by canonical/operator#787 and the fix is to stop setting items
  on Model.config._data directly. Do it with update_config, but
  suppress the config-changed event it triggers.
* test_ingress_app_provider_relate_provide previosly had error
  ops.model.RelationDataTypeError: relation data values must be strings, not <class 'bool'>
  caused by canonical/operator#786 and the fix is to send string values
  instead of Python bools (lowercase as these would be sent to
  relation-set as YAML).
* Fix unit name in test_lib_per_unit* tests (it should be the remote
  app) to silence the warnings about that.

Also remove the unexpected config value "asyncio_mode" in
pyproject.toml's pytest settings to suppress the warning about that.

In addition, tweak some type annotations in the ingress charm libs to
fix these Pyright errors (I haven't done "charmcraft publish-lib" or
similar though):

```
pyright 1.1.290
/home/ben/w/traefik-k8s-operator/lib/charms/traefik_k8s/v1/ingress.py
  /home/ben/w/traefik-k8s-operator/lib/charms/traefik_k8s/v1/ingress.py:218:16 - error: Expression of type "_RelationEventSnapshot" cannot be assigned to return type "dict[Unknown, Unknown]"
    "_RelationEventSnapshot" is incompatible with "dict[Unknown, Unknown]" (reportGeneralTypeIssues)
  /home/ben/w/traefik-k8s-operator/lib/charms/traefik_k8s/v1/ingress.py:221:25 - error: Argument of type "dict[Unknown, Unknown]" cannot be assigned to parameter "snapshot" of type "_RelationEventSnapshot" in function "restore"
    "dict[Unknown, Unknown]" is incompatible with "_RelationEventSnapshot" (reportGeneralTypeIssues)
  /home/ben/w/traefik-k8s-operator/lib/charms/traefik_k8s/v1/ingress.py:253:10 - error: Expression of type "IngressPerAppProviderEvents" cannot be assigned to declared type "property"
    "IngressPerAppProviderEvents" is incompatible with "property" (reportGeneralTypeIssues)
  /home/ben/w/traefik-k8s-operator/lib/charms/traefik_k8s/v1/ingress.py:409:10 - error: Expression of type "IngressPerAppRequirerEvents" cannot be assigned to declared type "property"
    "IngressPerAppRequirerEvents" is incompatible with "property" (reportGeneralTypeIssues)
/home/ben/w/traefik-k8s-operator/lib/charms/traefik_k8s/v1/ingress_per_unit.py
  /home/ben/w/traefik-k8s-operator/lib/charms/traefik_k8s/v1/ingress_per_unit.py:320:10 - error: Expression of type "IngressPerUnitProviderEvents" cannot be assigned to declared type "property"
    "IngressPerUnitProviderEvents" is incompatible with "property" (reportGeneralTypeIssues)
  /home/ben/w/traefik-k8s-operator/lib/charms/traefik_k8s/v1/ingress_per_unit.py:578:16 - error: Expression of type "_RelationEventSnapshot" cannot be assigned to return type "dict[Unknown, Unknown]"
    "_RelationEventSnapshot" is incompatible with "dict[Unknown, Unknown]" (reportGeneralTypeIssues)
  /home/ben/w/traefik-k8s-operator/lib/charms/traefik_k8s/v1/ingress_per_unit.py:581:25 - error: Argument of type "dict[Unknown, Unknown]" cannot be assigned to parameter "snapshot" of type "_RelationEventSnapshot" in function "restore"
    "dict[Unknown, Unknown]" is incompatible with "_RelationEventSnapshot" (reportGeneralTypeIssues)
7 errors, 0 warnings, 0 informations
```

**But there are also a couple of failures from 2.0.0rc2:**

Just remove a couple of usages of the now-removed "key" parameter to
CharmBase.__init__() in tests.

This will still work fine with ops 1.x, but also works with 2.0.

**This change is broken into two commits with the fixes for 1.x and 2.0 separately.**