### PR TITLE
check version bump on library modifications

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -84,3 +84,8 @@ deps =
 commands =
     charm: pyright --pythonversion 3.8 {[vars]src_path}
     lib: pyright --pythonversion 3.8 {[vars]lib_path}
+    lib: /usr/bin/env sh -c 'for m in $(git diff main --name-only {[vars]lib_path}); do \
+    lib:    if ! git diff $m | grep -q "+LIBPATCH\|+LIBAPI"; then \
+    lib:        echo "You forgot to bump the version on $m!"; exit 1; \
+    lib:    fi; done'
+allowlist_externals = /usr/bin/env


### PR DESCRIPTION
## Issue
Forgetting to bump `LIBPATCH` on a library update causes that update to not be detected at any level, as the CI won't release a new library, but it can be detected by the PR label, leading to confusion.


## Solution
Add a simple check to the `static-lib` environment to make sure that *if* a library has been modified, its `LIBPATCH` has been bumped. Once this is approved and merged, I will replicate it to all of our other repos.   
I'm open to have this somewhere else if you think it's better, such as its own `tox` environment (which would require modifying the *_quality_checks* CI to also run that step), or anywhere else.

## Context
Note that this is intentionally a loose check (it only checks if the `LIBPATCH` line was modified); this allows for *some* flexibility in not bumping the version by just adding a comment to that line.  
However, if there's a need for multiple PRs on the same library, and we don't want to release the library every time, the correct approach is probably to create another branch out of main (i.e., `library-change`); then merge the different PRs to `library-change`, and finally open a PR from that branch to main.
