### PR TITLE
Fix has_ingress integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,6 +5,7 @@ import grp
 import logging
 import os
 import shutil
+import socket
 import subprocess
 from collections import defaultdict
 from dataclasses import dataclass
@@ -317,9 +318,19 @@ def get_relation_data(
     return RelationData(provider=provider_data, requirer=requirer_data)
 
 
-def assert_can_ping(ip, port):
-    response = os.system(f"ping -c 1 {ip} -p {port}")
-    assert response == 0, f"{ip}:{port} is down/unreachable"
+def _can_connect(ip, port) -> bool:
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.connect((ip, int(port)))
+        return True
+    except:  # noqa: E722
+        return False
+    finally:
+        s.close()
+
+
+def assert_can_connect(ip, port):
+    assert _can_connect(ip, port), f"{ip}:{port} is down/unreachable"
 
 
 async def deploy_traefik_if_not_deployed(ops_test: OpsTest, traefik_charm):

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -7,7 +7,7 @@ import yaml
 from pytest_operator.plugin import OpsTest
 
 from tests.integration.conftest import (
-    assert_can_ping,
+    assert_can_connect,
     get_relation_data,
     trfk_resources,
 )
@@ -45,7 +45,7 @@ def assert_ipa_charm_has_ingress(ops_test: OpsTest):
     provider_app_data = yaml.safe_load(data.provider.application_data["ingress"])
     url = provider_app_data["url"]
     ip, port = url.split("//")[1].split("/")[0].split(":")
-    assert_can_ping(ip, port)
+    assert_can_connect(ip, port)
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/test_charm_ipu.py
+++ b/tests/integration/test_charm_ipu.py
@@ -6,7 +6,7 @@ import yaml
 from pytest_operator.plugin import OpsTest
 
 from tests.integration.conftest import (
-    assert_can_ping,
+    assert_can_connect,
     deploy_traefik_if_not_deployed,
     get_relation_data,
 )
@@ -41,7 +41,7 @@ def assert_ipu_charm_has_ingress(ops_test: OpsTest):
     provider_app_data = yaml.safe_load(data.provider.application_data["ingress"])
     url = provider_app_data["ipu-tester/0"]["url"]
     ip, port = url.split("//")[1].split("/")[0].split(":")
-    assert_can_ping(ip, port)
+    assert_can_connect(ip, port)
 
 
 @pytest.mark.abort_on_fail


### PR DESCRIPTION
Integration tests for `ingress-per-app` and `ingress-per-unit` were validating that the ingress is present by calling `ping` with the `-p` flag and the port. The `-p` flag is not for specifying a port however, but to specify padding data to put in the payload of the `ICMP` packet.

Because the `metallb` configuration is using the local IP of the host running `microk8s`, it is expected to always answer to pings. Therefore, those tests were not testing anything.

This change replaces the `ping` with a direct socket, testing the TCP connectivity to the ingress port.

## Issue
<!-- What issue is this PR trying to solve? -->


## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->
