### PR TITLE
Switch Traefik to use the ROCK on ghcr.io

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -25,9 +25,9 @@ containers:
 resources:
   traefik-image:
     type: oci-image
-    description: OCI image for traefik (https://hub.docker.com/_/traefik/)
+    description: OCI image for traefik
     # Included for simplicity in integration tests
-    upstream-source: docker.io/jnsgruk/traefik:2.9.6 ### Update this when we settle which image we want to use
+    upstream-source: ghcr.io/canonical/traefik:latest
 
 storage:
   # We need to store the configurations in a volume, as Traefik's directory


### PR DESCRIPTION
## Issue
We are currently running Traefik using the upstream OCI image.

## Solution
We are now building our own ROCKs for the observability stack. We should also make sure we're using them so that effort is not in vain.

## Testing Instructions
- Deploy the charm with the new resource
- Verify functionality is still there

## Release Notes
Switch from upstream OCI image to ROCK
