### PR TITLE
Do not check app.name if app is None

### DIFF
--- a/lib/charms/traefik_k8s/v1/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v1/ingress_per_unit.py
@@ -801,7 +801,7 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
         if not relation:
             return {}
 
-        if not relation.app and not relation.app.name:  # type: ignore
+        if not relation.app or not relation.app.name:  # type: ignore
             # FIXME Workaround for https://github.com/canonical/operator/issues/693
             # We must be in a relation_broken hook
             return {}


### PR DESCRIPTION
## Issue
When removing the application, in relation-broken, `relation.app.name` fails because `relaion.app` is None.

```
  File "/var/lib/juju/agents/unit-prom-0/charm/lib/charms/traefik_k8s/v1/ingress_per_unit.py", line 804, in _urls_from_relation_data
    if not relation.app and not relation.app.name:  # type: ignore
```


## Solution
Replace `and` with `or`.

Fixes #149.
Fixes https://github.com/canonical/prometheus-k8s-operator/issues/460.

## Context
https://github.com/canonical/prometheus-k8s-operator/issues/460


## Testing Instructions
1. Relate `prometheus` - `traefik`
2. Remove traefik.
3. (Before this fix you'd get the error)


## Release Notes
<!-- A digestable summary of the change in this PR -->
