### PR TITLE
Do not subscript `relation.app` if it is None

### DIFF
--- a/lib/charms/traefik_k8s/v1/ingress.py
+++ b/lib/charms/traefik_k8s/v1/ingress.py
@@ -69,7 +69,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 11
+LIBPATCH = 12
 
 DEFAULT_RELATION_NAME = "ingress"
 RELATION_INTERFACE = "ingress"
@@ -298,8 +298,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
 
         For convenience, we convert 'port' to integer.
         """
-        assert relation.app, "no app in relation (shouldn't happen)"  # for type checker
-        if not all((relation.app, relation.app.name)):
+        if not relation.app or not relation.app.name:  # type: ignore
             # Handle edge case where remote app name can be missing, e.g.,
             # relation_broken events.
             # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
@@ -333,8 +332,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
 
     def _provided_url(self, relation: Relation) -> ProviderIngressData:  # type: ignore
         """Fetch and validate this app databag; return the ingress url."""
-        assert relation.app, "no app in relation (shouldn't happen)"  # for type checker
-        if not all((relation.app, relation.app.name, self.unit.is_leader())):
+        if not relation.app or not relation.app.name or not self.unit.is_leader():  # type: ignore
             # Handle edge case where remote app name can be missing, e.g.,
             # relation_broken events.
             # Also, only leader units can read own app databags.
@@ -533,12 +531,11 @@ class IngressPerAppRequirer(_IngressPerAppBase):
         Returns None if the URL isn't available yet.
         """
         relation = self.relation
-        if not relation:
+        if not relation or not relation.app:
             return None
 
         # fetch the provider's app databag
         try:
-            assert relation.app, "no app in relation (shouldn't happen)"  # for type checker
             raw = relation.data.get(relation.app, {}).get("ingress")
         except ModelError as e:
             log.debug(

--- a/src/charm.py
+++ b/src/charm.py
@@ -851,7 +851,7 @@ class TraefikIngressCharm(CharmBase):
         # logic before pebble in the traefik container is up and running. If that
         # is the case, nevermind, we will wipe the dangling config files anyhow
         # during _on_traefik_pebble_ready .
-        if self.container.can_connect():
+        if self.container.can_connect() and relation.app:
             try:
                 config_path = f"{_DYNAMIC_CONFIG_DIR}/{self._relation_config_file(relation)}"
                 self.container.remove_path(config_path, recursive=True)


### PR DESCRIPTION
## Issue
There are more code pathways where `relation.app` is empty, causing runtime errors.

## Solution
Add `relation.app` guards. Fixes #158.


## Context
NTA.


## Testing Instructions
Manual test.
We already have `test_remove_relation` in itests, which didn't pick it up, probably because pylibjuju doesn't wait for the relation to be removed.


## Release Notes
Do not subscript `relation.app` if it is None.
