### PR TITLE
Fixed version in interface tester configuration

### DIFF
--- a/tests/interface/test_ingress.py
+++ b/tests/interface/test_ingress.py
@@ -14,5 +14,6 @@ def test_ingress_interface(interface_tester: InterfaceTester, interface_name: st
         repo="https://github.com/PietroPasotti/charm-relation-interfaces",
         branch="interface_tester/tester_plugin",
         interface_name=interface_name,
+        interface_version=1,
     )
     interface_tester.run()


### PR DESCRIPTION
## Issue
The interface tester was missing a configuration key. We're using ingress v1, so we should test against v1.
