### PR TITLE
use ruff instead of flake8

### DIFF
--- a/lib/charms/traefik_k8s/v1/ingress.py
+++ b/lib/charms/traefik_k8s/v1/ingress.py
@@ -69,7 +69,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 12
+LIBPATCH = 13
 
 DEFAULT_RELATION_NAME = "ingress"
 RELATION_INTERFACE = "ingress"
@@ -183,8 +183,8 @@ class _IngressPerAppBase(Object):
 
 
 class _IPAEvent(RelationEvent):
-    __args__ = ()  # type: Tuple[str, ...]
-    __optional_kwargs__ = {}  # type: Dict[str, Any]
+    __args__: Tuple[str, ...] = ()
+    __optional_kwargs__: Dict[str, Any] = {}
 
     @classmethod
     def __attrs__(cls):
@@ -229,11 +229,11 @@ class IngressPerAppDataProvidedEvent(_IPAEvent):
     __args__ = ("name", "model", "port", "host", "strip_prefix")
 
     if typing.TYPE_CHECKING:
-        name = None  # type: Optional[str]
-        model = None  # type: Optional[str]
-        port = None  # type: Optional[str]
-        host = None  # type: Optional[str]
-        strip_prefix = False  # type: bool
+        name: Optional[str] = None
+        model: Optional[str] = None
+        port: Optional[str] = None
+        host: Optional[str] = None
+        strip_prefix: bool = False
 
 
 class IngressPerAppDataRemovedEvent(RelationEvent):
@@ -305,7 +305,7 @@ class IngressPerAppProvider(_IngressPerAppBase):
             return {}
 
         databag = relation.data[relation.app]
-        remote_data = {}  # type: Dict[str, Union[int, str]]
+        remote_data: Dict[str, Union[int, str]] = {}
         for k in ("port", "host", "model", "name", "mode", "strip-prefix"):
             v = databag.get(k)
             if v is not None:
@@ -387,7 +387,7 @@ class IngressPerAppReadyEvent(_IPAEvent):
 
     __args__ = ("url",)
     if typing.TYPE_CHECKING:
-        url = None  # type: Optional[str]
+        url: Optional[str] = None
 
 
 class IngressPerAppRevokedEvent(RelationEvent):

--- a/lib/charms/traefik_k8s/v1/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v1/ingress_per_unit.py
@@ -82,7 +82,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 11
 
 log = logging.getLogger(__name__)
 
@@ -166,13 +166,12 @@ def _type_convert_stored(obj):
     """Convert Stored* to their appropriate types, recursively."""
     if isinstance(obj, StoredList):
         return list(map(_type_convert_stored, obj))
-    elif isinstance(obj, StoredDict):
-        rdict = {}  # type: Dict[Any, Any]
+    if isinstance(obj, StoredDict):
+        rdict: Dict[Any, Any] = {}
         for k in obj.keys():
             rdict[k] = _type_convert_stored(obj[k])
         return rdict
-    else:
-        return obj
+    return obj
 
 
 def _validate_data(data, schema):
@@ -240,7 +239,7 @@ class _IngressPerUnitBase(Object):
                 (defaults to "ingress-per-unit").
         """
         super().__init__(charm, relation_name)
-        self.charm = charm  # type: CharmBase
+        self.charm: CharmBase = charm
 
         self.relation_name = relation_name
         self.app = self.charm.app
@@ -483,7 +482,7 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
             return {}
 
         databag = relation.data[remote_unit]
-        remote_data = {}  # type: Dict[str, Union[int, str]]
+        remote_data: Dict[str, Union[int, str]] = {}
         for k in ("port", "host", "model", "name", "mode", "strip-prefix"):
             v = databag.get(k)
             if v is not None:
@@ -544,8 +543,8 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
 
 
 class _IPUEvent(RelationEvent):
-    __args__ = ()  # type: Tuple[str, ...]
-    __optional_kwargs__ = {}  # type: Dict[str, Any]
+    __args__: Tuple[str, ...] = ()
+    __optional_kwargs__: Dict[str, Any] = {}
 
     @classmethod
     def __attrs__(cls):
@@ -645,7 +644,7 @@ class IngressPerUnitRequirerEvents(ObjectEvents):
 class IngressPerUnitRequirer(_IngressPerUnitBase):
     """Implementation of the requirer of ingress_per_unit."""
 
-    on = IngressPerUnitRequirerEvents()  # type: IngressPerUnitRequirerEvents
+    on: IngressPerUnitRequirerEvents = IngressPerUnitRequirerEvents()
     # used to prevent spurious urls to be sent out if the event we're currently
     # handling is a relation-broken one.
     _stored = StoredState()
@@ -669,24 +668,26 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
         All request args must be given as keyword args.
 
         Args:
-            `charm`: the charm that is instantiating the library.
-            `relation_name`: the name of the relation name to bind to
+            charm: the charm that is instantiating the library.
+            relation_name: the name of the relation name to bind to
                 (defaults to "ingress-per-unit"; relation must be of interface
-                type "ingress_per_unit" and have "limit: 1")
-            `host`: Hostname to be used by the ingress provider to address the
+                type "ingress_per_unit" and have "limit: 1").
+            host: Hostname to be used by the ingress provider to address the
                 requirer unit; if unspecified, the FQDN of the unit will be
-                used instead
-            `port`: port to be used by the ingress provider to address the
+                used instead.
+            port: port to be used by the ingress provider to address the
                     requirer unit.
-            `listen_to`: Choose which events should be fired on this unit:
+            mode: mode to be used between "tcp" and "http".
+            listen_to: Choose which events should be fired on this unit:
                 "only-this-unit": this unit will only be notified when ingress
                   is ready/revoked for this unit.
                 "all-units": this unit will be notified when ingress is
                   ready/revoked for any unit of this application, including
                   itself.
                 "all": this unit will receive both event types (which means it
-                  will be notified *twice* of changes to this unit's ingress!)
-        """  # noqa: D417
+                  will be notified *twice* of changes to this unit's ingress!).
+            strip_prefix: remove prefixes from the URL path.
+        """
         super().__init__(charm, relation_name)
         self._stored.set_default(current_urls=None)  # type: ignore
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,3 @@ per-file-ignores = {"*tests/*" = ["D100","D101","D102","D103","D104"]}
 
 [tool.ruff.pydocstyle]
 convention = "google"
-
-[tool.ruff.mccabe]
-max-complexity = 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,23 +20,19 @@ reportTypedDictNotRequiredAccess = false
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
+[tool.ruff]
+line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info"]
+select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
+# Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
+ignore = ["E501", "D107", "N818", "RET504"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["*tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+per-file-ignores = {"*tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 10

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -3,11 +3,10 @@
 from unittest.mock import patch
 
 import pytest
+from charm import TraefikIngressCharm
 from interface_tester import InterfaceTester
 from ops.pebble import Layer
 from scenario.state import Container, State
-
-from charm import TraefikIngressCharm
 
 
 # Interface tests are centrally hosted at https://github.com/canonical/charm-relation-interfaces.

--- a/tests/scenario/test_setup.py
+++ b/tests/scenario/test_setup.py
@@ -5,9 +5,8 @@
 
 from unittest.mock import MagicMock, PropertyMock, patch
 
-from scenario import Container, State
-
 from charm import _TRAEFIK_SERVICE_NAME, TraefikIngressCharm
+from scenario import Container, State
 
 
 @patch("charm.KubernetesServicePatch")

--- a/tests/scenario/test_status.py
+++ b/tests/scenario/test_status.py
@@ -4,9 +4,8 @@
 import unittest
 from unittest.mock import MagicMock, PropertyMock, patch
 
-from scenario import Container, State
-
 from charm import TraefikIngressCharm
+from scenario import Container, State
 
 
 @patch("charm.KubernetesServicePatch")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,12 +8,11 @@ from unittest.mock import Mock, patch
 
 import ops.testing
 import yaml
+from charm import _STATIC_CONFIG_PATH, TraefikIngressCharm
 from ops.charm import ActionEvent
 from ops.model import ActiveStatus, Application, BlockedStatus, Relation, WaitingStatus
 from ops.pebble import PathError
 from ops.testing import Harness
-
-from charm import _STATIC_CONFIG_PATH, TraefikIngressCharm
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 
@@ -58,8 +57,8 @@ def _requirer_provide_ingress_requirements(
 
 
 class _RequirerMock:
-    local_app = None  # type: Application
-    relation = None  # type: Relation
+    local_app: Application = None
+    relation: Relation = None
 
     def is_ready(self):
         try:

--- a/tests/unit/test_lib_per_app_provides.py
+++ b/tests/unit/test_lib_per_app_provides.py
@@ -56,7 +56,13 @@ def test_ingress_app_provider_relate_provide(
 ):
     harness.set_leader(True)
     relation_id = harness.add_relation("ingress", "remote")
-    remote_data = dict(host="host", port="42", name="foo", model="bar", strip_prefix=strip_prefix)
+    remote_data = {
+        "host": "host",
+        "port": "42",
+        "name": "foo",
+        "model": "bar",
+        "strip_prefix": strip_prefix,
+    }
     harness.update_relation_data(relation_id, "remote", remote_data)
 
     relation = harness.model.get_relation("ingress", relation_id)

--- a/tests/unit/test_route.py
+++ b/tests/unit/test_route.py
@@ -5,9 +5,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 import yaml
-from ops.testing import Harness
-
 from charm import TraefikIngressCharm
+from ops.testing import Harness
 
 MODEL_NAME = "test-model"
 REMOTE_APP_NAME = "traefikRouteApp"

--- a/tests/unit/test_tls_certificates.py
+++ b/tests/unit/test_tls_certificates.py
@@ -5,9 +5,8 @@ import unittest
 from unittest.mock import patch
 
 import ops.testing
-from ops.testing import Harness
-
 from charm import TraefikIngressCharm
+from ops.testing import Harness
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,30 +26,22 @@ passenv =
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
-    flake8==4.0.1
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
+    ruff
     codespell
 commands =
     codespell {[vars]lib_path}
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv* \
       --skip .mypy_cache --skip icon.svg
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:unit]


### PR DESCRIPTION
The **flake8** plugins we use are re-implemented in **ruff**, which is why they have been removed from the dependencies.

**isort** is enabled (and used when formatting) through the `I001` rule.

The "exclude list" has been updated to omit folders that **ruff** excludes by default.

Everything else is the same, the only difference being two new rules being ignored (which weren't checked before anyway): 
* `N818: Exception name should be named with an Error suffix`, which I excluded due to the big refactoring required for it;
* `RET504: Unnecessary variable assignment before return statement`, which we do everywhere as it increases readability.