### PR TITLE
Apply `stripPrefix` to TLS routes also

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -18,55 +18,33 @@ import yaml
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
 from charms.observability_libs.v1.kubernetes_service_patch import (
-    KubernetesServicePatch,
-    ServicePort,
-)
+    KubernetesServicePatch, ServicePort)
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from charms.tls_certificates_interface.v2.tls_certificates import (
-    CertificateAvailableEvent,
-    CertificateExpiringEvent,
-    CertificateInvalidatedEvent,
-    TLSCertificatesRequiresV2,
-    generate_csr,
-    generate_private_key,
-)
+    CertificateAvailableEvent, CertificateExpiringEvent,
+    CertificateInvalidatedEvent, TLSCertificatesRequiresV2, generate_csr,
+    generate_private_key)
 from charms.traefik_k8s.v1.ingress import IngressPerAppProvider
-from charms.traefik_k8s.v1.ingress_per_unit import (
-    DataValidationError,
-    IngressPerUnitProvider,
-)
+from charms.traefik_k8s.v1.ingress_per_unit import (DataValidationError,
+                                                    IngressPerUnitProvider)
 from charms.traefik_route_k8s.v0.traefik_route import (
-    TraefikRouteProvider,
-    TraefikRouteRequirerReadyEvent,
-)
+    TraefikRouteProvider, TraefikRouteRequirerReadyEvent)
 from deepmerge import always_merger
 from lightkube.core.client import Client
 from lightkube.resources.core_v1 import Service
-from ops.charm import (
-    ActionEvent,
-    CharmBase,
-    ConfigChangedEvent,
-    PebbleReadyEvent,
-    RelationBrokenEvent,
-    RelationEvent,
-    RelationJoinedEvent,
-    StartEvent,
-    UpdateStatusEvent,
-)
+from ops.charm import (ActionEvent, CharmBase, ConfigChangedEvent,
+                       PebbleReadyEvent, RelationBrokenEvent, RelationEvent,
+                       RelationJoinedEvent, StartEvent, UpdateStatusEvent)
 from ops.framework import StoredState
 from ops.main import main
-from ops.model import (
-    ActiveStatus,
-    BlockedStatus,
-    MaintenanceStatus,
-    Relation,
-    WaitingStatus,
-)
+from ops.model import (ActiveStatus, BlockedStatus, MaintenanceStatus,
+                       Relation, WaitingStatus)
 from ops.pebble import APIError, PathError
 
 if typing.TYPE_CHECKING:
     from charms.traefik_k8s.v1.ingress import RequirerData as RequirerData_IPA
-    from charms.traefik_k8s.v1.ingress_per_unit import RequirerData as RequirerData_IPU
+    from charms.traefik_k8s.v1.ingress_per_unit import \
+        RequirerData as RequirerData_IPU
 
 logger = logging.getLogger(__name__)
 
@@ -808,6 +786,9 @@ class TraefikIngressCharm(CharmBase):
         if middlewares:
             config["http"]["middlewares"] = middlewares
             router_cfg[traefik_router_name]["middlewares"] = list(middlewares.keys())
+
+            if f"{traefik_router_name}-tls" in router_cfg:
+                router_cfg[f"{traefik_router_name}-tls"]["middlewares"] = list(middlewares.keys())
 
         return config, url
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,11 +8,13 @@ from unittest.mock import Mock, patch
 
 import ops.testing
 import yaml
-from charm import _STATIC_CONFIG_PATH, TraefikIngressCharm
 from ops.charm import ActionEvent
-from ops.model import ActiveStatus, Application, BlockedStatus, Relation, WaitingStatus
+from ops.model import (ActiveStatus, Application, BlockedStatus, Relation,
+                       WaitingStatus)
 from ops.pebble import PathError
 from ops.testing import Harness
+
+from charm import _STATIC_CONFIG_PATH, TraefikIngressCharm
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 
@@ -187,6 +189,9 @@ class TestTraefikIngressCharm(unittest.TestCase):
                     expected["http"]["routers"]["juju-test-model-remote-0-router"].update(
                         {"middlewares": ["juju-sidecar-noprefix-test-model-remote-0"]},
                     )
+                    expected["http"]["routers"]["juju-test-model-remote-0-router-tls"].update(
+                        {"middlewares": ["juju-sidecar-noprefix-test-model-remote-0"]},
+                    )
 
                 self.assertEqual(conf, expected)
 
@@ -265,6 +270,9 @@ class TestTraefikIngressCharm(unittest.TestCase):
                 if strip_prefix:
                     expected["http"].update(middlewares)
                     expected["http"]["routers"]["juju-test-model-remote-0-router"].update(
+                        {"middlewares": ["juju-sidecar-noprefix-test-model-remote-0"]},
+                    )
+                    expected["http"]["routers"]["juju-test-model-remote-0-router-tls"].update(
                         {"middlewares": ["juju-sidecar-noprefix-test-model-remote-0"]},
                     )
 


### PR DESCRIPTION
## Issue
Previously, `stripPrefix` was not applied to TLS routes if it was set. 

## Solution
Add it into the config and update tests.

Closes #173 

## Testing Instructions
Deploy and relate with something which sets `strip_prefix=True`, ensure that it actually works on the endpoint charm.

## Release Notes
Apply `stripPrefix` to TLS routes also