### PR TITLE
Fix itests

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -580,6 +580,7 @@ class TraefikIngressCharm(CharmBase):
         # FIXME? on relation broken, data is still there so cannot simply call
         #  self._process_status_and_configurations(). For this reason, the static config in
         #  _STATIC_CONFIG_PATH will be updated only on update-status.
+        #  https://github.com/canonical/operator/issues/888
 
     def _handle_traefik_route_ready(self, event: TraefikRouteRequirerReadyEvent):
         """A traefik_route charm has published some ingress data."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -332,3 +332,13 @@ async def safe_relate(ops_test: OpsTest, ep1, ep2):
         # relation already exists? skip
         logging.error(e)
         pass
+
+
+@pytest.fixture(autouse=True, scope='module')
+async def setup_env(ops_test: OpsTest):
+    # Prevent "update-status" from interfering with the test:
+    # - if fired "too quickly", traefik will flip between active/idle and maintenance;
+    # - make sure charm code does not rely on update-status for correct operation.
+    await ops_test.model.set_config(
+        {"update-status-hook-interval": "60m", "logging-config": "<root>=WARNING; unit=DEBUG"}
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -334,7 +334,7 @@ async def safe_relate(ops_test: OpsTest, ep1, ep2):
         pass
 
 
-@pytest.fixture(autouse=True, scope='module')
+@pytest.fixture(autouse=True, scope="module")
 async def setup_env(ops_test: OpsTest):
     # Prevent "update-status" from interfering with the test:
     # - if fired "too quickly", traefik will flip between active/idle and maintenance;

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -317,10 +317,9 @@ async def deploy_charm_if_not_deployed(ops_test: OpsTest, charm, app_name: str, 
         await ops_test.model.deploy(charm, resources=resources, application_name=app_name)
 
     # block until app goes to active/idle
-    async with ops_test.fast_forward():
-        # if we're running this locally, we need to wait for "waiting"
-        # CI however deploys all in a single model, so traefik is active already.
-        await ops_test.model.wait_for_idle([app_name], status="active", timeout=1000)
+    # if we're running this locally, we need to wait for "waiting"
+    # CI however deploys all in a single model, so traefik is active already.
+    await ops_test.model.wait_for_idle([app_name], status="active", timeout=1000)
 
 
 async def safe_relate(ops_test: OpsTest, ep1, ep2):

--- a/tests/integration/test_charm_tcp.py
+++ b/tests/integration/test_charm_tcp.py
@@ -22,13 +22,6 @@ tcp_charm_resources = {
 
 
 @pytest.mark.abort_on_fail
-async def test_setup_env(ops_test: OpsTest):
-    await ops_test.model.set_config(
-        {"update-status-hook-interval": "60m", "logging-config": "<root>=WARNING; unit=DEBUG"}
-    )
-
-
-@pytest.mark.abort_on_fail
 async def test_deployment(ops_test: OpsTest, traefik_charm, tcp_tester_charm):
     await deploy_traefik_if_not_deployed(ops_test, traefik_charm)
     await ops_test.model.deploy(tcp_tester_charm, "tcp-tester", resources=tcp_charm_resources)

--- a/tests/integration/test_tcp_ipa_compatibility.py
+++ b/tests/integration/test_tcp_ipa_compatibility.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 import asyncio
 
-import pytest
 import pytest_asyncio
 from pytest_operator.plugin import OpsTest
 

--- a/tests/integration/test_tcp_ipa_compatibility.py
+++ b/tests/integration/test_tcp_ipa_compatibility.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 import asyncio
 
+import pytest
 import pytest_asyncio
 from pytest_operator.plugin import OpsTest
 
@@ -17,6 +18,13 @@ from tests.integration.test_charm_tcp import (  # noqa
     assert_tcp_charm_has_ingress,
     tcp_charm_resources,
 )
+
+
+@pytest.mark.abort_on_fail
+async def test_setup_env(ops_test: OpsTest):
+    await ops_test.model.set_config(
+        {"update-status-hook-interval": "60m", "logging-config": "<root>=WARNING; unit=DEBUG"}
+    )
 
 
 @pytest_asyncio.fixture
@@ -35,10 +43,9 @@ async def tcp_ipa_deployment(
         safe_relate(ops_test, "ipa-tester:ingress", "traefik-k8s:ingress"),
     )
 
-    async with ops_test.fast_forward("1h"):
-        await ops_test.model.wait_for_idle(
-            ["traefik-k8s", "tcp-tester", "ipa-tester"], status="active", timeout=1000
-        )
+    await ops_test.model.wait_for_idle(
+        ["traefik-k8s", "tcp-tester", "ipa-tester"], status="active", timeout=1000
+    )
 
 
 async def test_tcp_ipa_compatibility(ops_test, tcp_ipa_deployment):

--- a/tests/integration/test_tcp_ipa_compatibility.py
+++ b/tests/integration/test_tcp_ipa_compatibility.py
@@ -20,13 +20,6 @@ from tests.integration.test_charm_tcp import (  # noqa
 )
 
 
-@pytest.mark.abort_on_fail
-async def test_setup_env(ops_test: OpsTest):
-    await ops_test.model.set_config(
-        {"update-status-hook-interval": "60m", "logging-config": "<root>=WARNING; unit=DEBUG"}
-    )
-
-
 @pytest_asyncio.fixture
 async def tcp_ipa_deployment(
     ops_test: OpsTest, traefik_charm, tcp_tester_charm, ipa_tester_charm  # noqa

--- a/tests/integration/test_tcp_ipu_compatibility.py
+++ b/tests/integration/test_tcp_ipu_compatibility.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 import asyncio
 
-import pytest
 import pytest_asyncio
 from pytest_operator.plugin import OpsTest
 

--- a/tests/integration/test_tcp_ipu_compatibility.py
+++ b/tests/integration/test_tcp_ipu_compatibility.py
@@ -20,15 +20,6 @@ from tests.integration.test_charm_tcp import (  # noqa
 )
 
 
-@pytest.mark.abort_on_fail
-async def test_setup_env(ops_test: OpsTest):
-    # ensure update-status does not fire "too" quickly, else traefik will flip between
-    # active/idle and maintenance: updating ingress configuration
-    await ops_test.model.set_config(
-        {"update-status-hook-interval": "60m", "logging-config": "<root>=WARNING; unit=DEBUG"}
-    )
-
-
 @pytest_asyncio.fixture
 async def tcp_ipu_deployment(
     ops_test: OpsTest, traefik_charm, tcp_tester_charm, ipu_tester_charm  # noqa

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -53,13 +53,6 @@ def get_endpoints(ops_test: OpsTest, *, scheme: str, netloc: str) -> list:
 
 
 @pytest.mark.abort_on_fail
-async def test_setup_env(ops_test: OpsTest):
-    await ops_test.model.set_config(
-        {"update-status-hook-interval": "60m", "logging-config": "<root>=WARNING; unit=DEBUG"}
-    )
-
-
-@pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest, traefik_charm):
     await asyncio.gather(
         ops_test.model.deploy(traefik_charm, resources=trfk.resources, application_name=trfk.name),


### PR DESCRIPTION
## Issue
Itests were relying on update-status.

## Solution
Do not rely on update-status in itests.


## Context
NTA.


## Testing Instructions
No functional changes. Passes locally. If passes in CI we're probably ok with this change.


## Release Notes
Do not rely on update-status in itests.