### PR TITLE
Endpoint deprecator

### DIFF
--- a/lib/charms/traefik_k8s/v1/ingress.py
+++ b/lib/charms/traefik_k8s/v1/ingress.py
@@ -1,0 +1,579 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+r"""# Interface Library for ingress.
+
+This library wraps relation endpoints using the `ingress` interface
+and provides a Python API for both requesting and providing per-application
+ingress, with load-balancing occurring across all units.
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.traefik_k8s.v1.ingress
+```
+
+In the `metadata.yaml` of the charm, add the following:
+
+```yaml
+requires:
+    ingress:
+        interface: ingress
+        limit: 1
+```
+
+Then, to initialise the library:
+
+```python
+from charms.traefik_k8s.v1.ingress import (IngressPerAppRequirer,
+  IngressPerAppReadyEvent, IngressPerAppRevokedEvent)
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.ingress = IngressPerAppRequirer(self, port=80)
+    # The following event is triggered when the ingress URL to be used
+    # by this deployment of the `SomeCharm` is ready (or changes).
+    self.framework.observe(
+        self.ingress.on.ready, self._on_ingress_ready
+    )
+    self.framework.observe(
+        self.ingress.on.revoked, self._on_ingress_revoked
+    )
+
+    def _on_ingress_ready(self, event: IngressPerAppReadyEvent):
+        logger.info("This app's ingress URL: %s", event.url)
+
+    def _on_ingress_revoked(self, event: IngressPerAppRevokedEvent):
+        logger.info("This app no longer has ingress")
+"""
+
+import logging
+import socket
+import typing
+from typing import Any, Dict, Optional, Tuple, Union
+
+import yaml
+from ops.charm import CharmBase, RelationBrokenEvent, RelationEvent
+from ops.framework import EventSource, Object, ObjectEvents, StoredState
+from ops.model import ModelError, Relation
+
+# The unique Charmhub library identifier, never change it
+LIBID = "e6de2a5cd5b34422a204668f3b8f90d2"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 1
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 14
+
+DEFAULT_RELATION_NAME = "ingress"
+RELATION_INTERFACE = "ingress"
+
+log = logging.getLogger(__name__)
+
+try:
+    import jsonschema
+
+    DO_VALIDATION = True
+except ModuleNotFoundError:
+    log.warning(
+        "The `ingress` library needs the `jsonschema` package to be able "
+        "to do runtime data validation; without it, it will still work but validation "
+        "will be disabled. \n"
+        "It is recommended to add `jsonschema` to the 'requirements.txt' of your charm, "
+        "which will enable this feature."
+    )
+    DO_VALIDATION = False
+
+INGRESS_REQUIRES_APP_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "model": {"type": "string"},
+        "name": {"type": "string"},
+        "host": {"type": "string"},
+        "port": {"type": "string"},
+        "strip-prefix": {"type": "string"},
+        "redirect-https": {"type": "string"},
+    },
+    "required": ["model", "name", "host", "port"],
+}
+
+INGRESS_PROVIDES_APP_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "ingress": {"type": "object", "properties": {"url": {"type": "string"}}},
+    },
+    "required": ["ingress"],
+}
+
+try:
+    from typing import TypedDict
+except ImportError:
+    from typing_extensions import TypedDict  # py35 compat
+
+# Model of the data a unit implementing the requirer will need to provide.
+RequirerData = TypedDict(
+    "RequirerData",
+    {
+        "model": str,
+        "name": str,
+        "host": str,
+        "port": int,
+        "strip-prefix": bool,
+        "redirect-https": bool,
+    },
+    total=False,
+)
+# Provider ingress data model.
+ProviderIngressData = TypedDict("ProviderIngressData", {"url": str})
+# Provider application databag model.
+ProviderApplicationData = TypedDict("ProviderApplicationData", {"ingress": ProviderIngressData})  # type: ignore
+
+
+def _validate_data(data, schema):
+    """Checks whether `data` matches `schema`.
+
+    Will raise DataValidationError if the data is not valid, else return None.
+    """
+    if not DO_VALIDATION:
+        return
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.ValidationError as e:
+        raise DataValidationError(data, schema) from e
+
+
+class DataValidationError(RuntimeError):
+    """Raised when data validation fails on IPU relation data."""
+
+
+class _IngressPerAppBase(Object):
+    """Base class for IngressPerUnit interface classes."""
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(charm, relation_name)
+
+        self.charm: CharmBase = charm
+        self.relation_name = relation_name
+        self.app = self.charm.app
+        self.unit = self.charm.unit
+
+        observe = self.framework.observe
+        rel_events = charm.on[relation_name]
+        observe(rel_events.relation_created, self._handle_relation)
+        observe(rel_events.relation_joined, self._handle_relation)
+        observe(rel_events.relation_changed, self._handle_relation)
+        observe(rel_events.relation_broken, self._handle_relation_broken)
+        observe(charm.on.leader_elected, self._handle_upgrade_or_leader)  # type: ignore
+        observe(charm.on.upgrade_charm, self._handle_upgrade_or_leader)  # type: ignore
+
+    @property
+    def relations(self):
+        """The list of Relation instances associated with this endpoint."""
+        return list(self.charm.model.relations[self.relation_name])
+
+    def _handle_relation(self, event):
+        """Subclasses should implement this method to handle a relation update."""
+        pass
+
+    def _handle_relation_broken(self, event):
+        """Subclasses should implement this method to handle a relation breaking."""
+        pass
+
+    def _handle_upgrade_or_leader(self, event):
+        """Subclasses should implement this method to handle upgrades or leadership change."""
+        pass
+
+
+class _IPAEvent(RelationEvent):
+    __args__: Tuple[str, ...] = ()
+    __optional_kwargs__: Dict[str, Any] = {}
+
+    @classmethod
+    def __attrs__(cls):
+        return cls.__args__ + tuple(cls.__optional_kwargs__.keys())
+
+    def __init__(self, handle, relation, *args, **kwargs):
+        super().__init__(handle, relation)
+
+        if not len(self.__args__) == len(args):
+            raise TypeError("expected {} args, got {}".format(len(self.__args__), len(args)))
+
+        for attr, obj in zip(self.__args__, args):
+            setattr(self, attr, obj)
+        for attr, default in self.__optional_kwargs__.items():
+            obj = kwargs.get(attr, default)
+            setattr(self, attr, obj)
+
+    def snapshot(self):
+        dct = super().snapshot()
+        for attr in self.__attrs__():
+            obj = getattr(self, attr)
+            try:
+                dct[attr] = obj
+            except ValueError as e:
+                raise ValueError(
+                    "cannot automagically serialize {}: "
+                    "override this method and do it "
+                    "manually.".format(obj)
+                ) from e
+
+        return dct
+
+    def restore(self, snapshot) -> None:
+        super().restore(snapshot)
+        for attr, obj in snapshot.items():
+            setattr(self, attr, obj)
+
+
+class IngressPerAppDataProvidedEvent(_IPAEvent):
+    """Event representing that ingress data has been provided for an app."""
+
+    __args__ = ("name", "model", "port", "host", "strip_prefix", "redirect_https")
+
+    if typing.TYPE_CHECKING:
+        name: Optional[str] = None
+        model: Optional[str] = None
+        port: Optional[str] = None
+        host: Optional[str] = None
+        strip_prefix: bool = False
+        redirect_https: bool = False
+
+
+class IngressPerAppDataRemovedEvent(RelationEvent):
+    """Event representing that ingress data has been removed for an app."""
+
+
+class IngressPerAppProviderEvents(ObjectEvents):
+    """Container for IPA Provider events."""
+
+    data_provided = EventSource(IngressPerAppDataProvidedEvent)
+    data_removed = EventSource(IngressPerAppDataRemovedEvent)
+
+
+class IngressPerAppProvider(_IngressPerAppBase):
+    """Implementation of the provider of ingress."""
+
+    on = IngressPerAppProviderEvents()  # type: ignore
+
+    def __init__(self, charm: CharmBase, relation_name: str = DEFAULT_RELATION_NAME):
+        """Constructor for IngressPerAppProvider.
+
+        Args:
+            charm: The charm that is instantiating the instance.
+            relation_name: The name of the relation endpoint to bind to
+                (defaults to "ingress").
+        """
+        super().__init__(charm, relation_name)
+
+    def _handle_relation(self, event):
+        # created, joined or changed: if remote side has sent the required data:
+        # notify listeners.
+        if self.is_ready(event.relation):
+            data = self._get_requirer_data(event.relation)
+            self.on.data_provided.emit(  # type: ignore
+                event.relation,
+                data["name"],
+                data["model"],
+                data["port"],
+                data["host"],
+                data.get("strip-prefix", False),
+                data.get("redirect-https", False),
+            )
+
+    def _handle_relation_broken(self, event):
+        self.on.data_removed.emit(event.relation)  # type: ignore
+
+    def wipe_ingress_data(self, relation: Relation):
+        """Clear ingress data from relation."""
+        assert self.unit.is_leader(), "only leaders can do this"
+        try:
+            relation.data
+        except ModelError as e:
+            log.warning(
+                "error {} accessing relation data for {!r}. "
+                "Probably a ghost of a dead relation is still "
+                "lingering around.".format(e, relation.name)
+            )
+            return
+        del relation.data[self.app]["ingress"]
+
+    def _get_requirer_data(self, relation: Relation) -> RequirerData:  # type: ignore
+        """Fetch and validate the requirer's app databag.
+
+        For convenience, we convert 'port' to integer.
+        """
+        if not relation.app or not relation.app.name:  # type: ignore
+            # Handle edge case where remote app name can be missing, e.g.,
+            # relation_broken events.
+            # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
+            return {}
+
+        databag = relation.data[relation.app]
+        remote_data: Dict[str, Union[int, str]] = {}
+        for k in ("port", "host", "model", "name", "mode", "strip-prefix", "redirect-https"):
+            v = databag.get(k)
+            if v is not None:
+                remote_data[k] = v
+        _validate_data(remote_data, INGRESS_REQUIRES_APP_SCHEMA)
+        remote_data["port"] = int(remote_data["port"])
+        remote_data["strip-prefix"] = bool(remote_data.get("strip-prefix", "false") == "true")
+        remote_data["redirect-https"] = bool(remote_data.get("redirect-https", "false") == "true")
+        return typing.cast(RequirerData, remote_data)
+
+    def get_data(self, relation: Relation) -> RequirerData:  # type: ignore
+        """Fetch the remote app's databag, i.e. the requirer data."""
+        return self._get_requirer_data(relation)
+
+    def is_ready(self, relation: Optional[Relation] = None):
+        """The Provider is ready if the requirer has sent valid data."""
+        if not relation:
+            return any(map(self.is_ready, self.relations))
+
+        try:
+            return bool(self._get_requirer_data(relation))
+        except DataValidationError as e:
+            log.warning("Requirer not ready; validation error encountered: %s" % str(e))
+            return False
+
+    def _provided_url(self, relation: Relation) -> ProviderIngressData:  # type: ignore
+        """Fetch and validate this app databag; return the ingress url."""
+        if not relation.app or not relation.app.name or not self.unit.is_leader():  # type: ignore
+            # Handle edge case where remote app name can be missing, e.g.,
+            # relation_broken events.
+            # Also, only leader units can read own app databags.
+            # FIXME https://github.com/canonical/traefik-k8s-operator/issues/34
+            return typing.cast(ProviderIngressData, {})  # noqa
+
+        # fetch the provider's app databag
+        raw_data = relation.data[self.app].get("ingress")
+        if not raw_data:
+            raise RuntimeError("This application did not `publish_url` yet.")
+
+        ingress: ProviderIngressData = yaml.safe_load(raw_data)
+        _validate_data({"ingress": ingress}, INGRESS_PROVIDES_APP_SCHEMA)
+        return ingress
+
+    def publish_url(self, relation: Relation, url: str):
+        """Publish to the app databag the ingress url."""
+        ingress = {"url": url}
+        ingress_data = {"ingress": ingress}
+        _validate_data(ingress_data, INGRESS_PROVIDES_APP_SCHEMA)
+        relation.data[self.app]["ingress"] = yaml.safe_dump(ingress)
+
+    @property
+    def proxied_endpoints(self):
+        """Returns the ingress settings provided to applications by this IngressPerAppProvider.
+
+        For example, when this IngressPerAppProvider has provided the
+        `http://foo.bar/my-model.my-app` URL to the my-app application, the returned dictionary
+        will be:
+
+        ```
+        {
+            "my-app": {
+                "url": "http://foo.bar/my-model.my-app"
+            }
+        }
+        ```
+        """
+        results = {}
+
+        for ingress_relation in self.relations:
+            assert (
+                ingress_relation.app
+            ), "no app in relation (shouldn't happen)"  # for type checker
+            results[ingress_relation.app.name] = self._provided_url(ingress_relation)
+
+        return results
+
+
+class IngressPerAppReadyEvent(_IPAEvent):
+    """Event representing that ingress for an app is ready."""
+
+    __args__ = ("url",)
+    if typing.TYPE_CHECKING:
+        url: Optional[str] = None
+
+
+class IngressPerAppRevokedEvent(RelationEvent):
+    """Event representing that ingress for an app has been revoked."""
+
+
+class IngressPerAppRequirerEvents(ObjectEvents):
+    """Container for IPA Requirer events."""
+
+    ready = EventSource(IngressPerAppReadyEvent)
+    revoked = EventSource(IngressPerAppRevokedEvent)
+
+
+class IngressPerAppRequirer(_IngressPerAppBase):
+    """Implementation of the requirer of the ingress relation."""
+
+    on = IngressPerAppRequirerEvents()  # type: ignore
+
+    # used to prevent spurious urls to be sent out if the event we're currently
+    # handling is a relation-broken one.
+    _stored = StoredState()
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        *,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        strip_prefix: bool = False,
+        redirect_https: bool = False,
+    ):
+        """Constructor for IngressRequirer.
+
+        The request args can be used to specify the ingress properties when the
+        instance is created. If any are set, at least `port` is required, and
+        they will be sent to the ingress provider as soon as it is available.
+        All request args must be given as keyword args.
+
+        Args:
+            charm: the charm that is instantiating the library.
+            relation_name: the name of the relation endpoint to bind to (defaults to `ingress`);
+                relation must be of interface type `ingress` and have "limit: 1")
+            host: Hostname to be used by the ingress provider to address the requiring
+                application; if unspecified, the default Kubernetes service name will be used.
+            strip_prefix: configure Traefik to strip the path prefix.
+            redirect_https: redirect incoming requests to the HTTPS.
+
+        Request Args:
+            port: the port of the service
+        """
+        super().__init__(charm, relation_name)
+        self.charm: CharmBase = charm
+        self.relation_name = relation_name
+        self._strip_prefix = strip_prefix
+        self._redirect_https = redirect_https
+
+        self._stored.set_default(current_url=None)  # type: ignore
+
+        # if instantiated with a port, and we are related, then
+        # we immediately publish our ingress data  to speed up the process.
+        if port:
+            self._auto_data = host, port
+        else:
+            self._auto_data = None
+
+    def _handle_relation(self, event):
+        # created, joined or changed: if we have auto data: publish it
+        self._publish_auto_data(event.relation)
+
+        if self.is_ready():
+            # Avoid spurious events, emit only when there is a NEW URL available
+            new_url = (
+                None
+                if isinstance(event, RelationBrokenEvent)
+                else self._get_url_from_relation_data()
+            )
+            if self._stored.current_url != new_url:  # type: ignore
+                self._stored.current_url = new_url  # type: ignore
+                self.on.ready.emit(event.relation, new_url)  # type: ignore
+
+    def _handle_relation_broken(self, event):
+        self._stored.current_url = None  # type: ignore
+        self.on.revoked.emit(event.relation)  # type: ignore
+
+    def _handle_upgrade_or_leader(self, event):
+        """On upgrade/leadership change: ensure we publish the data we have."""
+        for relation in self.relations:
+            self._publish_auto_data(relation)
+
+    def is_ready(self):
+        """The Requirer is ready if the Provider has sent valid data."""
+        try:
+            return bool(self._get_url_from_relation_data())
+        except DataValidationError as e:
+            log.warning("Requirer not ready; validation error encountered: %s" % str(e))
+            return False
+
+    def _publish_auto_data(self, relation: Relation):
+        if self._auto_data and self.unit.is_leader():
+            host, port = self._auto_data
+            self.provide_ingress_requirements(host=host, port=port)
+
+    def provide_ingress_requirements(self, *, host: Optional[str] = None, port: int):
+        """Publishes the data that Traefik needs to provide ingress.
+
+        NB only the leader unit is supposed to do this.
+
+        Args:
+            host: Hostname to be used by the ingress provider to address the
+             requirer unit; if unspecified, FQDN will be used instead
+            port: the port of the service (required)
+        """
+        # get only the leader to publish the data since we only
+        # require one unit to publish it -- it will not differ between units,
+        # unlike in ingress-per-unit.
+        assert self.unit.is_leader(), "only leaders should do this."
+        assert self.relation, "no relation"
+
+        if not host:
+            host = socket.getfqdn()
+
+        data = {
+            "model": self.model.name,
+            "name": self.app.name,
+            "host": host,
+            "port": str(port),
+        }
+
+        if self._strip_prefix:
+            data["strip-prefix"] = "true"
+
+        if self._redirect_https:
+            data["redirect-https"] = "true"
+
+        _validate_data(data, INGRESS_REQUIRES_APP_SCHEMA)
+        self.relation.data[self.app].update(data)
+
+    @property
+    def relation(self):
+        """The established Relation instance, or None."""
+        return self.relations[0] if self.relations else None
+
+    def _get_url_from_relation_data(self) -> Optional[str]:
+        """The full ingress URL to reach the current unit.
+
+        Returns None if the URL isn't available yet.
+        """
+        relation = self.relation
+        if not relation or not relation.app:
+            return None
+
+        # fetch the provider's app databag
+        try:
+            raw = relation.data.get(relation.app, {}).get("ingress")
+        except ModelError as e:
+            log.debug(
+                f"Error {e} attempting to read remote app data; "
+                f"probably we are in a relation_departed hook"
+            )
+            return None
+
+        if not raw:
+            return None
+
+        ingress: ProviderIngressData = yaml.safe_load(raw)
+        _validate_data({"ingress": ingress}, INGRESS_PROVIDES_APP_SCHEMA)
+        return ingress["url"]
+
+    @property
+    def url(self) -> Optional[str]:
+        """The full ingress URL to reach the current unit.
+
+        Returns None if the URL isn't available yet.
+        """
+        data = self._stored.current_url or self._get_url_from_relation_data()  # type: ignore
+        assert isinstance(data, (str, type(None)))  # for static checker
+        return data

--- a/src/endpoint_deprecator.py
+++ b/src/endpoint_deprecator.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Endpoint deprecator lib."""
+import logging
+
+from ops import CharmBase, Relation, UnknownStatus, WaitingStatus, ActiveStatus, StatusBase
+
+logger = logging.getLogger(__name__)
+
+
+class UnsupportedInterface(RuntimeError):
+    """Raised if a relation interface can't be remapped."""
+
+
+def _is_empty(relation: Relation):
+    return not _is_nonempty(relation)
+
+
+def _is_nonempty(relation: Relation):
+    return relation.data[relation.app] or any((relation.data[unit] for unit in relation.units))
+
+
+def _compute_remapping(relation: Relation, remappings):
+    for (version, wrapper, accept), event_remap in remappings:
+        if accept(relation):
+            logger.info(f"{relation} accepted by {wrapper} @version {version!r}")
+            return event_remap
+        logger.warning(f'{relation} could not accept preferred version {version}: falling back down')
+    raise UnsupportedInterface(f"relation {relation} not accepted by any supported wrapper")
+
+
+class EventRemapper:
+    def __init__(self, charm: CharmBase, endpoint: str, remappings):
+        self._charm = charm
+        self._endpoint = endpoint
+        self._remappings = remappings
+
+        self._status = UnknownStatus()
+
+        # setup observers
+        relations = self._charm.model.relations[self._endpoint]
+        nonempty_relations = tuple(filter(_is_nonempty, relations))
+
+        if not nonempty_relations:
+            logger.info("all relations are empty... setting waiting status")
+            self._status = WaitingStatus("waiting on relation data")
+        else:
+            remapping, rejected = {}, []
+
+            for relation in nonempty_relations:
+                try:
+                    remapping.update(_compute_remapping(relation, self._remappings))
+                except UnsupportedInterface:
+                    logger.error(f"Error attempting to remap {relation}", exc_info=True)
+                    rejected.append(relation)
+                    continue
+
+            some_empty_relations = tuple(filter(_is_empty, relations))
+
+            error_msg = ""
+            if rejected:
+                error_msg = f"Some relations on {endpoint} were rejected and are unsupported"
+
+            if some_empty_relations:
+                error_msg += f"Some relations on {endpoint} are still empty."
+
+            if error_msg:
+                # active but degraded
+                logger.error(error_msg)
+                self._status = ActiveStatus("degraded (see logs)")
+            else:
+                self._status = ActiveStatus()
+
+            for event, observer in remapping.items():
+                self._charm.framework.observe(event, observer)
+
+    @property
+    def status(self) -> StatusBase:
+        return self._status

--- a/tests/scenario/test_endpoint_deprecator.py
+++ b/tests/scenario/test_endpoint_deprecator.py
@@ -24,7 +24,7 @@ def charm_type():
             super().__init__(framework)
             self.ipa_v1 = ipa_v1 = IPAV1Shim(charm=self)
             self.ipa_v2 = ipa_v2 = IPAV2Shim(charm=self)
-            self.ipa = EventRemapper(self, "ingress", (
+            self.ipa = EventRemapper(self, "ingress", remappings=(
                 (("1", ipa_v1, ipa_v1.is_ready), {
                     ipa_v1.on.data_provided: self._provide_ingress_v1,
                     ipa_v1.on.data_removed: self._remove_ingress_v1

--- a/tests/scenario/test_endpoint_deprecator.py
+++ b/tests/scenario/test_endpoint_deprecator.py
@@ -1,0 +1,180 @@
+import pytest
+from ops import CharmBase, Framework, ActiveStatus, WaitingStatus
+from scenario import Context, State, Relation, capture_events
+
+from endpoint_deprecator import EventRemapper
+from lib.charms.traefik_k8s.v1 import ingress as ingress_v1
+from lib.charms.traefik_k8s.v2 import ingress as ingress_v2
+
+
+class IPAV1Shim(ingress_v1.IngressPerAppProvider):
+    handle_kind = "ipav1_shim"
+
+
+class IPAV2Shim(ingress_v2.IngressPerAppProvider):
+    handle_kind = "ipav2_shim"
+
+
+@pytest.fixture
+def charm_type():
+    class MyCharm(CharmBase):
+        _calls = []
+
+        def __init__(self, framework: Framework):
+            super().__init__(framework)
+            self.ipa_v1 = ipa_v1 = IPAV1Shim(charm=self)
+            self.ipa_v2 = ipa_v2 = IPAV2Shim(charm=self)
+            self.ipa = EventRemapper(self, "ingress", (
+                (("1", ipa_v1, ipa_v1.is_ready), {
+                    ipa_v1.on.data_provided: self._provide_ingress_v1,
+                    ipa_v1.on.data_removed: self._remove_ingress_v1
+                }),
+                (("2", ipa_v2, ipa_v2.is_ready), {
+                    ipa_v2.on.data_provided: self._provide_ingress_v2,
+                    ipa_v2.on.data_removed: self._remove_ingress_v2
+                }),
+            ))
+
+        def _provide_ingress_v1(self, e):
+            MyCharm._calls.append("+v1")
+
+        def _remove_ingress_v1(self, e):
+            MyCharm._calls.append("-v1")
+
+        def _provide_ingress_v2(self, e):
+            MyCharm._calls.append("+v2")
+
+        def _remove_ingress_v2(self, e):
+            MyCharm._calls.append("-v2")
+
+    return MyCharm
+
+
+@pytest.fixture
+def ctx(charm_type):
+    return Context(
+        charm_type,
+        meta={'name': 'foo',
+              "provides": {"ingress": {"interface": "ingress"}}
+              }
+    )
+
+
+def test_remapped_event_empty_relations(ctx, charm_type):
+    # both relations are empty, so we won't scream unsupported
+    ipa_v1 = Relation(
+        endpoint='ingress',
+    )
+    ipa_v2 = Relation(
+        endpoint='ingress',
+    )
+    state = State(relations=[ipa_v1, ipa_v2])
+
+    def post_event(charm):
+        assert charm.ipa.status == WaitingStatus("waiting on relation data")
+
+    with capture_events() as captured:
+        ctx.run("start", state, post_event=post_event)
+
+    assert not charm_type._calls
+
+
+def test_remapped_event_observation(ctx, charm_type):
+    remote_data_v1 = {
+        "host": "host",
+        "port": "42",
+        "name": "foo",
+        "model": "bar",
+    }
+    ipa_v1 = Relation(
+        endpoint='ingress',
+        remote_app_data=remote_data_v1
+    )
+    ipa_v2 = Relation(
+        endpoint='ingress',
+    )
+    state = State(relations=[ipa_v1, ipa_v2])
+
+    def post_event(charm):
+        assert isinstance(charm.ipa.status, ActiveStatus)
+        assert charm.ipa.status.message  # nonempty
+
+    with capture_events() as captured:
+        ctx.run(ipa_v1.changed_event, state, post_event=post_event)
+
+    assert len(captured) == 2
+    assert charm_type._calls == ['+v1']
+
+
+def test_simultaneous_remapping(ctx, charm_type):
+    remote_data_v1 = {
+        "host": "host",
+        "port": "42",
+        "name": "foo",
+        "model": "bar",
+    }
+    remote_app_data_v2 = {
+        "name": "foo",
+        "model": "bar",
+    }
+    remote_unit_data_v2 = {
+        "port": "42",
+        "host": "host",
+    }
+
+    ipa_v1 = Relation(
+        endpoint='ingress',
+        remote_app_data=remote_data_v1
+    )
+    ipa_v2 = Relation(
+        endpoint='ingress',
+        remote_app_data=remote_app_data_v2,
+        remote_units_data={1: remote_unit_data_v2},
+    )
+    state = State(relations=[ipa_v1, ipa_v2])
+
+    def post_event(charm):
+        assert isinstance(charm.ipa.status, ActiveStatus)
+        assert not charm.ipa.status.message  # empty
+
+    with capture_events():
+        ctx.run(ipa_v1.changed_event, state, post_event=post_event)
+
+    assert charm_type._calls == ["+v1"]
+
+    with capture_events():
+        ctx.run(ipa_v2.changed_event, state, post_event=post_event)
+
+    assert charm_type._calls == ["+v1", "+v2"]
+
+
+def test_departing(ctx, charm_type):
+    remote_data_v1 = {
+        "host": "host",
+        "port": "42",
+        "name": "foo",
+        "model": "bar",
+    }
+    remote_app_data_v2 = {
+        "name": "foo",
+        "model": "bar",
+    }
+    remote_unit_data_v2 = {
+        "port": "42",
+        "host": "host",
+    }
+
+    ipa_v1 = Relation(
+        endpoint='ingress',
+    )
+    ipa_v2 = Relation(
+        endpoint='ingress',
+        remote_app_data=remote_app_data_v2,
+        remote_units_data={1: remote_unit_data_v2},
+    )
+    state = State(relations=[ipa_v1, ipa_v2])
+
+    with capture_events():
+        ctx.run(ipa_v2.broken_event, state)
+
+    assert charm_type._calls == ["-v2"]


### PR DESCRIPTION
Proposal on how to implement parallel support for ingress v1 and v2

see test_endpoint_deprecator for the UX (not implemented in TraefikCharm yet)


TLDR:
```python
    class MyCharm(CharmBase):
        def __init__(self, framework: Framework):
            super().__init__(framework)
            self.ipa_v1 = ipa_v1 = IPAV1(charm=self)
            self.ipa_v2 = ipa_v2 = IPAV2(charm=self)

            self.ipa = EventRemapper(self, "ingress", (
                remappings=(("1", ipa_v1, ipa_v1.is_ready), {
                    ipa_v1.on.data_provided: self._provide_ingress_v1,
                    ipa_v1.on.data_removed: self._remove_ingress_v1
                }),
                (("2", ipa_v2, ipa_v2.is_ready), {
                    ipa_v2.on.data_provided: self._provide_ingress_v2,
                    ipa_v2.on.data_removed: self._remove_ingress_v2
                }),
            ))
```

general flow:
- on instantiation, EventRemapper will:
  -  for relation in relations["ingress"]:
     - for remapper(version_name, owner, readiness_check): observers in remappings:
        - if readiness_check(version):
           - register all observers.
        - else: unhappy