### PR TITLE
Reduce the number of API calls to K8S

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -5,6 +5,7 @@
 """Charm Traefik."""
 import contextlib
 import enum
+import functools
 import ipaddress
 import json
 import logging
@@ -1271,6 +1272,7 @@ class TraefikIngressCharm(CharmBase):
         ]
 
 
+@functools.lru_cache
 def _get_loadbalancer_status(namespace: str, service_name: str):
     client = Client()  # type: ignore
     traefik_service = client.get(Service, name=service_name, namespace=namespace)


### PR DESCRIPTION
The charm makes a large number of API calls to retrieve information about the IP address allocated to the K8S service; cache this information to reduce the number of calls made and speed up hook performance.

## Issue
Improve the performance of hook executions

## Solution
Cache response from K8S to reduce the amount of API calls made.

## Context
The traefik charm stands out as always the last to settle in Sunbeam deployments; hopefully this may improve this situation a bit.

## Testing Instructions
https://microstack.run/docs -> "multi-node tutorial"
