### PR TITLE
removed leader guard

### DIFF
--- a/lib/charms/traefik_k8s/v2/ingress.py
+++ b/lib/charms/traefik_k8s/v2/ingress.py
@@ -71,7 +71,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["pydantic<2.0"]
 
@@ -576,7 +576,7 @@ class IngressPerAppRequirer(_IngressPerAppBase):
             return False
 
     def _publish_auto_data(self, relation: Relation):
-        if self._auto_data and self.unit.is_leader():
+        if self._auto_data:
             host, port = self._auto_data
             self.provide_ingress_requirements(host=host, port=port)
 

--- a/tests/scenario/test_ingress_per_app.py
+++ b/tests/scenario/test_ingress_per_app.py
@@ -7,8 +7,9 @@
 
 import pytest
 import yaml
-from ops import pebble
-from scenario import Container, Model, Mount, Relation, State
+from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
+from ops import CharmBase, Framework, pebble
+from scenario import Container, Context, Model, Mount, Relation, State
 
 
 @pytest.fixture
@@ -85,8 +86,9 @@ def test_ingress_per_app_created(
 
 @pytest.mark.parametrize("port, host", ((80, "1.1.1.{}"), (81, "10.1.10.{}")))
 @pytest.mark.parametrize("n_units", (2, 3, 10))
+@pytest.mark.parametrize("evt_name", ("joined", "changed"))
 def test_ingress_per_app_scale(
-    traefik_ctx, host, port, model, traefik_container, tmp_path, n_units
+    traefik_ctx, host, port, model, traefik_container, tmp_path, n_units, evt_name
 ):
     """Check the config when a new ingress per leader unit joins."""
     cfg_file = tmp_path.joinpath("traefik", "juju", "juju_ingress_ingress_1_remote.yaml")
@@ -140,7 +142,7 @@ def test_ingress_per_app_scale(
         relations=[ipa],
     )
 
-    traefik_ctx.run(ipa.changed_event, state)
+    traefik_ctx.run(getattr(ipa, evt_name + "_event"), state)
 
     new_config = yaml.safe_load(cfg_file.read_text())
     # verify that the config has changed!
@@ -161,3 +163,37 @@ def test_ingress_per_app_scale(
         # IPL:
         # len(d["service"][svc_name]["loadBalancer"]["servers"]) == 1
         # d["service"][svc_name]["loadBalancer"]["servers"][0]["url"] == leader_url
+
+
+@pytest.mark.parametrize("port, host", ((80, "1.1.1.1"), (81, "10.1.10.1")))
+@pytest.mark.parametrize("evt_name", ("joined", "changed"))
+@pytest.mark.parametrize("leader", (True, False))
+def test_ingress_per_app_requirer_with_auto_data(host, port, model, evt_name, leader):
+    class MyRequirer(CharmBase):
+        def __init__(self, framework: Framework):
+            super().__init__(framework)
+            self.ipa = IngressPerAppRequirer(self, host=host, port=port)
+
+    ctx = Context(
+        charm_type=MyRequirer,
+        meta={"name": "charlie", "requires": {"ingress": {"interface": "ingress"}}},
+    )
+
+    ipa = Relation("ingress")
+    state = State(
+        model=model,
+        leader=leader,
+        relations=[ipa],
+    )
+
+    state_out = ctx.run(getattr(ipa, evt_name + "_event"), state)
+
+    ipa_out = state_out.get_relations("ingress")[0]
+    assert ipa_out.local_unit_data == {"host": host}
+
+    if leader:
+        assert ipa_out.local_app_data == {
+            "model": "test-model",
+            "name": "charlie",
+            "port": str(port),
+        }


### PR DESCRIPTION
now that ingress requirer also expose unit data, we need to remove a leader guard preventing auto-data from being published on joined and changed without charm intervention.

Fixes a bug discovered by @gregory-schiano 