### PR TITLE
Tracing/flip direction

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 31
+LIBPATCH = 32
 
 logger = logging.getLogger(__name__)
 
@@ -525,7 +525,7 @@ def _validate_relation_by_interface_and_direction(
     relation = charm.meta.relations[relation_name]
 
     actual_relation_interface = relation.interface_name
-    if actual_relation_interface != expected_relation_interface:
+    if actual_relation_interface and actual_relation_interface != expected_relation_interface:
         raise RelationInterfaceMismatchError(
             relation_name, expected_relation_interface, actual_relation_interface
         )

--- a/lib/charms/loki_k8s/v0/loki_push_api.py
+++ b/lib/charms/loki_k8s/v0/loki_push_api.py
@@ -67,21 +67,20 @@ and three optional arguments.
           def __init__(self, *args):
               super().__init__(*args)
               ...
-              self._loki_ready()
+              external_url = urlparse(self._external_url)
+              self.loki_provider = LokiPushApiProvider(
+                  self,
+                  address=external_url.hostname or self.hostname,
+                  port=external_url.port or 80,
+                  scheme=external_url.scheme,
+                  path=f"{external_url.path}/loki/api/v1/push",
+              )
               ...
 
-          def _loki_ready(self):
-              try:
-                  version = self._loki_server.version
-                  self.loki_provider = LokiPushApiProvider(self)
-                  logger.debug("Loki Provider is available. Loki version: %s", version)
-              except LokiServerNotReadyError as e:
-                  self.unit.status = MaintenanceStatus(str(e))
-              except LokiServerError as e:
-                  self.unit.status = BlockedStatus(str(e))
-
-  - `port`: Loki Push Api endpoint port. Default value: 3100.
-  - `rules_dir`: Directory to store alert rules. Default value: "/loki/rules".
+  - `port`: Loki Push Api endpoint port. Default value: `3100`.
+  - `scheme`: Loki Push Api endpoint scheme (`HTTP` or `HTTPS`). Default value: `HTTP`
+  - `address`: Loki Push Api endpoint address. Default value: `localhost`
+  - `path`: Loki Push Api endpoint path. Default value: `loki/api/v1/push`
 
 
 The `LokiPushApiProvider` object has several responsibilities:
@@ -481,7 +480,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 19
+LIBPATCH = 20
 
 logger = logging.getLogger(__name__)
 

--- a/lib/charms/observability_libs/v0/cert_handler.py
+++ b/lib/charms/observability_libs/v0/cert_handler.py
@@ -62,7 +62,7 @@ logger = logging.getLogger(__name__)
 
 LIBID = "b5cd5cd580f3428fa5f59a8876dcbe6a"
 LIBAPI = 0
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 class CertChanged(EventBase):
@@ -352,6 +352,11 @@ class CertHandler(Object):
         rel = self._peer_relation
         assert rel is not None  # For type checker
         rel.data[self.charm.unit].update({"chain": json.dumps(value)})
+
+    @property
+    def chain(self) -> List[str]:
+        """Return the ca chain."""
+        return self._chain
 
     def _on_certificate_expiring(
         self, event: Union[CertificateExpiringEvent, CertificateInvalidatedEvent]

--- a/lib/charms/tempo_k8s/v0/tracing.py
+++ b/lib/charms/tempo_k8s/v0/tracing.py
@@ -6,47 +6,15 @@ This document explains how to integrate with the Tempo charm for the purpose of 
 tracing endpoint provided by Tempo. It also explains how alternative implementations of the Tempo charm
 may maintain the same interface and be backward compatible with all currently integrated charms.
 
-## Provider Library Usage
-
-Charms seeking to push traces to Tempo, must do so using the `TracingEndpointProvider`
-object from this charm library. For the simplest use cases, using the `TracingEndpointProvider`
-object only requires instantiating it, typically in the constructor of your charm. The
-`TracingEndpointProvider` constructor requires the name of the relation over which a tracing endpoint
- is exposed by the Tempo charm. This relation must use the
-`tracing` interface. 
- The `TracingEndpointProvider` object may be instantiated as follows
-
-    from charms.tempo_k8s.v0.tracing import TracingEndpointProvider
-
-    def __init__(self, *args):
-        super().__init__(*args)
-        # ...
-        self.tracing = TracingEndpointProvider(self)
-        # ...
-
-Note that the first argument (`self`) to `TracingEndpointProvider` is always a reference to the
-parent charm.
-
-Units of provider charms obtain the tempo endpoint to which they will push their traces by using one 
-of these  `TracingEndpointProvider` attributes, depending on which protocol they support:
-- otlp_grpc_endpoint
-- otlp_http_endpoint
-- zipkin_endpoint
-- tempo_endpoint
-
 ## Requirer Library Usage
 
-The `TracingEndpointRequirer` object may be used by charms to manage relations with their
-trace sources. For this purposes a Tempo-like charm needs to do two things
-
-1. Instantiate the `TracingEndpointRequirer` object by providing it a
-reference to the parent (Tempo) charm and optionally the name of the relation that the Tempo charm
-uses to interact with its trace sources. This relation must conform to the `tracing` interface
-and it is strongly recommended that this relation be named `tracing` which is its
-default value.
-
-For example a Tempo charm may instantiate the `TracingEndpointRequirer` in its constructor as
-follows
+Charms seeking to push traces to Tempo, must do so using the `TracingEndpointRequirer`
+object from this charm library. For the simplest use cases, using the `TracingEndpointRequirer`
+object only requires instantiating it, typically in the constructor of your charm. The
+`TracingEndpointRequirer` constructor requires the name of the relation over which a tracing endpoint
+ is exposed by the Tempo charm. This relation must use the
+`tracing` interface. 
+ The `TracingEndpointRequirer` object may be instantiated as follows
 
     from charms.tempo_k8s.v0.tracing import TracingEndpointRequirer
 
@@ -54,6 +22,38 @@ follows
         super().__init__(*args)
         # ...
         self.tracing = TracingEndpointRequirer(self)
+        # ...
+
+Note that the first argument (`self`) to `TracingEndpointRequirer` is always a reference to the
+parent charm.
+
+Units of provider charms obtain the tempo endpoint to which they will push their traces by using one 
+of these  `TracingEndpointRequirer` attributes, depending on which protocol they support:
+- otlp_grpc_endpoint
+- otlp_http_endpoint
+- zipkin_endpoint
+- tempo_endpoint
+
+## Requirer Library Usage
+
+The `TracingEndpointProvider` object may be used by charms to manage relations with their
+trace sources. For this purposes a Tempo-like charm needs to do two things
+
+1. Instantiate the `TracingEndpointProvider` object by providing it a
+reference to the parent (Tempo) charm and optionally the name of the relation that the Tempo charm
+uses to interact with its trace sources. This relation must conform to the `tracing` interface
+and it is strongly recommended that this relation be named `tracing` which is its
+default value.
+
+For example a Tempo charm may instantiate the `TracingEndpointProvider` in its constructor as
+follows
+
+    from charms.tempo_k8s.v0.tracing import TracingEndpointProvider
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        # ...
+        self.tracing = TracingEndpointProvider(self)
         # ...
 
 
@@ -92,7 +92,9 @@ logger = logging.getLogger(__name__)
 DEFAULT_RELATION_NAME = "tracing"
 RELATION_INTERFACE_NAME = "tracing"
 
-IngesterProtocol = Literal["otlp_grpc", "otlp_http", "zipkin", "tempo"]
+IngesterProtocol = Literal[
+    "otlp_grpc", "otlp_http", "zipkin", "tempo", "jaeger_http_thrift", "jaeger_grpc"
+]
 
 RawIngester = Tuple[IngesterProtocol, int]
 
@@ -103,6 +105,10 @@ class TracingError(RuntimeError):
 
 class DataValidationError(TracingError):
     """Raised when data validation fails on IPU relation data."""
+
+
+class AmbiguousRelationUsageError(TracingError):
+    """Raised when one wrongly assumes that there can only be one relation on an endpoint."""
 
 
 # todo: use fully-encoded json fields like Traefik does. MUCH neater
@@ -139,11 +145,15 @@ class DatabagModel(BaseModel):
 
 # todo use models from charm-relation-interfaces
 class Ingester(BaseModel):  # noqa: D101
+    """Ingester data structure."""
+
     protocol: IngesterProtocol
     port: int
 
 
-class TracingRequirerAppData(DatabagModel):  # noqa: D101
+class TracingProviderAppData(DatabagModel):  # noqa: D101
+    """Application databag model for the tracing provider."""
+
     host: str
     ingesters: List[Ingester]
 
@@ -296,7 +306,7 @@ def _validate_relation_by_interface_and_direction(
         raise TypeError("Unexpected RelationDirection: {}".format(expected_relation_role))
 
 
-class TracingEndpointRequirer(Object):
+class TracingEndpointProvider(Object):
     """Class representing a trace ingester service."""
 
     def __init__(
@@ -324,7 +334,7 @@ class TracingEndpointRequirer(Object):
                 role.
         """
         _validate_relation_by_interface_and_direction(
-            charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.requires
+            charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.provides
         )
 
         super().__init__(charm, relation_name)
@@ -342,7 +352,7 @@ class TracingEndpointRequirer(Object):
         try:
             if self._charm.unit.is_leader():
                 for relation in self._charm.model.relations[self._relation_name]:
-                    TracingRequirerAppData(
+                    TracingProviderAppData(
                         host=self._host,
                         ingesters=[
                             Ingester(port=port, protocol=protocol)
@@ -385,13 +395,13 @@ class EndpointChangedEvent(_AutoSnapshotEvent):
 
 
 class TracingEndpointEvents(CharmEvents):
-    """TracingEndpointProvider events."""
+    """TracingEndpointRequirer events."""
 
     endpoint_changed = EventSource(EndpointChangedEvent)
     endpoint_removed = EventSource(EndpointRemovedEvent)
 
 
-class TracingEndpointProvider(Object):
+class TracingEndpointRequirer(Object):
     """A tracing endpoint for Tempo."""
 
     on = TracingEndpointEvents()  # type: ignore
@@ -401,15 +411,15 @@ class TracingEndpointProvider(Object):
         charm: CharmBase,
         relation_name: str = DEFAULT_RELATION_NAME,
     ):
-        """Construct a tracing provider for a Tempo charm.
+        """Construct a tracing requirer for a Tempo charm.
 
-        If your charm exposes a Tempo tracing endpoint, the `TracingEndpointProvider` object
-        enables your charm to easily communicate how to reach that endpoint.
-
+        If your application supports pushing traces to a distributed tracing backend, the
+        `TracingEndpointRequirer` object enables your charm to easily access endpoint information
+        exchanged over a `tracing` relation interface.
 
         Args:
             charm: a `CharmBase` object that manages this
-                `TracingEndpointProvider` object. Typically, this is `self` in the instantiating
+                `TracingEndpointRequirer` object. Typically, this is `self` in the instantiating
                 class.
             relation_name: an optional string name of the relation between `charm`
                 and the Tempo charmed service. The default is "tracing". It is strongly
@@ -427,10 +437,13 @@ class TracingEndpointProvider(Object):
                 role.
         """
         _validate_relation_by_interface_and_direction(
-            charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.provides
+            charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.requires
         )
 
         super().__init__(charm, relation_name)
+
+        self._is_single_endpoint = charm.meta.relations[relation_name].limit == 1
+
         self._charm = charm
         self._relation_name = relation_name
 
@@ -439,28 +452,38 @@ class TracingEndpointProvider(Object):
         self.framework.observe(events.relation_broken, self._on_tracing_relation_broken)
 
     @property
-    def relation(self) -> Relation:
-        """The tracing relation associated with this endpoint.
+    def relations(self) -> List[Relation]:
+        """The tracing relations associated with this endpoint."""
+        return self._charm.model.relations[self._relation_name]
 
-        Assumes tracing has limit 1.
-        """
-        return self._charm.model.get_relation(self._relation_name)
+    @property
+    def _relation(self) -> Relation:
+        """If this wraps a single endpoint, the relation bound to it, if any."""
+        if not self._is_single_endpoint:
+            objname = type(self).__name__
+            raise AmbiguousRelationUsageError(
+                f"This {objname} wraps a {self._relation_name} endpoint that has "
+                "limit != 1. We can't determine what relation, of the possibly many, you are "
+                f"talking about. Please pass a relation instance while calling {objname}, "
+                "or set limit=1 in the charm metadata."
+            )
+        relations = self.relations
+        return relations[0] if relations else None
 
     def is_ready(self, relation: Optional[Relation] = None):
         """Is this endpoint ready?"""
-        relation = relation or self.relation
-
+        relation = relation or self._relation
         if not relation:
-            logger.error("no relation")
+            logger.error(f"no relation on {self._relation_name}: tracing not ready")
             return False
         if relation.data is None:
-            logger.error("relation data is None")
+            logger.error(f"relation data is None for {relation}")
             return False
         if not relation.app:
             logger.error(f"{relation} event received but there is no relation.app")
             return False
         try:
-            TracingRequirerAppData.load(relation.data[relation.app])
+            TracingProviderAppData.load(relation.data[relation.app])
         except (json.JSONDecodeError, pydantic.ValidationError):
             logger.info(f"failed validating relation data for {relation}")
             return False
@@ -473,7 +496,7 @@ class TracingEndpointProvider(Object):
             self.on.endpoint_removed.emit(relation)  # type: ignore
             return
 
-        data = TracingRequirerAppData.load(relation.data[relation.app])
+        data = TracingProviderAppData.load(relation.data[relation.app])
         self.on.endpoint_changed.emit(relation, data.host, [i.dict() for i in data.ingesters])  # type: ignore
 
     def _on_tracing_relation_broken(self, event: RelationBrokenEvent):
@@ -481,16 +504,16 @@ class TracingEndpointProvider(Object):
         relation = event.relation
         self.on.endpoint_removed.emit(relation)
 
-    @property
-    def endpoints(self) -> Optional[TracingRequirerAppData]:
+    def get_all_endpoints(
+        self, relation: Optional[Relation] = None
+    ) -> Optional[TracingProviderAppData]:
         """Unmarshalled relation data."""
-        relation = self.relation
-        if not self.is_ready(relation):
+        if not self.is_ready(relation or self._relation):
             return
-        return TracingRequirerAppData.load(relation.data[relation.app])  # type: ignore
+        return TracingProviderAppData.load(relation.data[relation.app])  # type: ignore
 
-    def _get_ingester(self, protocol: IngesterProtocol):
-        ep = self.endpoints
+    def _get_ingester(self, relation: Relation, protocol: IngesterProtocol):
+        ep = self.get_all_endpoints(relation)
         if not ep:
             return None
         try:
@@ -500,22 +523,28 @@ class TracingEndpointProvider(Object):
             logger.error(f"no ingester found with protocol={protocol!r}")
             return None
 
-    @property
-    def otlp_grpc_endpoint(self) -> Optional[str]:
+    def otlp_grpc_endpoint(self, relation: Optional[Relation] = None) -> Optional[str]:
         """Ingester endpoint for the ``otlp_grpc`` protocol."""
-        return self._get_ingester("otlp_grpc")
+        return self._get_ingester(relation or self._relation, protocol="otlp_grpc")
 
-    @property
-    def otlp_http_endpoint(self) -> Optional[str]:
+    def otlp_http_endpoint(self, relation: Optional[Relation] = None) -> Optional[str]:
         """Ingester endpoint for the ``otlp_http`` protocol."""
-        return self._get_ingester("otlp_http")
+        return self._get_ingester(relation or self._relation, protocol="otlp_http")
 
-    @property
-    def zipkin_endpoint(self) -> Optional[str]:
+    def zipkin_endpoint(self, relation: Optional[Relation] = None) -> Optional[str]:
         """Ingester endpoint for the ``zipkin`` protocol."""
-        return self._get_ingester("zipkin")
+        return self._get_ingester(relation or self._relation, protocol="zipkin")
+
+    def tempo_endpoint(self, relation: Optional[Relation] = None) -> Optional[str]:
+        """Ingester endpoint for the ``tempo`` protocol."""
+        return self._get_ingester(relation or self._relation, protocol="tempo")
 
     @property
-    def tempo_endpoint(self) -> Optional[str]:
-        """Ingester endpoint for the ``tempo`` protocol."""
-        return self._get_ingester("tempo")
+    def jaeger_http_thrift_endpoint(self) -> Optional[str]:
+        """Ingester endpoint for the ``jaeger_http_thrift`` protocol."""
+        return self._get_ingester("jaeger_http_thrift")
+
+    @property
+    def jaeger_grpc_endpoint(self) -> Optional[str]:
+        """Ingester endpoint for the ``jaeger_grpc`` protocol."""
+        return self._get_ingester("jaeger_grpc")

--- a/lib/charms/traefik_k8s/v2/ingress.py
+++ b/lib/charms/traefik_k8s/v2/ingress.py
@@ -79,7 +79,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 PYDEPS = ["pydantic<2.0"]
 
@@ -98,8 +98,6 @@ class DatabagModel(BaseModel):
 
         allow_population_by_field_name = True
         """Allow instantiating this class by field name (instead of forcing alias)."""
-        extra = "forbid"
-        """Raise if unknown fields are added to the databag."""
 
     _NEST_UNDER = None
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -63,11 +63,6 @@ provides:
     description: |
       Forwards the built-in grafana dashboard(s) for monitoring traefik.
     interface: grafana_dashboard
-  tracing:
-    description: |
-      Tracing endpoint for integrating with tempo.
-    limit: 1
-    interface: tracing
 
 requires:
   certificates:
@@ -79,6 +74,11 @@ requires:
     interface: loki_push_api
     description: |
       Receives Loki's push api endpoint address to push logs to, and forwards charm's built-in alert rules to Loki.
+  tracing:
+    description: |
+      Tracing endpoint for integrating with tempo.
+    limit: 1
+    interface: tracing
 
 
 peers:

--- a/tests/scenario/test_tracing_integration.py
+++ b/tests/scenario/test_tracing_integration.py
@@ -5,14 +5,14 @@ import pytest
 import yaml
 from charm import _CA_CERT_PATH, _DYNAMIC_TRACING_PATH
 from charms.tempo_k8s.v0.charm_instrumentation import _charm_tracing_disabled
-from charms.tempo_k8s.v0.tracing import Ingester, TracingRequirerAppData
+from charms.tempo_k8s.v0.tracing import Ingester, TracingProviderAppData
 from scenario import Relation, State
 
 
 @pytest.fixture
 def tracing_relation():
     db = {}
-    TracingRequirerAppData(
+    TracingProviderAppData(
         host="foo.com", ingesters=[Ingester(protocol="otlp_grpc", port=81)]
     ).dump(db)
     tracing = Relation("tracing", remote_app_data=db)

--- a/tests/unit/test_databag_model.py
+++ b/tests/unit/test_databag_model.py
@@ -41,13 +41,12 @@ def test_invalid_model():
 
 
 def test_extra_fields():
-    with pytest.raises(pydantic.ValidationError):
-        IngressRequirerAppData(
-            model="foo",
-            name="bar",
-            port=10,
-            strip_prefix=True,
-            redirect_https=False,
-            scheme="https",
-            qux="floz",
-        )
+    IngressRequirerAppData(
+        model="foo",
+        name="bar",
+        port=10,
+        strip_prefix=True,
+        redirect_https=False,
+        scheme="https",
+        qux="floz",
+    )


### PR DESCRIPTION
tracing provider becomes requirer

this is what needs to be done in all charms that implement the pre 0.5 tracing interface

@lucabello --> prometheus
@shipperizer --> kratos

Note: this pr points to the tracing_integration branch; when that merges retarget to main, or if [this pr](https://github.com/canonical/tempo-k8s-operator/pull/35) lands first, we can merge this immediately.