### PR TITLE
Render https-redirect middleware only if scheme is https

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -827,7 +827,9 @@ class TraefikIngressCharm(CharmBase):
             if data.get("strip-prefix", False):
                 config.update({"stripPrefix": {"prefixes": [f"/{prefix}"], "forceSlash": False}})
 
-        if data.get("redirect-https", False):
+        # Condition rendering the https-redirect middleware on the scheme, otherwise we'd get a 404
+        # when attempting to reach an http endpoint.
+        if data.get("redirect-https", False) and data.get("scheme") == "https":
             config.update({"redirectScheme": {"scheme": "https", "port": 443, "permanent": True}})
 
         if config:

--- a/tests/scenario/utils.py
+++ b/tests/scenario/utils.py
@@ -83,7 +83,8 @@ def _render_config(
         expected["http"]["serversTransports"] = transports
 
     if middlewares := _render_middlewares(
-        strip_prefix=strip_prefix and routing_mode == "path", redirect_https=redirect_https
+        strip_prefix=strip_prefix and routing_mode == "path",
+        redirect_https=redirect_https and scheme == "https",
     ):
         expected["http"].update(middlewares)
         expected["http"]["routers"]["juju-test-model-remote-0-router"].update(

--- a/tests/scenario/utils.py
+++ b/tests/scenario/utils.py
@@ -5,23 +5,21 @@ from scenario import Relation
 
 
 def _render_middlewares(*, strip_prefix: bool = False, redirect_https: bool = False) -> dict:
-    middlewares = {}
-    if redirect_https:
-        middlewares.update({"redirectScheme": {"scheme": "https", "port": 443, "permanent": True}})
+    no_prefix_middleware = {}
     if strip_prefix:
-        middlewares.update(
-            {
-                "stripPrefix": {
-                    "prefixes": ["/test-model-remote-0"],
-                    "forceSlash": False,
-                }
-            }
-        )
-    return (
-        {"middlewares": {"juju-sidecar-noprefix-test-model-remote-0": middlewares}}
-        if middlewares
-        else {}
-    )
+        no_prefix_middleware["juju-sidecar-noprefix-test-model-remote-0"] = {
+            "stripPrefix": {"prefixes": ["/test-model-remote-0"], "forceSlash": False}
+        }
+
+    # Condition rendering the https-redirect middleware on the scheme, otherwise we'd get a 404
+    # when attempting to reach an http endpoint.
+    redir_scheme_middleware = {}
+    if redirect_https:
+        redir_scheme_middleware["juju-sidecar-redir-https-test-model-remote-0"] = {
+            "redirectScheme": {"scheme": "https", "port": 443, "permanent": True}
+        }
+
+    return {**no_prefix_middleware, **redir_scheme_middleware}
 
 
 def _render_config(
@@ -86,12 +84,12 @@ def _render_config(
         strip_prefix=strip_prefix and routing_mode == "path",
         redirect_https=redirect_https and scheme == "https",
     ):
-        expected["http"].update(middlewares)
+        expected["http"].update({"middlewares": middlewares})
         expected["http"]["routers"]["juju-test-model-remote-0-router"].update(
-            {"middlewares": ["juju-sidecar-noprefix-test-model-remote-0"]},
+            {"middlewares": list(middlewares.keys())},
         )
         expected["http"]["routers"]["juju-test-model-remote-0-router-tls"].update(
-            {"middlewares": ["juju-sidecar-noprefix-test-model-remote-0"]},
+            {"middlewares": list(middlewares.keys())},
         )
 
     return expected


### PR DESCRIPTION
## Issue
Getting 404 when related charms set `redirect_https=True` but effective scheme is `http`.


## Solution
Condition rendering the https-redirect middleware on the scheme.


## Testing Instructions
Relate trfk - am and curl the traefik ingress url.


## Release Notes
Render https-redirect middleware only if scheme is https.