### PR TITLE
add https scheme support to IPU loadBalancer

### DIFF
--- a/lib/charms/traefik_k8s/v1/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v1/ingress_per_unit.py
@@ -114,6 +114,7 @@ INGRESS_REQUIRES_UNIT_SCHEMA = {
         "mode": {"type": "string"},
         "strip-prefix": {"type": "string"},
         "redirect-https": {"type": "string"},
+        "scheme": {"type": "string"},
     },
     "required": ["model", "name", "host", "port"],
 }
@@ -486,7 +487,7 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
 
         databag = relation.data[remote_unit]
         remote_data: Dict[str, Union[int, str]] = {}
-        for k in ("port", "host", "model", "name", "mode", "strip-prefix", "redirect-https"):
+        for k in ("port", "host", "model", "name", "mode", "strip-prefix", "redirect-https", "scheme"):
             v = databag.get(k)
             if v is not None:
                 remote_data[k] = v

--- a/lib/charms/traefik_k8s/v1/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v1/ingress_per_unit.py
@@ -82,7 +82,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 log = logging.getLogger(__name__)
 
@@ -154,6 +154,7 @@ RequirerData = TypedDict(
         "mode": Optional[Literal["tcp", "http"]],
         "strip-prefix": Optional[bool],
         "redirect-https": Optional[bool],
+        "scheme": Optional[Literal["http", "https"]],
     },
     total=False,
 )
@@ -663,6 +664,7 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
         listen_to: Literal["only-this-unit", "all-units", "both"] = "only-this-unit",
         strip_prefix: bool = False,
         redirect_https: bool = False,
+        scheme: typing.Callable[[], str] = lambda: "http",
     ):
         """Constructor for IngressPerUnitRequirer.
 
@@ -692,6 +694,7 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
                   will be notified *twice* of changes to this unit's ingress!).
             strip_prefix: remove prefixes from the URL path.
             redirect_https: redirect incoming requests to HTTPS
+            scheme: callable returning the scheme to use when constructing the ingress url.
         """
         super().__init__(charm, relation_name)
         self._stored.set_default(current_urls=None)  # type: ignore
@@ -703,6 +706,7 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
         self._mode = mode
         self._strip_prefix = strip_prefix
         self._redirect_https = redirect_https
+        self._get_scheme = scheme
 
         self.listen_to = listen_to
 
@@ -790,6 +794,7 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
             "host": host,
             "port": str(port),
             "mode": self._mode,
+            "scheme": self._get_scheme(),
         }
 
         if self._strip_prefix:

--- a/lib/charms/traefik_k8s/v1/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v1/ingress_per_unit.py
@@ -487,7 +487,16 @@ class IngressPerUnitProvider(_IngressPerUnitBase):
 
         databag = relation.data[remote_unit]
         remote_data: Dict[str, Union[int, str]] = {}
-        for k in ("port", "host", "model", "name", "mode", "strip-prefix", "redirect-https", "scheme"):
+        for k in (
+            "port",
+            "host",
+            "model",
+            "name",
+            "mode",
+            "strip-prefix",
+            "redirect-https",
+            "scheme",
+        ):
             v = databag.get(k)
             if v is not None:
                 remote_data[k] = v

--- a/src/charm.py
+++ b/src/charm.py
@@ -928,7 +928,7 @@ class TraefikIngressCharm(CharmBase):
 
     def _generate_per_unit_http_config(self, prefix: str, data: RequirerData_IPU) -> dict:
         """Generate a config dict for a given unit for IngressPerUnit."""
-        lb_servers = [{"url": f"http://{data['host']}:{data['port']}"}]
+        lb_servers = [{"url": f"{data['scheme']}://{data['host']}:{data['port']}"}]
         return self._generate_config_block(prefix, lb_servers, data)  # type: ignore
 
     def _generate_config_block(

--- a/src/charm.py
+++ b/src/charm.py
@@ -928,7 +928,7 @@ class TraefikIngressCharm(CharmBase):
 
     def _generate_per_unit_http_config(self, prefix: str, data: RequirerData_IPU) -> dict:
         """Generate a config dict for a given unit for IngressPerUnit."""
-        lb_servers = [{"url": f"{data['scheme']}://{data['host']}:{data['port']}"}]
+        lb_servers = [{"url": f"{data.get('scheme', 'http')}://{data['host']}:{data['port']}"}]
         return self._generate_config_block(prefix, lb_servers, data)  # type: ignore
 
     def _generate_config_block(

--- a/tests/scenario/utils.py
+++ b/tests/scenario/utils.py
@@ -38,10 +38,6 @@ def _render_config(
         "subdomain": "Host(`test-model-remote-0.testhostname`)",
     }
 
-    if rel_name != "ingress":
-        scheme = "http"
-        # ipu does not do https for now
-
     service_spec = {
         "loadBalancer": {"servers": [{"url": f"{scheme}://{host}:{port}"}]},
     }


### PR DESCRIPTION
## Issue
Fixes #219.

Tandem PRs:
- https://github.com/canonical/prometheus-k8s-operator/pull/508

## Solution
Add `scheme ` to IPU following the implementation made in `ingress v2`.