### PR TITLE
Replace mutual_tls with certificate_transfer

### DIFF
--- a/lib/.wokeignore
+++ b/lib/.wokeignore
@@ -1,1 +1,1 @@
-charms/mutual_tls_interface
+charms/certificate_transfer_interface

--- a/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
@@ -1,19 +1,17 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Library for the mutual-tls relation.
+"""Library for the certificate_transfer relation.
 
-This library contains the Requires and Provides classes for handling the mutual-tls interface.
+This library contains the Requires and Provides classes for handling the
+ertificate-transfer interface.
 
 ## Getting Started
 From a charm directory, fetch the library using `charmcraft`:
 
 ```shell
-charmcraft fetch-lib charms.mutual_tls_interface.v0.mutual_tls
+charmcraft fetch-lib charms.certificate_transfer_interface.v0.certificate_transfer
 ```
-
-Add the following libraries to the charm's `requirements.txt` file:
-- jsonschema
 
 ### Provider charm
 The provider charm is the charm providing public certificates to another charm that requires them.
@@ -23,13 +21,13 @@ Example:
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 
-from lib.charms.mutual_tls_interface.v0.mutual_tls import MutualTLSProvides
+from lib.charms.certificate_transfer_interface.v0.certificate_transfer import CertificateTransferProvides  # noqa: E501 W505
 
 
-class DummyMutualTLSProviderCharm(CharmBase):
+class DummyCertificateTransferProviderCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
-        self.mutual_tls = MutualTLSProvides(self, "certificates")
+        self.certificate_transfer = CertificateTransferProvides(self, "certificates")
         self.framework.observe(
             self.on.certificates_relation_joined, self._on_certificates_relation_joined
         )
@@ -38,11 +36,11 @@ class DummyMutualTLSProviderCharm(CharmBase):
         certificate = "my certificate"
         ca = "my CA certificate"
         chain = ["certificate 1", "certificate 2"]
-        self.mutual_tls.set_certificate(certificate=certificate, ca=ca, chain=chain)
+        self.certificate_transfer.set_certificate(certificate=certificate, ca=ca, chain=chain)
 
 
 if __name__ == "__main__":
-    main(DummyMutualTLSProviderCharm)
+    main(DummyCertificateTransferProviderCharm)
 ```
 
 ### Requirer charm
@@ -54,18 +52,18 @@ Example:
 from ops.charm import CharmBase
 from ops.main import main
 
-from lib.charms.mutual_tls_interface.v0.mutual_tls import (
+from lib.charms.certificate_transfer_interface.v0.certificate_transfer import (
     CertificateAvailableEvent,
-    MutualTLSRequires,
+    CertificateTransferRequires,
 )
 
 
-class DummyMutualTLSRequirerCharm(CharmBase):
+class DummyCertificateTransferRequirerCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
-        self.mutual_tls = MutualTLSRequires(self, "certificates")
+        self.certificate_transfer = CertificateTransferRequires(self, "certificates")
         self.framework.observe(
-            self.mutual_tls.on.certificate_available, self._on_certificate_available
+            self.certificate_transfer.on.certificate_available, self._on_certificate_available
         )
 
     def _on_certificate_available(self, event: CertificateAvailableEvent):
@@ -75,13 +73,13 @@ class DummyMutualTLSRequirerCharm(CharmBase):
 
 
 if __name__ == "__main__":
-    main(DummyMutualTLSRequirerCharm)
+    main(DummyCertificateTransferRequirerCharm)
 ```
 
 You can relate both charms by running:
 
 ```bash
-juju relate <mutual-tls provider charm> <mutual-tls requirer charm>
+juju relate <certificate_transfer provider charm> <certificate_transfer requirer charm>
 ```
 
 """
@@ -96,7 +94,7 @@ from ops.charm import CharmBase, CharmEvents, RelationChangedEvent
 from ops.framework import EventBase, EventSource, Handle, Object
 
 # The unique Charmhub library identifier, never change it
-LIBID = "b24dab3c7b464669a7710806defe34d4"
+LIBID = "3785165b24a743f2b0c60de52db25c8b"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
@@ -105,16 +103,18 @@ LIBAPI = 0
 # to 0 if you are raising the major API version
 LIBPATCH = 1
 
+PYDEPS = ["jsonschema"]
+
 
 logger = logging.getLogger(__name__)
 
 
 PROVIDER_JSON_SCHEMA = {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/mutual_tls/schemas/provider.json",  # noqa: E501
+    "$id": "https://canonical.github.io/charm-relation-interfaces/interfaces/certificate_transfer/schemas/provider.json",  # noqa: E501
     "type": "object",
-    "title": "`mutual_tls` provider schema",
-    "description": "The `mutual_tls` root schema comprises the entire provider application databag for this interface.",  # noqa: E501
+    "title": "`certificate_transfer` provider schema",
+    "description": "The `certificate_transfer` root schema comprises the entire provider application databag for this interface.",  # noqa: E501
     "default": {},
     "examples": [
         {
@@ -200,14 +200,14 @@ def _load_relation_data(raw_relation_data: dict) -> dict:
     return loaded_relation_data
 
 
-class MutualTLSRequirerCharmEvents(CharmEvents):
-    """List of events that the Mutual TLS requirer charm can leverage."""
+class CertificateTransferRequirerCharmEvents(CharmEvents):
+    """List of events that the Certificate Transfer requirer charm can leverage."""
 
     certificate_available = EventSource(CertificateAvailableEvent)
 
 
-class MutualTLSProvides(Object):
-    """Mutual TLS provider class."""
+class CertificateTransferProvides(Object):
+    """Certificate Transfer provider class."""
 
     def __init__(self, charm: CharmBase, relationship_name: str):
         super().__init__(charm, relationship_name)
@@ -281,10 +281,10 @@ class MutualTLSProvides(Object):
             logger.warning("Can't remove certificate - No certificate in relation data")
 
 
-class MutualTLSRequires(Object):
+class CertificateTransferRequires(Object):
     """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
 
-    on = MutualTLSRequirerCharmEvents()
+    on = CertificateTransferRequirerCharmEvents()
 
     def __init__(
         self,

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -82,15 +82,14 @@ requires:
     limit: 1
     interface: tracing
   receive-ca-cert:
-    interface: mutual_tls
+    interface: certificate_transfer
     description: |
       Receive a CA cert for traefik to trust.
       This relation can be used with a local CA to obtain the CA cert that was used to sign proxied
       endpoints.
-      Note: The interface name is a misnomer, as this is not in fact mTLS.
 
     # Must limit the relation count to 1 due to
-    # https://github.com/canonical/mutual-tls-interface/issues/6
+    # https://github.com/canonical/certificate-transfer-interface/issues/6
     limit: 1
 
 peers:

--- a/src/charm.py
+++ b/src/charm.py
@@ -15,12 +15,12 @@ from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
 import yaml
+from charms.certificate_transfer_interface.v0.certificate_transfer import (
+    CertificateAvailableEvent,
+    CertificateTransferRequires,
+)
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v0.loki_push_api import LogProxyConsumer
-from charms.mutual_tls_interface.v0.mutual_tls import (
-    CertificateAvailableEvent,
-    MutualTLSRequires,
-)
 from charms.observability_libs.v0.cert_handler import CertHandler
 from charms.observability_libs.v1.kubernetes_service_patch import (
     KubernetesServicePatch,
@@ -135,7 +135,7 @@ class TraefikIngressCharm(CharmBase):
             extra_sans_dns=sans,
         )
 
-        self.recv_ca_cert = MutualTLSRequires(self, "receive-ca-cert")
+        self.recv_ca_cert = CertificateTransferRequires(self, "receive-ca-cert")
 
         # FIXME: Do not move these lower. They must exist before `_tcp_ports` is called. The
         # better long-term solution is to allow dynamic modification of the object, and to try


### PR DESCRIPTION
## Issue
The mutual_tls relation has been renamed.

This PR depends on:
- https://github.com/canonical/self-signed-certificates-operator/pull/22


## Solution
Fetch-lib.

Fixes #223.

## Context
- End-to-end TLS.
- #204 


## Testing Instructions
Relate ca - traefik - alertmanager - ca, and confirm curl works.


## Release Notes
Replace mutual_tls with certificate_transfer.
