### PR TITLE
set insecureSkipVerify to False

### DIFF
--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -219,7 +219,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 33
+LIBPATCH = 34
 
 logger = logging.getLogger(__name__)
 
@@ -790,7 +790,7 @@ def _inject_labels(content: str, topology: dict, transformer: "CosTool") -> str:
 
     # We need to use an index so we can insert the changed element back later
     for panel_idx, panel in enumerate(panels):
-        if type(panel) is not dict:
+        if not isinstance(panel, dict):
             continue
 
         # Use the index to insert it back in the same location
@@ -835,7 +835,7 @@ def _modify_panel(panel: dict, topology: dict, transformer: "CosTool") -> dict:
             if panel["datasource"] not in known_datasources:
                 continue
             querytype = known_datasources[panel["datasource"]]
-        elif type(panel["datasource"]) == dict:
+        elif isinstance(panel["datasource"], dict):
             if panel["datasource"]["uid"] not in known_datasources:
                 continue
             querytype = known_datasources[panel["datasource"]["uid"]]

--- a/src/charm.py
+++ b/src/charm.py
@@ -987,7 +987,7 @@ class TraefikIngressCharm(CharmBase):
             # i.e. traefik itself is not related to tls certificates, but the ingress requirer is
             transport_name = "reverseTerminationTransport"
             lb_def["serversTransport"] = transport_name
-            transports = {transport_name: {"insecureSkipVerify": True}}
+            transports = {transport_name: {"insecureSkipVerify": False}}
 
         elif is_termination:
             # i.e. traefik itself is related to tls certificates, but the ingress requirer is not

--- a/tests/scenario/utils.py
+++ b/tests/scenario/utils.py
@@ -45,7 +45,7 @@ def _render_config(
     if scheme == "https":
         # service_spec["rootCAs"] = ["/opt/traefik/juju/certificate.cert"]
         service_spec["loadBalancer"]["serversTransport"] = "reverseTerminationTransport"
-        transports = {"reverseTerminationTransport": {"insecureSkipVerify": True}}
+        transports = {"reverseTerminationTransport": {"insecureSkipVerify": False}}
 
     expected = {
         "http": {


### PR DESCRIPTION
## Issue
As part of our TLS work, we agreed to turn off `insecureSkipVerify` in all of our charms.

## Solution
Set `insecureSkipVerify` to `False` in the default config.

Itest are failing because we need to fix first:

- https://github.com/canonical/prometheus-k8s-operator/issues/511
- https://github.com/canonical/grafana-k8s-operator/issues/249