### PR TITLE
[IPA] Add scheme to provide_ingress_requirements

### DIFF
--- a/lib/charms/traefik_k8s/v2/ingress.py
+++ b/lib/charms/traefik_k8s/v2/ingress.py
@@ -623,11 +623,15 @@ class IngressPerAppRequirer(_IngressPerAppBase):
              requirer unit; if unspecified, FQDN will be used instead
             port: the port of the service (required)
         """
+        # This public method may be used at various points of the charm lifecycle, possible when
+        # the ingress relation is not yet there.
+        # Abort if there is no relation (instead of requiring the caller to guard against it).
+        if not self.relation:
+            return
+
         # get only the leader to publish the data since we only
         # require one unit to publish it -- it will not differ between units,
         # unlike in ingress-per-unit.
-        assert self.relation, "no relation"
-
         if self.unit.is_leader():
             app_databag = self.relation.data[self.app]
 

--- a/lib/charms/traefik_k8s/v2/ingress.py
+++ b/lib/charms/traefik_k8s/v2/ingress.py
@@ -79,7 +79,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 PYDEPS = ["pydantic<2.0"]
 
@@ -612,10 +612,13 @@ class IngressPerAppRequirer(_IngressPerAppBase):
             host, port = self._auto_data
             self.provide_ingress_requirements(host=host, port=port)
 
-    def provide_ingress_requirements(self, *, host: Optional[str] = None, port: int):
+    def provide_ingress_requirements(
+        self, *, scheme: Optional[str] = None, host: Optional[str] = None, port: int
+    ):
         """Publishes the data that Traefik needs to provide ingress.
 
         Args:
+            scheme: Scheme to be used; if unspecified, use the one used by __init__.
             host: Hostname to be used by the ingress provider to address the
              requirer unit; if unspecified, FQDN will be used instead
             port: the port of the service (required)
@@ -627,11 +630,16 @@ class IngressPerAppRequirer(_IngressPerAppBase):
 
         if self.unit.is_leader():
             app_databag = self.relation.data[self.app]
+
+            if not scheme:
+                # If scheme was not provided, use the one given to the constructor.
+                scheme = self._get_scheme()
+
             try:
                 IngressRequirerAppData(  # type: ignore  # pyright does not like aliases
                     model=self.model.name,
                     name=self.app.name,
-                    scheme=self._get_scheme(),
+                    scheme=scheme,
                     port=port,
                     strip_prefix=self._strip_prefix,  # type: ignore  # pyright does not like aliases
                     redirect_https=self._redirect_https,  # type: ignore  # pyright does not like aliases


### PR DESCRIPTION
## Issue
The IPA library does not have a `scheme` arg in its manual updater, `provide_ingress_requirements`.


## Solution
Repeat #232, this time for IPA.

Addresses https://github.com/canonical/karma-k8s-operator/issues/29.


## Testing Instructions
Relate `ca - trfk - (karma - ca) - catalogue`, and make sure the karma URL displayed in catalogue is the ingress URL and not the k8s fqdn.

In tandem with:
- https://github.com/canonical/karma-k8s-operator/pull/36


## Release Notes
[IPA] Add scheme to provide_ingress_requirements.
