### PR TITLE
Set scheme for traefik_route

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -362,7 +362,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 41
+LIBPATCH = 42
 
 PYDEPS = ["cosl"]
 
@@ -604,12 +604,12 @@ class PrometheusConfig:
         return {
             "alertmanagers": [
                 {
+                    # For https we still do not render a `tls_config` section because
+                    # certs are expected to be made available by the charm via the
+                    # `update-ca-certificates` mechanism.
                     "scheme": scheme,
                     "path_prefix": path_prefix,
                     "static_configs": [{"targets": netlocs}],
-                    # FIXME figure out how to get alertmanager's ca_file into here
-                    #  Without this, prom errors: "x509: certificate signed by unknown authority"
-                    "tls_config": {"insecure_skip_verify": True},
                 }
                 for (scheme, path_prefix), netlocs in paths.items()
             ]
@@ -1176,16 +1176,8 @@ class MetricsEndpointConsumer(Object):
             scrape_configs, hosts, topology
         )
 
-        # If scheme is https but no ca section present, then auto add "insecure_skip_verify",
-        # otherwise scraping errors out with "x509: certificate signed by unknown authority".
-        # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#tls_config
-        for scrape_config in scrape_configs:
-            tls_config = scrape_config.get("tls_config", {})
-            ca_present = "ca" in tls_config or "ca_file" in tls_config
-            if scrape_config.get("scheme") == "https" and not ca_present:
-                tls_config["insecure_skip_verify"] = True
-                scrape_config["tls_config"] = tls_config
-
+        # For https scrape targets we still do not render a `tls_config` section because certs
+        # are expected to be made available by the charm via the `update-ca-certificates` mechanism.
         return scrape_configs
 
     def _relation_hosts(self, relation: Relation) -> Dict[str, Tuple[str, str]]:

--- a/lib/charms/traefik_k8s/v1/ingress_per_unit.py
+++ b/lib/charms/traefik_k8s/v1/ingress_per_unit.py
@@ -82,7 +82,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 15
+LIBPATCH = 16
 
 log = logging.getLogger(__name__)
 
@@ -798,7 +798,11 @@ class IngressPerUnitRequirer(_IngressPerUnitBase):
              requirer unit; if unspecified, FQDN will be used instead
             port: the port of the service (required)
         """
-        assert self.relation, "no relation"
+        # This public method may be used at various points of the charm lifecycle, possibly when
+        # the ingress relation is not yet there.
+        # Abort if there is no relation (instead of requiring the caller to guard against it).
+        if not self.relation:
+            return
 
         if not host:
             host = socket.getfqdn()

--- a/lib/charms/traefik_route_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_route_k8s/v0/traefik_route.py
@@ -192,7 +192,7 @@ class TraefikRouteProvider(Object):
         return list(self._charm.model.relations[self._relation_name])
 
     def _update_stored(self) -> None:
-        """Ensure that the stored host is up-to-date.
+        """Ensure that the stored data is up-to-date.
 
         This is split out into a separate method since, in the case of multi-unit deployments,
         removal of a `TraefikRouteRequirer` will not cause a `RelationEvent`, but the guard on
@@ -209,9 +209,9 @@ class TraefikRouteProvider(Object):
                 self._stored.scheme = ""
                 return
             external_host = relation.data[relation.app].get("external_host", "")
-            self._stored.external_host = external_host or self._stored.external_host  # type: ignore
+            self._stored.external_host = external_host or self._stored.external_host
             scheme = relation.data[relation.app].get("scheme", "")
-            self._stored.scheme = scheme or self._stored.scheme  # type: ignore
+            self._stored.scheme = scheme or self._stored.scheme
 
     def _on_relation_changed(self, event: RelationEvent):
         if self.is_ready(event.relation):
@@ -317,9 +317,9 @@ class TraefikRouteRequirer(Object):
                     self._stored.scheme = ""
                     return
                 external_host = relation.data[relation.app].get("external_host", "")
-                self._stored.external_host = external_host or self._stored.external_host  # type: ignore
+                self._stored.external_host = external_host or self._stored.external_host
                 scheme = relation.data[relation.app].get("scheme", "")
-                self._stored.scheme = scheme or self._stored.scheme  # type: ignore
+                self._stored.scheme = scheme or self._stored.scheme
 
     def _on_relation_changed(self, event: RelationEvent) -> None:
         """Update StoredState with external_host and other information from Traefik."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -159,7 +159,7 @@ class TraefikIngressCharm(CharmBase):
 
         self.ingress_per_unit = IngressPerUnitProvider(charm=self)
         self.traefik_route = TraefikRouteProvider(
-            charm=self, external_host=self.external_host  # type: ignore
+            charm=self, external_host=self.external_host, scheme=self._scheme  # type: ignore
         )
 
         web = ServicePort(self._port, name=f"{self.app.name}")
@@ -1071,12 +1071,15 @@ class TraefikIngressCharm(CharmBase):
         lb_servers = [{"url": f"http://{data['host']}:{data['port']}"}]
         return self._generate_config_block(prefix, lb_servers, data)  # type: ignore
 
+    @property
+    def _scheme(self):
+        return "https" if self.cert.enabled else "http"
+
     def _get_external_url(self, prefix):
-        scheme = "https" if self.cert.enabled else "http"
         if self._routing_mode is _RoutingMode.path:
-            url = f"{scheme}://{self.external_host}/{prefix}"
+            url = f"{self._scheme}://{self.external_host}/{prefix}"
         else:  # _RoutingMode.subdomain
-            url = f"{scheme}://{prefix}.{self.external_host}/"
+            url = f"{self._scheme}://{prefix}.{self.external_host}/"
         return url
 
     def _wipe_ingress_for_all_relations(self):

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ allowlist_externals = /usr/bin/env
 description = Scenario tests
 deps =
     pytest
-    ops-scenario>=4.0.4
+    ops-scenario<5
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native {[vars]tst_path}/scenario --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
## Issue
Grafana, which uses traefik_route, is currently unable to tell if the ingress endpoint is http or https.


## Solution
This PR adds a scheme arg, so that traefik could inform over relation data which scheme it is using.

In tandem with:
- https://github.com/canonical/traefik-route-k8s-operator/pull/41
- https://github.com/canonical/grafana-k8s-operator/pull/257

Drive-by fixes:
- [IPU] Abort provide_ingress_requirements if there is no relation. The same thing was already impl'd for IPA in #233.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
Set scheme for traefik_route.
