### PR TITLE
swapped charm_instrumentation with charm_tracing (charm lib rename)

### DIFF
--- a/lib/charms/tempo_k8s/v0/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v0/charm_tracing.py
@@ -79,27 +79,18 @@ from ops.charm import CharmBase
 from ops.framework import Framework
 
 # The unique Charmhub library identifier, never change it
-LIBID = "0a8cf1b7b95d4cfcb90055f2d84897b3"
+LIBID = "cb1705dcd1a14ca09b2e60187d1215c7"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 2
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-grpc==1.17.0"]
 
 logger = logging.getLogger("tracing")
-
-logger.warning(
-    "The charms.tempo_k8s.v0.charm_instrumentation charm lib has been renamed "
-    "to charms.tempo_k8s.v0.charm_tracing. Please delete this lib and fetch "
-    "charms.tempo_k8s.v0.charm_tracing instead. "
-    "This library is version-locked to 0.8 (no further versions will be released, ever) "
-    "and unmaintained. At some point this library might be deleted altogether and will no "
-    "longer be available in charmhub."
-)
 
 tracer: ContextVar[Tracer] = ContextVar("tracer")
 _GetterType = Union[Callable[[CharmBase], Optional[str]], property]
@@ -113,7 +104,7 @@ def is_enabled() -> bool:
 
 
 @contextmanager
-def _charm_tracing_disabled():
+def charm_tracing_disabled():
     """Contextmanager to temporarily disable charm tracing.
 
     For usage in tests.
@@ -204,15 +195,15 @@ def _get_server_cert(server_cert_getter, self, charm):
             f"{charm}.{server_cert_getter} should return a valid tls cert (string); "
             f"got {server_cert} instead."
         )
-    logger.debug(f"Certificate successfully retrieved.")  # todo: some more validation?
+    logger.debug("Certificate successfully retrieved.")  # todo: some more validation?
     return server_cert
 
 
 def _setup_root_span_initializer(
-        charm: Type[CharmBase],
-        tracing_endpoint_getter: _GetterType,
-        server_cert_getter: Optional[_GetterType],
-        service_name: Optional[str] = None,
+    charm: Type[CharmBase],
+    tracing_endpoint_getter: _GetterType,
+    server_cert_getter: Optional[_GetterType],
+    service_name: Optional[str] = None,
 ):
     """Patch the charm's initializer."""
     original_init = charm.__init__
@@ -311,10 +302,10 @@ def _setup_root_span_initializer(
 
 
 def trace_charm(
-        tracing_endpoint: str,
-        server_cert: Optional[str] = None,
-        service_name: Optional[str] = None,
-        extra_types: Sequence[type] = (),
+    tracing_endpoint: str,
+    server_cert: Optional[str] = None,
+    service_name: Optional[str] = None,
+    extra_types: Sequence[type] = (),
 ):
     """Autoinstrument the decorated charm with tracing telemetry.
 
@@ -366,11 +357,11 @@ def trace_charm(
 
 
 def _autoinstrument(
-        charm_type: Type[CharmBase],
-        tracing_endpoint_getter: _GetterType,
-        server_cert_getter: Optional[_GetterType] = None,
-        service_name: Optional[str] = None,
-        extra_types: Sequence[type] = (),
+    charm_type: Type[CharmBase],
+    tracing_endpoint_getter: _GetterType,
+    server_cert_getter: Optional[_GetterType] = None,
+    service_name: Optional[str] = None,
+    extra_types: Sequence[type] = (),
 ) -> Type[CharmBase]:
     """Set up tracing on this charm class.
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -32,7 +32,7 @@ from charms.observability_libs.v1.kubernetes_service_patch import (
     ServicePort,
 )
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
-from charms.tempo_k8s.v0.charm_instrumentation import trace_charm
+from charms.tempo_k8s.v0.charm_tracing import trace_charm
 from charms.tempo_k8s.v0.tracing import TracingEndpointRequirer
 from charms.tls_certificates_interface.v2.tls_certificates import (
     CertificateInvalidatedEvent,

--- a/tests/scenario/test_tracing_integration.py
+++ b/tests/scenario/test_tracing_integration.py
@@ -4,7 +4,7 @@ import opentelemetry
 import pytest
 import yaml
 from charm import _CA_CERT_PATH, _DYNAMIC_TRACING_PATH
-from charms.tempo_k8s.v0.charm_instrumentation import _charm_tracing_disabled
+from charms.tempo_k8s.v0.charm_tracing import _charm_tracing_disabled
 from charms.tempo_k8s.v0.tracing import Ingester, TracingProviderAppData
 from scenario import Relation, State
 

--- a/tests/scenario/test_tracing_integration.py
+++ b/tests/scenario/test_tracing_integration.py
@@ -4,7 +4,7 @@ import opentelemetry
 import pytest
 import yaml
 from charm import _CA_CERT_PATH, _DYNAMIC_TRACING_PATH
-from charms.tempo_k8s.v0.charm_tracing import _charm_tracing_disabled
+from charms.tempo_k8s.v0.charm_tracing import charm_tracing_disabled
 from charms.tempo_k8s.v0.tracing import Ingester, TracingProviderAppData
 from scenario import Relation, State
 
@@ -41,7 +41,7 @@ def test_charm_trace_collection(traefik_ctx, traefik_container, caplog, tracing_
 def test_traefik_tracing_config(traefik_ctx, traefik_container, tracing_relation):
     state_in = State(relations=[tracing_relation], containers=[traefik_container])
 
-    with _charm_tracing_disabled():
+    with charm_tracing_disabled():
         traefik_ctx.run(tracing_relation.changed_event, state_in)
 
     tracing_cfg = (
@@ -67,7 +67,7 @@ def test_traefik_tracing_config_with_tls(traefik_ctx, traefik_container, tracing
     with patch("charm.TraefikIngressCharm._is_tls_enabled") as tls_enabled:
         tls_enabled.return_value = "True"
 
-        with _charm_tracing_disabled():
+        with charm_tracing_disabled():
             traefik_ctx.run(tracing_relation.changed_event, state_in)
 
     tracing_cfg = (
@@ -101,7 +101,7 @@ def test_traefik_tracing_config_removed_if_relation_data_invalid(
         containers=[traefik_container],
     )
 
-    with _charm_tracing_disabled():
+    with charm_tracing_disabled():
         traefik_ctx.run(tracing_relation.changed_event, state_in)
 
     # assert file is not there
@@ -121,7 +121,7 @@ def test_traefik_tracing_config_removed_on_relation_broken(
 
     state_in = State(relations=[tracing_relation], containers=[traefik_container])
 
-    with _charm_tracing_disabled():
+    with charm_tracing_disabled():
         traefik_ctx.run(tracing_relation.broken_event, state_in)
 
     # assert file is not there

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ allowlist_externals = /usr/bin/env
 description = Scenario tests
 deps =
     pytest
-    ops-scenario
+    ops-scenario >= 5.1
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native {[vars]tst_path}/scenario --log-cli-level=INFO -s {posargs}


### PR DESCRIPTION
following https://github.com/canonical/tempo-k8s-operator/pull/43, we replace the charm_instrumentation lib with charm_tracing (rename)