### PR TITLE
TLS fixes

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -993,14 +993,14 @@ class TraefikIngressCharm(CharmBase):
             transports = {}
 
         elif is_end_to_end:
+            # We cannot assume traefik's CA is the same CA that signed the proxied apps.
+            # Since we use the update_ca_certificates machinery, we don't need to specify the
+            # "rootCAs" entry.
+            # Keeping the serverTransports section anyway because it is informative ("endToEndTLS"
+            # vs "reverseTerminationTransport") when inspecting the config file in production.
             transport_name = "endToEndTLS"
             lb_def["serversTransport"] = transport_name
-            transports = {
-                transport_name: {
-                    # Note: assuming traefik's CA is the same CA that signed the proxied apps.
-                    "rootCAs": [_CA_CERT_PATH],
-                }
-            }
+            transports = {transport_name: {"insecureSkipVerify": False}}
 
         else:
             transports = {}

--- a/src/charm.py
+++ b/src/charm.py
@@ -11,6 +11,7 @@ import logging
 import re
 import socket
 import typing
+from string import Template
 from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
 
@@ -70,7 +71,6 @@ from ops.model import (
     WaitingStatus,
 )
 from ops.pebble import APIError, LayerDict, PathError
-from string import Template
 
 logger = logging.getLogger(__name__)
 
@@ -263,10 +263,12 @@ class TraefikIngressCharm(CharmBase):
         preferred.
         """
         if event:
-            self.container.push(_RECV_CA_TEMPLATE.substitute(rel_id=event.relation_id), event.ca, make_dirs=True)
+            self.container.push(
+                _RECV_CA_TEMPLATE.substitute(rel_id=event.relation_id), event.ca, make_dirs=True
+            )
         else:
             for relation in self.model.relations.get(self.recv_ca_cert.relationship_name, []):
-                # For some reason, realtion.units includes our unit and app. Need to exclude them.
+                # For some reason, relation.units includes our unit and app. Need to exclude them.
                 for unit in set(relation.units).difference([self.app, self.unit]):
                     # Note: this nested loop handles the case of multi-unit CA, each unit providing
                     # a different ca cert, but that is not currently supported by the lib itself.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -152,6 +152,7 @@ class TestTraefikIngressCharm(unittest.TestCase):
         self.harness: Harness[TraefikIngressCharm] = Harness(TraefikIngressCharm)
         self.harness.set_model_name("test-model")
         self.addCleanup(self.harness.cleanup)
+        self.harness.handle_exec("traefik", ["update-ca-certificates", "--fresh"], result=0)
 
         patcher = patch.object(TraefikIngressCharm, "version", property(lambda *_: "0.0.0"))
         self.mock_version = patcher.start()
@@ -416,6 +417,7 @@ class TestConfigOptionsValidation(unittest.TestCase):
         self.harness: Harness[TraefikIngressCharm] = Harness(TraefikIngressCharm)
         self.harness.set_model_name("test-model")
         self.addCleanup(self.harness.cleanup)
+        self.harness.handle_exec("traefik", ["update-ca-certificates", "--fresh"], result=0)
 
         patcher = patch.object(TraefikIngressCharm, "version", property(lambda *_: "0.0.0"))
         self.mock_version = patcher.start()

--- a/tests/unit/test_route.py
+++ b/tests/unit/test_route.py
@@ -65,6 +65,7 @@ CONFIG_WITH_TLS = {
 def harness() -> Harness[TraefikIngressCharm]:
     harness = Harness(TraefikIngressCharm)
     harness.set_model_name(MODEL_NAME)
+    harness.handle_exec("traefik", ["update-ca-certificates", "--fresh"], result=0)
 
     patcher = patch.object(TraefikIngressCharm, "version", property(lambda *_: "0.0.0"))
     patcher.start()

--- a/tests/unit/test_tls_certificates.py
+++ b/tests/unit/test_tls_certificates.py
@@ -18,6 +18,7 @@ class TlsWithExternalHostname(unittest.TestCase):
         self.harness: Harness[TraefikIngressCharm] = Harness(TraefikIngressCharm)
         self.harness.set_model_name("test-model")
         self.addCleanup(self.harness.cleanup)
+        self.harness.handle_exec("traefik", ["update-ca-certificates", "--fresh"], result=0)
 
         patcher = patch.object(TraefikIngressCharm, "version", property(lambda *_: "0.0.0"))
         self.mock_version = patcher.start()


### PR DESCRIPTION
## Issue
Curling prometheus via ingress url results in `Internal Server Error`.


## Solution
1. Drop incorrect rootCAs section for e2e TLS.
2. On upgrade, make sure to push certs received via the "recv-ca-certs" relation.


## Context
On upgrade, no relation events are emitted (unless you modify relation data as part of the upgrade sequence). So if, for example, you get certificates over relation data, they would all be lost after an upgrade. And you do not want persistent storage because then you would need to figure out which ones you need to delete after an upgrade.

So on upgrade you’d need to iterate over all relations and write those certs to disk. But not quite on upgrade-charm. We need the container to be there, so this must happen of pebble-ready.


## Testing Instructions
Follow testing instructions in https://github.com/canonical/cos-lite-bundle/pull/80 and curl prometheus.

Until we have `cert_transfer` impl'd in prom and grafana, copy traefik's ca cert manually:
```
juju run external-ca/0 get-ca-certificate --format json | jq -r '."external-ca/0".results."ca-certificate"' > external-ca.crt
openssl x509 -noout -text -in external-ca.crt

echo | openssl s_client -showcerts -servername 10.43.8.206 -connect 10.43.8.206:443 | openssl x509 -text -noout

juju scp --container prometheus external-ca.crt prometheus/0:/usr/local/share/ca-certificates
juju ssh --container prometheus prometheus/0 update-ca-certificates --fresh

juju scp --container grafana external-ca.crt grafana/0:/usr/local/share/ca-certificates
juju ssh --container grafana grafana/0 update-ca-certificates --fresh

juju ssh --container grafana grafana/0 curl https://10.43.8.206/trfk-prometheus-0/api/v1/targets | jq | grep -E "scrapeUrl|health"
```

## Release Notes
Fix cert handling.
