### PR TITLE
docs: use canonical/traefik container image instead of jnsgruk/traefik

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ microk8s enable metallb 192.168.0.10-192.168.0.100 # You likely want change thes
 ## Usage
 
 ```sh
-juju deploy ./traefik-k8s_ubuntu-20.04-amd64.charm traefik-ingress --trust --resource traefik-image=docker.io/jnsgruk/traefik:2.6.1
+juju deploy ./traefik-k8s_ubuntu-20.04-amd64.charm traefik-ingress --trust --resource traefik-image=ghcr.io/canonical/traefik:2.10.4
 ```
 
 ## Configurations


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
No issue, just a minor nit in the `README.md`.

## Solution
<!-- A summary of the solution addressing the above issue -->
Replaces `jnsgruk/traefik` container image with `canonical/traefik`

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
N/A

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
N/A

## Release Notes
<!-- A digestable summary of the change in this PR -->
