### PR TITLE
Set default cert

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -16,6 +16,12 @@ parts:
       - jsonschema
       - cryptography
 
+      # Due to https://github.com/pypa/setuptools_scm/issues/918
+      - cosl
+      - deepmerge
+      - httpx
+      - "opentelemetry-api==1.17"
+
       # From PYDEPS
       - "importlib-metadata==6.0.0"
       - "opentelemetry-exporter-otlp-proto-grpc==1.17.0"

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -16,12 +16,6 @@ parts:
       - jsonschema
       - cryptography
 
-      # Due to https://github.com/pypa/setuptools_scm/issues/918
-      - cosl
-      - deepmerge
-      - httpx
-      - "opentelemetry-api==1.17"
-
       # From PYDEPS
       - "importlib-metadata==6.0.0"
       - "opentelemetry-exporter-otlp-proto-grpc==1.17.0"

--- a/lib/charms/tempo_k8s/v0/charm_tracing.py
+++ b/lib/charms/tempo_k8s/v0/charm_tracing.py
@@ -86,7 +86,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-grpc==1.17.0"]
 
@@ -313,7 +313,7 @@ def trace_charm(
     method calls on instances of this class.
 
     Usage:
-    >>> from charms.tempo_k8s.v0.charm_instrumentation import trace_charm
+    >>> from charms.tempo_k8s.v0.charm_tracing import trace_charm
     >>> from charms.tempo_k8s.v0.tracing import TracingEndpointProvider
     >>> from ops import CharmBase
     >>>
@@ -370,7 +370,7 @@ def _autoinstrument(
 
     Usage:
 
-    >>> from charms.tempo_k8s.v0.charm_instrumentation import _autoinstrument
+    >>> from charms.tempo_k8s.v0.charm_tracing import _autoinstrument
     >>> from ops.main import main
     >>> _autoinstrument(
     >>>         MyCharm,

--- a/tests/manual/bundle_1_http.yaml
+++ b/tests/manual/bundle_1_http.yaml
@@ -16,7 +16,7 @@ applications:
     series: focal
     scale: 1
     resources:
-      traefik-image: docker.io/jnsgruk/traefik:2.9.6
+      traefik-image: ghcr.io/canonical/traefik:2.10.4
 
 relations:
 - [am:ingress, trfk]

--- a/tests/manual/bundle_3_reverse_termination.yaml
+++ b/tests/manual/bundle_3_reverse_termination.yaml
@@ -16,7 +16,7 @@ applications:
     series: focal
     scale: 1
     resources:
-      traefik-image: docker.io/jnsgruk/traefik:2.9.6
+      traefik-image: ghcr.io/canonical/traefik:2.10.4
 
   ca:
     charm: self-signed-certificates

--- a/tests/manual/bundle_4_tls_termination.yaml
+++ b/tests/manual/bundle_4_tls_termination.yaml
@@ -16,15 +16,15 @@ applications:
     series: focal
     scale: 1
     resources:
-      traefik-image: docker.io/jnsgruk/traefik:2.9.6
+      traefik-image: ghcr.io/canonical/traefik:2.10.4
     options:
       external_hostname: cluster.local
 
-  ca:
+  external-ca:
     charm: self-signed-certificates
     channel: edge
     scale: 1
 
 relations:
 - [am:ingress, trfk]
-- [trfk:certificates, ca:certificates]
+- [trfk:certificates, external-ca:certificates]

--- a/tests/manual/bundle_5_tls_end_to_end.yaml
+++ b/tests/manual/bundle_5_tls_end_to_end.yaml
@@ -43,7 +43,7 @@ applications:
     series: focal
     scale: 1
     resources:
-      traefik-image: docker.io/jnsgruk/traefik:2.9.6
+      traefik-image: ghcr.io/canonical/traefik:2.10.4
     options:
       external_hostname: cluster.local
 
@@ -52,7 +52,12 @@ applications:
     channel: edge
     scale: 1
 
+  external-ca:
+    charm: self-signed-certificates
+    channel: edge
+    scale: 1
+
 relations:
 - [am:ingress, trfk]
 - [am:certificates, ca:certificates]
-- [trfk:certificates, ca:certificates]
+- [trfk:certificates, external-ca:certificates]


### PR DESCRIPTION
## Issue
When using bare IPs, traefik fails to match to the "domain" and serves the default cert, which fails the TLS handshake.


## Solution
Set the default cert to the external ca cert, so bare IPs work too.

In tandem with:
- https://github.com/canonical/observability-libs/pull/60

 Refs:
- https://community.traefik.io/t/send-https-request-to-ip-address-not-matching-certificate-domain/15534
- https://doc.traefik.io/traefik/https/tls/#default-certificate

## Testing Instructions
1. Deploy the traefik charm from this PR together with the bundle from https://github.com/canonical/cos-lite-bundle/pull/80
2. Curl the traefik IP from within one of the COS containers (e.g. prometheus): `curl -v 10.43.8.206 https://10.43.8.206/trfk-prometheus-0/api/v1/targets`.


## Release Notes
Set default cert.
