### PR TITLE
feat: add transparent routing mode

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ options:
       The routing mode allows you to specify how Traefik going to generate
       routes on behalf of the requesters.
 
-      Valid values are "path" and "subdomain".
+      Valid values are "path", "subdomain", and "transparent".
 
       With the "path" routing mode, Traefik will use its externally-visible url,
       and create a route for the requester that will be structure like:

--- a/src/charm.py
+++ b/src/charm.py
@@ -1108,7 +1108,7 @@ class TraefikIngressCharm(CharmBase):
         elif self._routing_mode is _RoutingMode.subdomain:  # _RoutingMode.subdomain
             url = f"{self._scheme}://{prefix}.{self.external_host}/"
         else:  # _RoutingMode.transparent
-            url = f"{self._scheme}://{self.external_host}/"
+            url = f"{self._scheme}://{self.external_host}"
         return url
 
     def _wipe_ingress_for_all_relations(self):

--- a/src/charm.py
+++ b/src/charm.py
@@ -94,6 +94,7 @@ BIN_PATH = "/usr/bin/traefik"
 class _RoutingMode(enum.Enum):
     path = "path"
     subdomain = "subdomain"
+    transparent = "transparent"
 
 
 class _IngressRelationType(enum.Enum):
@@ -969,8 +970,10 @@ class TraefikIngressCharm(CharmBase):
         host = self.external_host
         if self._routing_mode is _RoutingMode.path:
             route_rule = f"PathPrefix(`/{prefix}`)"
-        else:  # _RoutingMode.subdomain
+        elif self._routing_mode is _RoutingMode.subdomain:
             route_rule = f"Host(`{prefix}.{host}`)"
+        else:  # _RoutingMode.transparent
+            route_rule = f"PathPrefix(`/`)"
 
         traefik_router_name = f"juju-{prefix}-router"
         traefik_service_name = f"juju-{prefix}-service"
@@ -1102,8 +1105,10 @@ class TraefikIngressCharm(CharmBase):
     def _get_external_url(self, prefix):
         if self._routing_mode is _RoutingMode.path:
             url = f"{self._scheme}://{self.external_host}/{prefix}"
-        else:  # _RoutingMode.subdomain
+        elif self._routing_mode is _RoutingMode.subdomain:  # _RoutingMode.subdomain
             url = f"{self._scheme}://{prefix}.{self.external_host}/"
+        else:  # _RoutingMode.transparent
+            url = f"{self._scheme}://{self.external_host}/"
         return url
 
     def _wipe_ingress_for_all_relations(self):


### PR DESCRIPTION
With this mode we are ensuring that no prefix is added when manipulating the external url and generating the configuration segment.
This feature is helpful when we need transparency for handling ingress.

This PR is for discussing the implementation and use case(s).
## Issue
<!-- What issue is this PR trying to solve? -->


## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->
