### PR TITLE
Include throwing pebble ready in the refresh events of Kubernetes service patch

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -194,7 +194,7 @@ class TraefikIngressCharm(CharmBase):
                 self.ingress_per_unit.on.data_removed,  # type: ignore
                 self.traefik_route.on.ready,  # type: ignore
                 self.traefik_route.on.data_removed,  # type: ignore
-                self.on.traefik_pebble_ready, # type: ignore
+                self.on.traefik_pebble_ready,  # type: ignore
             ],
         )
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -194,6 +194,7 @@ class TraefikIngressCharm(CharmBase):
                 self.ingress_per_unit.on.data_removed,  # type: ignore
                 self.traefik_route.on.ready,  # type: ignore
                 self.traefik_route.on.data_removed,  # type: ignore
+                self.on.traefik_pebble_ready, # type: ignore
             ],
         )
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

Fixes #257

## Solution
<!-- A summary of the solution addressing the above issue -->
By including the pebble ready in refresh events, we can prevent the juju override of turning it back into clusterIP

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
Juju on microk8s

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Same as https://github.com/canonical/traefik-k8s-operator/issues/257 

## Release Notes
<!-- A digestable summary of the change in this PR -->
-
