### PR TITLE
Fix issue with remote unit scale down

### DIFF
--- a/lib/charms/traefik_k8s/v2/ingress.py
+++ b/lib/charms/traefik_k8s/v2/ingress.py
@@ -79,7 +79,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 PYDEPS = ["pydantic<2.0"]
 
@@ -244,6 +244,7 @@ class _IngressPerAppBase(Object):
         observe(rel_events.relation_created, self._handle_relation)
         observe(rel_events.relation_joined, self._handle_relation)
         observe(rel_events.relation_changed, self._handle_relation)
+        observe(rel_events.relation_departed, self._handle_relation)
         observe(rel_events.relation_broken, self._handle_relation_broken)
         observe(charm.on.leader_elected, self._handle_upgrade_or_leader)  # type: ignore
         observe(charm.on.upgrade_charm, self._handle_upgrade_or_leader)  # type: ignore

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -3,7 +3,7 @@ from unittest.mock import PropertyMock, patch
 import pytest
 from charm import TraefikIngressCharm
 from ops import pebble
-from scenario import Container, Context, Model, Mount
+from scenario import Container, Context, Model, Mount, ExecOutput
 
 MOCK_EXTERNAL_HOSTNAME = "testhostname"
 
@@ -52,6 +52,10 @@ def traefik_container(tmp_path):
         name="traefik",
         can_connect=True,
         layers={"traefik": layer},
+        exec_mock={
+            ('update-ca-certificates', '--fresh'): ExecOutput(),
+            ('/usr/bin/traefik', 'version'): ExecOutput(stdout="42.42"),
+        },
         service_status={"traefik": pebble.ServiceStatus.ACTIVE},
         mounts={"opt": opt},
     )

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -3,7 +3,7 @@ from unittest.mock import PropertyMock, patch
 import pytest
 from charm import TraefikIngressCharm
 from ops import pebble
-from scenario import Container, Context, Model, Mount, ExecOutput
+from scenario import Container, Context, ExecOutput, Model, Mount
 
 MOCK_EXTERNAL_HOSTNAME = "testhostname"
 
@@ -53,8 +53,8 @@ def traefik_container(tmp_path):
         can_connect=True,
         layers={"traefik": layer},
         exec_mock={
-            ('update-ca-certificates', '--fresh'): ExecOutput(),
-            ('/usr/bin/traefik', 'version'): ExecOutput(stdout="42.42"),
+            ("update-ca-certificates", "--fresh"): ExecOutput(),
+            ("/usr/bin/traefik", "version"): ExecOutput(stdout="42.42"),
         },
         service_status={"traefik": pebble.ServiceStatus.ACTIVE},
         mounts={"opt": opt},

--- a/tests/scenario/test_ipa.py
+++ b/tests/scenario/test_ipa.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+from typing import Tuple, List
+
+import yaml
+from scenario import Context, Relation, State
+
+
+def create(traefik_ctx: Context, state: State):
+    ingress = Relation("ingress")
+    return traefik_ctx.run(ingress.joined_event, state.replace(relations=[ingress]))
+
+
+def join(traefik_ctx: Context, state: State):
+    ingress = state.get_relations("ingress")[0]
+    state = traefik_ctx.run(ingress.joined_event, state)
+    remote_units_data = ingress.remote_units_data
+
+    joining_unit_id = max(remote_units_data)
+    if remote_units_data[joining_unit_id]:
+        joining_unit_id += 1
+
+    remote_units_data[joining_unit_id] = {
+        "host": f'"neutron-{joining_unit_id}.neutron-endpoints.zaza-de71889d82db.svc.cluster.local"'}
+    relations = [ingress.replace(
+        remote_app_data={
+            "model": '"zaza"',
+            "name": '"neutron"',
+            "port": "9696",
+            "redirect-https": "false",
+            "scheme": '"http"',
+            "strip-prefix": "false"
+        },
+        remote_units_data=remote_units_data,
+        remote_unit_ids=list(remote_units_data)
+    )]
+
+    state = traefik_ctx.run(state.get_relations("ingress")[0].changed_event, state.replace(
+        relations=relations
+    ))
+    return state
+
+
+def depart(traefik_ctx: Context, state: State, pop_unit: bool = True):
+    def _pop(state: State):
+        ingress = state.get_relations("ingress")[0]
+        remote_units_data = ingress.remote_units_data.copy()
+        departing_unit_id = max(remote_units_data)
+        del remote_units_data[departing_unit_id]
+        return state.replace(
+            relations=[ingress.replace(remote_units_data=remote_units_data,
+                                       remote_unit_ids=list(remote_units_data))])
+
+    if pop_unit:  # pop before departed
+        state = _pop(state)
+
+    state = traefik_ctx.run(state.get_relations("ingress")[0].departed_event, state)
+
+    if not pop_unit:  # pop after departed; before changed
+        state = _pop(state)
+
+    state = traefik_ctx.run(state.get_relations("ingress")[0].changed_event, state)
+    return state
+
+
+def break_(traefik_ctx: Context, state: State):
+    ingress = state.get_relations("ingress")[0]
+    return traefik_ctx.run(
+        ingress.broken_event,
+        state.replace(
+            relations=[
+                ingress.replace(remote_app_data={},
+                                remote_units_data={},
+                                remote_unit_ids=[])
+            ]
+        )
+    )
+
+
+def get_configs(traefik_ctx: Context, state: State) -> Tuple[Path, List[Path]]:
+    """Return static and dynamic configs"""
+    vfs_root = state.get_container("traefik").get_filesystem(traefik_ctx)
+    opt = vfs_root / 'opt' / 'traefik' / 'juju'
+    etc = vfs_root / 'etc' / 'traefik' / 'traefik.yaml'
+    return etc, list(opt.glob("*.yaml"))
+
+
+def get_servers(cfg):
+    cfg_yaml = yaml.safe_load(cfg.read_text())
+    return cfg_yaml['http']['services']['juju-zaza-neutron-service']['loadBalancer']['servers']
+
+
+def test_traefik_remote_app_scaledown_from_2(traefik_ctx, traefik_container):
+    state = State(containers=[traefik_container])
+
+    with traefik_ctx.manager(traefik_container.pebble_ready_event, state) as mgr:
+        state = mgr.run()
+        static, dynamic = get_configs(traefik_ctx, state)
+
+    assert static.exists()
+    assert len(dynamic) == 0
+
+    state = create(traefik_ctx, state)
+
+    state = join(traefik_ctx, state)
+
+    _, dynamic = get_configs(traefik_ctx, state)
+    assert len(dynamic) == 1
+    assert len(get_servers(dynamic[0])) == 1
+
+    state = join(traefik_ctx, state)
+
+    _, dynamic = get_configs(traefik_ctx, state)
+    assert len(get_servers(dynamic[0])) == 2
+
+    state = depart(traefik_ctx, state)
+
+    _, dynamic = get_configs(traefik_ctx, state)
+    assert len(get_servers(dynamic[0])) == 1
+
+    break_(traefik_ctx, state)
+    assert not dynamic[0].exists()

--- a/tests/scenario/test_ipa.py
+++ b/tests/scenario/test_ipa.py
@@ -53,13 +53,7 @@ def depart(traefik_ctx: Context, state: State):
         remote_units_data = ingress.remote_units_data.copy()
         departing_unit_id = max(remote_units_data)
         del remote_units_data[departing_unit_id]
-        return state.replace(
-            relations=[
-                ingress.replace(
-                    remote_units_data=remote_units_data
-                )
-            ]
-        )
+        return state.replace(relations=[ingress.replace(remote_units_data=remote_units_data)])
 
     state = _pop(state)
 
@@ -76,11 +70,7 @@ def break_(traefik_ctx: Context, state: State):
     ingress = state.get_relations("ingress")[0]
     return traefik_ctx.run(
         ingress.broken_event,
-        state.replace(
-            relations=[
-                ingress.replace(remote_app_data={}, remote_units_data={})
-            ]
-        ),
+        state.replace(relations=[ingress.replace(remote_app_data={}, remote_units_data={})]),
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ allowlist_externals = /usr/bin/env
 description = Scenario tests
 deps =
     pytest
-    ops-scenario >= 5.1
+    ops-scenario >= 5.3
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native {[vars]tst_path}/scenario --log-cli-level=INFO -s {posargs}
@@ -94,7 +94,7 @@ commands =
 description = Run interface tests
 deps =
     pytest
-    ops-scenario
+    ops-scenario>=5.3
     pytest-interface-tester > 0.3
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes #260 

## Solution
<!-- A summary of the solution addressing the above issue -->
Add an observer for relation-departed

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
code wrongly assumed relation-changed would be fired if a remote unit departed

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
added a unittest to validate the behaviour at `tests.scenario.test_ipa.test_traefik_remote_app_scaledown_from_2`


## Release Notes
<!-- A digestable summary of the change in this PR -->
- fixed issue where urls from scaled-down remote units would be persisted in servers configuration
