### PR TITLE
Fix Interface and Scenario tests

### DIFF
--- a/tests/interface/test_ingress.py
+++ b/tests/interface/test_ingress.py
@@ -13,10 +13,6 @@ def test_ingress_v1_interface(interface_tester: InterfaceTester):
 
 def test_ingress_v2_interface(interface_tester: InterfaceTester):
     interface_tester.configure(
-        # todo: remove branch/repo overrides when
-        #  https://github.com/canonical/charm-relation-interfaces/pull/85 lands
-        repo="https://github.com/canonical/charm-relation-interfaces",
-        branch="ingress-v2-json",
         interface_name="ingress",
         interface_version=2,
     )

--- a/tests/scenario/test_ipa.py
+++ b/tests/scenario/test_ipa.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import List, Tuple
 
-import pytest
 import yaml
 from scenario import Context, Relation, State
 
@@ -120,7 +119,5 @@ def test_traefik_remote_app_scaledown_from_2(traefik_ctx, traefik_container):
     _, dynamic = get_configs(traefik_ctx, state)
     assert len(get_servers(dynamic[0])) == 1
 
-    with pytest.raises(IndexError):
-        # FIXME: solved in scenario 5.3.1 @https://github.com/canonical/ops-scenario/pull/64
-        break_(traefik_ctx, state)
-        assert not dynamic[0].exists()
+    break_(traefik_ctx, state)
+    assert not dynamic[0].exists()

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ allowlist_externals = /usr/bin/env
 description = Scenario tests
 deps =
     pytest
-    ops-scenario >= 5.3
+    ops-scenario >= 5.3.1
     -r{toxinidir}/requirements.txt
 commands =
     pytest -v --tb native {[vars]tst_path}/scenario --log-cli-level=INFO -s {posargs}
@@ -94,7 +94,7 @@ commands =
 description = Run interface tests
 deps =
     pytest
-    ops-scenario>=5.3
+    ops-scenario>=5.3.1
     pytest-interface-tester > 0.3
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
## Issue

Problems in Scenario and interface tests
- Using ops-scenario >= 5.3.1
- https://github.com/canonical/ops-scenario/pull/64 is merged so IndexError does not raise anymore. test_ipa.py needs to be updated.
- https://github.com/canonical/charm-relation-interfaces/pull/85 is merged. No need to use specific ingress-v2-json ingress branch.

## Solution
After merging following PRs, the problems appeared in the tests and the tests are fixed accordingly.
-  https://github.com/canonical/ops-scenario/pull/64 
-  https://github.com/canonical/charm-relation-interfaces/pull/85


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
Run `tox` to validate that all tests are passing.


## Release Notes
This PR aims to fix the problems which are happened after merging some PRs in the dependent external libraries.
