### PR TITLE
Validate the availability of traefik container before updating CA cer…

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -268,6 +268,8 @@ class TraefikIngressCharm(CharmBase):
 
     def _on_recv_ca_cert_available(self, event: CertificateTransferAvailableEvent):
         # Assuming only one cert per relation (this is in line with the original lib design).
+        if not self.container.can_connect():
+            return
         self._update_received_ca_certs(event)
 
     def _update_received_ca_certs(self, event: Optional[CertificateTransferAvailableEvent] = None):
@@ -278,9 +280,6 @@ class TraefikIngressCharm(CharmBase):
         Calling this function from upgrade-charm might be too early though. Pebble-ready is
         preferred.
         """
-        if not self.container.can_connect():
-            return
-
         if event:
             self.container.push(
                 _RECV_CA_TEMPLATE.substitute(rel_id=event.relation_id), event.ca, make_dirs=True

--- a/src/charm.py
+++ b/src/charm.py
@@ -278,6 +278,9 @@ class TraefikIngressCharm(CharmBase):
         Calling this function from upgrade-charm might be too early though. Pebble-ready is
         preferred.
         """
+        if not self.container.can_connect():
+            return
+
         if event:
             self.container.push(
                 _RECV_CA_TEMPLATE.substitute(rel_id=event.relation_id), event.ca, make_dirs=True

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -423,9 +423,9 @@ class TestTraefikCertTransferInterface(unittest.TestCase):
     @patch("ops.model.Container.exec")
     @patch("charm._get_loadbalancer_status", lambda **__: "10.0.0.1")
     @patch("charm.KubernetesServicePatch", lambda *_, **__: None)
-    def test_given_container_can_connect_when_receive_ca_cert_relation_joins_then_ca_certs_are_updated(
-        self, patch_exec
-    ):
+    def test_transferred_ca_certs_are_updated(self, patch_exec):
+        # Given container is ready, when receive-ca-cert relation joins,
+        # then ca certs are updated.
         provider_app = "self-signed-certificates"
         self.harness.set_leader(True)
         self.harness.begin_with_initial_hooks()
@@ -441,9 +441,9 @@ class TestTraefikCertTransferInterface(unittest.TestCase):
     @patch("ops.model.Container.exec")
     @patch("charm._get_loadbalancer_status", lambda **__: "10.0.0.1")
     @patch("charm.KubernetesServicePatch", lambda *_, **__: None)
-    def test_given_container_not_ready_when_receive_ca_cert_relation_joins_then_ca_certs_are_not_updated(
-        self, patch_exec
-    ):
+    def test_transferred_ca_certs_are_not_updated(self, patch_exec):
+        # Given container is not ready, when receive-ca-cert relation joins,
+        # then not attempting to update ca certs.
         provider_app = "self-signed-certificates"
         self.harness.set_leader(True)
         self.harness.set_can_connect(container=self.container_name, val=False)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -410,6 +410,52 @@ class TestTraefikIngressCharm(unittest.TestCase):
         assert yaml.safe_load(static_config)["entryPoints"][prefix] == expected_entrypoint
 
 
+class TestTraefikCertTransferInterface(unittest.TestCase):
+    def setUp(self):
+        self.harness: Harness[TraefikIngressCharm] = Harness(TraefikIngressCharm)
+        self.harness.set_model_name("test-model")
+        self.addCleanup(self.harness.cleanup)
+        patcher = patch.object(TraefikIngressCharm, "version", property(lambda *_: "0.0.0"))
+        self.mock_version = patcher.start()
+        self.addCleanup(patcher.stop)
+        self.container_name = "traefik"
+
+    @patch("ops.model.Container.exec")
+    @patch("charm._get_loadbalancer_status", lambda **__: "10.0.0.1")
+    @patch("charm.KubernetesServicePatch", lambda *_, **__: None)
+    def test_given_container_can_connect_when_receive_ca_cert_relation_joins_then_ca_certs_are_updated(
+        self, patch_exec
+    ):
+        provider_app = "self-signed-certificates"
+        self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
+        self.harness.set_can_connect(container=self.container_name, val=True)
+        certificate_transfer_rel_id = self.harness.add_relation(
+            relation_name="receive-ca-cert", remote_app=provider_app
+        )
+        self.harness.add_relation_unit(
+            relation_id=certificate_transfer_rel_id, remote_unit_name=f"{provider_app}/0"
+        )
+        patch_exec.assert_called_once_with(["update-ca-certificates", "--fresh"])
+
+    @patch("ops.model.Container.exec")
+    @patch("charm._get_loadbalancer_status", lambda **__: "10.0.0.1")
+    @patch("charm.KubernetesServicePatch", lambda *_, **__: None)
+    def test_given_container_not_ready_when_receive_ca_cert_relation_joins_then_ca_certs_are_not_updated(
+        self, patch_exec
+    ):
+        provider_app = "self-signed-certificates"
+        self.harness.set_leader(True)
+        self.harness.set_can_connect(container=self.container_name, val=False)
+        certificate_transfer_rel_id = self.harness.add_relation(
+            relation_name="receive-ca-cert", remote_app=provider_app
+        )
+        self.harness.add_relation_unit(
+            relation_id=certificate_transfer_rel_id, remote_unit_name=f"{provider_app}/0"
+        )
+        patch_exec.assert_not_called()
+
+
 class TestConfigOptionsValidation(unittest.TestCase):
     @patch("charm._get_loadbalancer_status", lambda **_: "10.0.0.1")
     @patch("charm.KubernetesServicePatch", lambda *_, **__: None)


### PR DESCRIPTION
Validate the availability of traefik container before updating CA certs

## Issue
While updating CA certificates when CertificateTransfer relation joined, traefik container many not be running yet. This causes ConnectionError like https://github.com/canonical/vault-k8s-operator/actions/runs/6430745831/job/17462295379?pr=53. 


## Solution
Availability of traefik container needs to be checked before trying to update CA certs


## Context
The issue is appeared when Traefik is related with Vault-k8s using CertificateTransfer interface.


## Testing Instructions
Run `tox -e integration`.


## Release Notes
This PR aims to fix the bug: https://github.com/canonical/traefik-k8s-operator/issues/265. 
First https://github.com/canonical/traefik-k8s-operator/pull/266 needs to be merged as it fixes some existing test problems  in main branch. Otherwise, some tests are failing regardless of this PR.
