### PR TITLE
Subdomain certs

### DIFF
--- a/doc/adr/2023-10-18 subdomain routing with cert per unit.md
+++ b/doc/adr/2023-10-18 subdomain routing with cert per unit.md
@@ -29,6 +29,8 @@ the use-case of strict subdomain routing (no wildcards).
 * Bad, because may get rate limited by the CA.
   * IPA: new CSR (CRR) for every added (removed) app
   * IPU: new CSR (CRR) for every added (removed) unit
+* Bad, because if we are not careful, the rate limit could break the only cert
+  in use.
 
 ## Pros and Cons of the Options
 
@@ -67,7 +69,9 @@ SAN example: app1.example.com, app2.example.com
 
 * Good, because no wildcard certs (more secure).
 * Bad, because the number of SANs per cert is limited.
-
+* Bad, because may get rate limited by the CA.
+* Bad, because depends on the order things are done on an ACME server: if the
+  server first revokes the previous certificate, it could create outages.
 
 ### One cert per app (wildcard SANs only for ingress-per-unit)
 ```
@@ -108,3 +112,8 @@ echo | openssl s_client -showcerts -connect google.com:443 | openssl x509 -noout
 - StackExchange projects have wildcard SAN.
 - Government and bank websites have a separate cert per subdomain (and they do not use wildcard SANs)
 - Let's Encrypt limits to 100 SANs per cert ([ref](https://community.letsencrypt.org/t/why-sans-are-limited-to-100-domains-only/154930))
+- Wildcard certs don't allow HTTP challenge, nor ALPN validation using ACME
+  protocol, only DNS challenge is supported
+  (https://letsencrypt.org/docs/challenge-types/).
+- For now, the only `tls-certificates` providers in the ecosystem are using the
+  DNS-01 challenge.

--- a/doc/adr/2023-10-18 subdomain routing with cert per unit.md
+++ b/doc/adr/2023-10-18 subdomain routing with cert per unit.md
@@ -1,0 +1,110 @@
+# Obtain a separate cert per every unit when using subdomain routing
+
+## Context and Problem Statement
+Until now, the TLS cert solution was designed with only path routing in mind.
+When using Traefik in the subdomain routing mode, all Ingress will use
+Traefik's default certificate, because charm code only obtains one cert (for
+the external hostname), and traefik obviously cannot match that cert with
+subdomains.
+
+https://github.com/canonical/traefik-k8s-operator/issues/244
+
+## Considered Options
+
+- One cert per app/unit (no wildcards)
+- Only one cert (as many wildcard SANs as necessary)
+- Only one cert (keep appending subdomains; no wildcards)
+- One cert per app (wildcard SANs only for ingress-per-unit)
+- One cert per app (keep appending IPU subdomains; no wildcards)
+
+## Decision Outcome
+
+Chosen option: "One cert per app/unit (no wildcards)", because we must support
+the use-case of strict subdomain routing (no wildcards).
+
+### Consequences
+
+* Good, because no wildcard certs (more secure).
+* Good, because not limited by SAN count per cert.
+* Bad, because may get rate limited by the CA.
+  * IPA: new CSR (CRR) for every added (removed) app
+  * IPU: new CSR (CRR) for every added (removed) unit
+
+## Pros and Cons of the Options
+
+### One cert per app/unit (no wildcards)
+```
+IPA: model-app.example.com
+IPU: model-app-0.example.com
+
+SAN example: model-app-0.example.com
+```
+
+* Good, because no wildcard certs (more secure).
+* Good, because not limited by SAN count per cert.
+* Bad, because may get rate limited by the CA.
+
+### Only one cert (as many wildcard SANs as necessary)
+```
+IPA: model-app.example.com
+IPU: model-app-0.example.com
+
+SAN example: *.example.com
+```
+
+* Good, because won't get rate limited by the CA.
+* Good, because simple to implement.
+* Bad, because the number of SANs per cert is limited.
+* Bad, because a wildcard cert is too permissive.
+
+### Only one cert (keep appending subdomains; no wildcards)
+```
+IPA: model-app.example.com
+IPU: model-app-0.example.com
+
+SAN example: app1.example.com, app2.example.com
+```
+
+* Good, because no wildcard certs (more secure).
+* Bad, because the number of SANs per cert is limited.
+
+
+### One cert per app (wildcard SANs only for ingress-per-unit)
+```
+IPA: app.model.example.com
+IPU: app-0.app.model.example.com
+
+SAN example (IPA): app.model.example.com
+SAN example (IPU): *.app.model.example.com
+```
+
+* Bad, because the number of SANs per cert is limited.
+* Bad, because may get rate limited by the CA.
+
+### One cert per app (keep appending IPU subdomains; no wildcards)
+```
+IPA: model-app.example.com
+IPU: model-app-0.example.com
+
+SAN example (IPA): app1.model.example.com
+SAN example (IPU): app2-0.app2.model.example.com, app2-1.app2.model.example.com
+```
+
+* Good, because no wildcard certs (more secure).
+* Bad, because the number of SANs per cert is limited.
+* Bad, because may get rate limited by the CA.
+
+
+## More Information
+
+```bash
+# Count SANs with:
+echo | openssl s_client -showcerts -connect google.com:443 | openssl x509 -noout -text | grep DNS | tr ',' '\n' | wc -l
+```
+
+- Google has 134 subdomains in one cert (and they also use wildcard SANs)
+- Wikipedia has 41 subdomains in one cert (and they also use wildcard SANs)
+- Wordpress and blogger have wildcard SAN.
+- StackExchange projects have wildcard SAN.
+- Government and bank websites have a separate cert per subdomain (and they do not use wildcard SANs)
+- Let's Encrypt limits to 100 SANs per cert ([ref](https://community.letsencrypt.org/t/why-sans-are-limited-to-100-domains-only/154930))

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -1,0 +1,37 @@
+ADR template is based on https://adr.github.io/madr/examples.html.
+
+```markdown
+# ADR topic
+
+## Context and Problem Statement
+
+
+## Considered Options
+
+- Option 1
+- Option 2
+
+## Decision Outcome
+
+Chosen option: ..., because ...
+
+### Consequences
+
+* Good, because ...
+* Good, because ...
+* Bad, because ...
+
+## Pros and Cons of the Options
+
+### Option 1
+
+* Good, because ...
+* Bad, because ...
+
+### Option 2
+
+* Good, because ...
+* Bad, because ...
+
+## More Information
+```

--- a/tests/scenario/test_status.py
+++ b/tests/scenario/test_status.py
@@ -3,7 +3,7 @@
 
 from unittest.mock import MagicMock, PropertyMock, patch
 
-from ops import ActiveStatus, WaitingStatus
+from ops import ActiveStatus, BlockedStatus, WaitingStatus
 from scenario import Container, State
 
 
@@ -49,4 +49,27 @@ def test_start_traefik_active(traefik_ctx, *_):
     out = traefik_ctx.run("start", state)
 
     # THEN unit status is `active`
+    assert out.unit_status == ActiveStatus("")
+
+
+@patch("charm.TraefikIngressCharm._external_host", PropertyMock(return_value="1.2.3.4"))
+@patch("traefik.Traefik.is_ready", PropertyMock(return_value=True))
+@patch("charm.TraefikIngressCharm._tcp_entrypoints_changed", MagicMock(return_value=False))
+def test_block_if_no_ext_host_in_subdomain_routing(traefik_ctx, *_):
+    # GIVEN external host is a bare IP from metallb (see decorator)
+    # WHEN a `config-change` hook fires and routing mode is subdomain
+    state = State(
+        config={"routing_mode": "subdomain"},
+        containers=[Container(name="traefik", can_connect=True)],
+    )
+    out = traefik_ctx.run("config-changed", state)
+
+    # THEN unit status is `blocked`
+    assert isinstance(out.unit_status, BlockedStatus)
+
+    # AND WHEN the routing mode is reverted to path
+    out.config["routing_mode"] = "path"
+
+    # THEN unit status is `active`
+    out = traefik_ctx.run("config-changed", out)
     assert out.unit_status == ActiveStatus("")


### PR DESCRIPTION
## Issue
The TLS cert solution was designed with only path routing in mind.
With subdomain routing, traefik is unable to match a domain to a cert.


## Solution
- [ ] Keep using cert_handler as-is for the bare hostname cert. Should keep it even for subdomain routing, to be able to reach traefik api endpoints and metrics endpoint.
- [ ] Refactor to have a cert per app (IPA) or per unit (IPU).
  - [ ] when ingress relation (unit) joins/departs, send CSR/CRR on behalf of the unit
  - [ ] when routing mode changes from subdomain to path, CRR everything
  - [ ] when routing mode changes from path to subdomain, CSR everything

Fixes #244.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->
