### PR TITLE
Fix version number in documentation

### DIFF
--- a/lib/charms/traefik_k8s/v2/ingress.py
+++ b/lib/charms/traefik_k8s/v2/ingress.py
@@ -13,7 +13,7 @@ To get started using the library, you just need to fetch the library using `char
 
 ```shell
 cd some-charm
-charmcraft fetch-lib charms.traefik_k8s.v1.ingress
+charmcraft fetch-lib charms.traefik_k8s.v2.ingress
 ```
 
 In the `metadata.yaml` of the charm, add the following:


### PR DESCRIPTION
This changed in https://github.com/canonical/traefik-k8s-operator/pull/286 -- Likely a mistake.

It's possible there is more to this, but this is just something I noticed in one of our downstream PRs.

## Issue
Suspected documentation regression


## Solution
Fix the typo.


## Context
https://github.com/canonical/traefik-k8s-operator/pull/286


## Testing Instructions
None.


## Release Notes
Fixed a documentation regression in the v2 ingress library
