### PR TITLE
do not ask for grpc endpoint since we're not requesting it

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -433,8 +433,6 @@ class TraefikIngressCharm(CharmBase):
 
         if endpoint := self._tracing.otlp_http_endpoint():
             grpc = False
-        elif endpoint := self._tracing.otlp_grpc_endpoint():
-            grpc = True
         else:
             logger.error(
                 "tracing integration is active but none of the "


### PR DESCRIPTION
## Issue
When relating tempo to traefik, if tempo does not reply with an otlp_http endpoint, traefik will look for a grpc one. 
However that's not been requested in `__init__` and so that raises an exception.

## Solution
Remove the optional grpc path as we're not requesting it. Instead, rely on otlp_http being requested in `__init__`.


## Context
n/a

## Testing Instructions
deploy traefik and relate to tempo

## Upgrade Notes
- minor bugfix on the tracing integration