### PR TITLE
fixed export by alias in pydantic v2 and ingress mandatory args

### DIFF
--- a/tests/scenario/test_ingress_per_app.py
+++ b/tests/scenario/test_ingress_per_app.py
@@ -184,9 +184,6 @@ def test_ingress_per_app_requirer_with_auto_data(host, ip, port, model, evt_name
             "model": '"test-model"',
             "name": '"charlie"',
             "port": str(port),
-            "redirect-https": "false",
-            "scheme": '"http"',
-            "strip-prefix": "false",
         }
 
 

--- a/tests/unit/test_databag_model.py
+++ b/tests/unit/test_databag_model.py
@@ -29,7 +29,6 @@ def test_round_trip(nest_under):
         "name": "bar",
         "port": 10,
         "strip_prefix": True,
-        "redirect_https": False,
         "scheme": "https",
     }
     aliased = {k.replace("_", "-"): v for k, v in cfg.items()}

--- a/tests/unit/test_ingress_lib.py
+++ b/tests/unit/test_ingress_lib.py
@@ -41,8 +41,8 @@ def test_io_ingress_requirer_app_data():
             "port": 10,
             "name": "foo",
             "strip-prefix": True,
-            "redirect-https": None,
-            "scheme": "http",
+            # "redirect-https": False, omitted because default
+            # "scheme": "http", omitted because default
         }.items()
     }
     assert IngressRequirerAppData.load(databag) == app_data
@@ -68,7 +68,7 @@ def test_aliases():
             "port": 10,
             "strip-prefix": True,
             "redirect-https": True,
-            "scheme": "http",
+            # "scheme": "http", omitted because default
         }.items()
     }
 
@@ -78,7 +78,7 @@ def test_aliases():
 def test_io_provider_data():
     """Round trip test: A.dump().load() == A for A = IngressProviderAppData."""
     databag = {}
-    url = {"url": "https://foo.com"}
+    url = {"url": "https://foo.com/"}
     app_data = IngressProviderAppData(ingress=url)
 
     app_data.dump(databag)

--- a/tests/unit/test_lib_per_app_provides.py
+++ b/tests/unit/test_lib_per_app_provides.py
@@ -75,7 +75,7 @@ def test_ingress_app_provider_relate_provide(
     relation = harness.model.get_relation("ingress", relation_id)
     assert provider.is_ready(relation)
 
-    provider.publish_url(relation, "https://foo.com")
+    provider.publish_url(relation, "https://foo.com/")
 
     ingress = harness.get_relation_data(relation_id, "test-provider")["ingress"]
-    assert yaml.safe_load(ingress) == {"url": "https://foo.com"}
+    assert yaml.safe_load(ingress) == {"url": "https://foo.com/"}

--- a/tests/unit/test_lib_per_app_requires.py
+++ b/tests/unit/test_lib_per_app_requires.py
@@ -54,7 +54,7 @@ def test_ingress_app_requirer_uninitialized(requirer: IngressPerAppRequirer, har
 @pytest.mark.parametrize("strip_prefix", (True, False))
 def test_ingress_app_requirer_related(requirer: IngressPerAppRequirer, harness, strip_prefix):
     harness.set_leader(True)
-    url = "http://foo.bar"
+    url = "http://foo.bar/"
 
     assert not requirer.is_ready()
     # provider goes to ready immediately because we inited ipa with port=80.
@@ -160,5 +160,9 @@ class TestIPAEventsEmission(unittest.TestCase):
             self.harness.charm.ipa.provide_ingress_requirements(port=80)
 
             self.assertEqual(
-                self.harness.get_relation_data(self.rel_id, "ipa-requirer/0")["ip"], "null"
+                # None is default so it gets omitted
+                self.harness.get_relation_data(self.rel_id, "ipa-requirer/0").get(
+                    "ip", "<OMITTED>"
+                ),
+                "<OMITTED>",
             )

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,6 @@ deps =
     pytest-asyncio==0.21.0
     pytest-operator
     juju
-    pydantic<2.0
     tenacity
     -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
## Issue
Fixes #307 
And it switches back strip-prefix and redirect-https and ip to be optional args.

## Testing Instructions

Pack this charm, deploy this bundle and verify that there are no errors on the tempo-traefik handshake.

```yaml
bundle: kubernetes
  tempo:
    charm: tempo-k8s
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
  traefik:
    charm: traefik-k8s
    channel: edge
    revision: 171
    series: focal
    resources:
      traefik-image: 158
    scale: 1
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
    trust: true
relations:
- - traefik:ingress
  - tempo:ingress
```