### PR TITLE
Fix redirections to match schema

### DIFF
--- a/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
+++ b/lib/charms/certificate_transfer_interface/v0/certificate_transfer.py
@@ -21,7 +21,9 @@ Example:
 from ops.charm import CharmBase, RelationJoinedEvent
 from ops.main import main
 
-from lib.charms.certificate_transfer_interface.v0.certificate_transfer import CertificateTransferProvides  # noqa: E501 W505
+from lib.charms.certificate_transfer_interface.v0.certificate_transfer import(
+    CertificateTransferProvides,
+)
 
 
 class DummyCertificateTransferProviderCharm(CharmBase):
@@ -36,7 +38,9 @@ class DummyCertificateTransferProviderCharm(CharmBase):
         certificate = "my certificate"
         ca = "my CA certificate"
         chain = ["certificate 1", "certificate 2"]
-        self.certificate_transfer.set_certificate(certificate=certificate, ca=ca, chain=chain, relation_id=event.relation.id)
+        self.certificate_transfer.set_certificate(
+            certificate=certificate, ca=ca, chain=chain, relation_id=event.relation.id
+        )
 
 
 if __name__ == "__main__":
@@ -95,7 +99,7 @@ juju relate <certificate_transfer provider charm> <certificate_transfer requirer
 
 import json
 import logging
-from typing import List
+from typing import List, Mapping
 
 from jsonschema import exceptions, validate  # type: ignore[import-untyped]
 from ops.charm import CharmBase, CharmEvents, RelationBrokenEvent, RelationChangedEvent
@@ -109,7 +113,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 PYDEPS = ["jsonschema"]
 
@@ -210,7 +214,7 @@ class CertificateRemovedEvent(EventBase):
         self.relation_id = snapshot["relation_id"]
 
 
-def _load_relation_data(raw_relation_data: dict) -> dict:
+def _load_relation_data(raw_relation_data: Mapping[str, str]) -> dict:
     """Load relation data from the relation data bag.
 
     Args:
@@ -313,7 +317,7 @@ class CertificateTransferProvides(Object):
 class CertificateTransferRequires(Object):
     """TLS certificates requirer class to be instantiated by TLS certificates requirers."""
 
-    on = CertificateTransferRequirerCharmEvents()
+    on = CertificateTransferRequirerCharmEvents()  # type: ignore
 
     def __init__(
         self,

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -205,9 +205,9 @@ class Traefik:
 
         if self._tls_enabled:
             # enable http -> https redirect
-            web_config["http"] = (
-                {"redirections": {"entryPoint": {"to": "websecure", "scheme": "https"}}},
-            )
+            web_config["http"] = {
+                "redirections": {"entryPoint": {"to": "websecure", "scheme": "https"}},
+            }
 
         # TODO Disable static config with telemetry and check new version
         raw_config = {


### PR DESCRIPTION
## Issue
Due to python's tricky syntax, a hard to spot regression sneaked into #298:
The [redirections](https://doc.traefik.io/traefik/routing/entrypoints/#redirection) was placed in a tuple, and serialized as a list, whereas it is supposed to be a dict.

As a result, itests [fail](https://github.com/canonical/cos-lite-bundle/actions/runs/8348911023/job/22851889833) with `error: field not found, node: [0]`:
```
ops.pebble.ChangeError: cannot perform the following tasks:
- Start service "traefik" (cannot start service: exited quickly with code 1)
----- Logs from task 1 -----
2024-03-19T20:35:42Z INFO Most recent service output:
    (...)
    time="2024-03-19T20:35:36Z" level=warning msg="No domain found in rule PathPrefix(`/test-bundle-jf9n-prometheus-0`), the TLS options applied for this router will depend on the SNI of each request" entryPointName=websecure routerName=juju-test-bundle-jf9n-prometheus-0-router-tls@file
    time="2024-03-19T20:35:38Z" level=debug msg="Configuration received: {\"http\":{\"routers\":{\"juju-test-bundle-jf9n-alertmanager-router\":{\"entryPoints\":[\"web\"],\"middlewares\":[\"juju-sidecar-noprefix-test-bundle-jf9n-alertmanager\"],\"service\":\"juju-test-bundle-jf9n-alertmanager-service\",\"rule\":\"PathPrefix(`/test-bundle-jf9n-alertmanager`)\"},\"juju-test-bundle-jf9n-alertmanager-router-tls\":{\"entryPoints\":[\"websecure\"],\"middlewares\":[\"juju-sidecar-noprefix-test-bundle-jf9n-alertmanager\"],\"service\":\"juju-test-bundle-jf9n-alertmanager-service\",\"rule\":\"PathPrefix(`/test-bundle-jf9n-alertmanager`)\",\"tls\":{}},\"juju-test-bundle-jf9n-catalogue-router\":{\"entryPoints\":[\"web\"],\"middlewares\":[\"juju-sidecar-noprefix-test-bundle-jf9n-catalogue\"],\"service\":\"juju-test-bundle-jf9n-catalogue-service\",\"rule\":\"PathPrefix(`/test-bundle-jf9n-catalogue`)\"},\"juju-test-bundle-jf9n-catalogue-router-tls\":{\"entryPoints\":[\"websecure\"],\"middlewares\":[\"juju-sidecar-noprefix-test-bundle-jf9n-catalogue\"],\"service\":\"juju-test-bundle-jf9n-catalogue-service\",\"rule\":\"PathPrefix(`/test-bundle-jf9n-catalogue`)\",\"tls\":{}},\"juju-test-bundle-jf9n-grafana-router\":{\"entryPoints\":[\"web\"],\"middlewares\":[\"juju-sidecar-noprefix-test-bundle-jf9n-grafana\"],\"service\":\"juju-test-bundle-jf9n-grafana-service\",\"rule\":\"PathPrefix(`/test-bundle-jf9n-grafana`)\"},\"juju-test-bundle-jf9n-grafana-router-tls\":{\"entryPoints\":[\"websecure\"],\"service\":\"juju-test-bundle-jf9n-grafana-service\",\"rule\":\"PathPrefix(`/test-bundle-jf9n-grafana`)\",\"tls\":{}},\"juju-test-bundle-jf9n-loki-0-router\":{\"entryPoints\":[\"web\"],\"middlewares\":[\"juju-sidecar-noprefix-test-bundle-jf9n-loki-0\"],\"service\":\"juju-test-bundle-jf9n-loki-0-service\",\"rule\":\"PathPrefix(`/test-bundle-jf9n-loki-0`)\"},\"juju-test-bundle-jf9n-loki-0-router-tls\":{\"entryPoints\":[\"websecure\"],\"middlewares\":[\"juju-sidecar-noprefix-test-bundle-jf9n-loki-0\"],\"service\":\"juju-test-bundle-jf9n-loki-0-service\",\"rule\":\"PathPrefix(`/test-bundle-jf9n-loki-0`)\",\"tls\":{}},\"juju-test-bundle-jf9n-prometheus-0-router\":{\"entryPoints\":[\"web\"],\"middlewares\":[\"juju-sidecar-noprefix-test-bundle-jf9n-prometheus-0\"],\"service\":\"juju-test-bundle-jf9n-prometheus-0-service\",\"rule\":\"PathPrefix(`/test-bundle-jf9n-prometheus-0`)\"},\"juju-test-bundle-jf9n-prometheus-0-router-tls\":{\"entryPoints\":[\"websecure\"],\"middlewares\":[\"juju-sidecar-noprefix-test-bundle-jf9n-prometheus-0\"],\"service\":\"juju-test-bundle-jf9n-prometheus-0-service\",\"rule\":\"PathPrefix(`/test-bundle-jf9n-prometheus-0`)\",\"tls\":{}}},\"services\":{\"juju-test-bundle-jf9n-alertmanager-service\":{\"loadBalancer\":{\"servers\":[{\"url\":\"http://alertmanager-1.alertmanager-endpoints.test-bundle-jf9n.svc.cluster.local:9093\"},{\"url\":\"http://alertmanager-0.alertmanager-endpoints.test-bundle-jf9n.svc.cluster.local:9093\"}],\"passHostHeader\":true}},\"juju-test-bundle-jf9n-catalogue-service\":{\"loadBalancer\":{\"servers\":[{\"url\":\"http://catalogue-0.catalogue-endpoints.test-bundle-jf9n.svc.cluster.local:80\"}],\"passHostHeader\":true}},\"juju-test-bundle-jf9n-grafana-service\":{\"loadBalancer\":{\"servers\":[{\"url\":\"http://grafana-0.grafana-endpoints.test-bundle-jf9n.svc.cluster.local:3000\"}],\"passHostHeader\":true}},\"juju-test-bundle-jf9n-loki-0-service\":{\"loadBalancer\":{\"servers\":[{\"url\":\"https://loki-0.loki-endpoints.test-bundle-jf9n.svc.cluster.local:3100\"}],\"passHostHeader\":true,\"serversTransport\":\"endToEndTLS\"}},\"juju-test-bundle-jf9n-prometheus-0-service\":{\"loadBalancer\":{\"servers\":[{\"url\":\"http://prometheus-0.prometheus-endpoints.test-bundle-jf9n.svc.cluster.local:9090\"}],\"passHostHeader\":true}}},\"middlewares\":{\"juju-sidecar-noprefix-test-bundle-jf9n-alertmanager\":{\"stripPrefix\":{\"prefixes\":[\"/test-bundle-jf9n-alertmanager\"]}},\"juju-sidecar-noprefix-test-bundle-jf9n-catalogue\":{\"stripPrefix\":{\"prefixes\":[\"/test-bundle-jf9n-catalogue\"]}},\"juju-sidecar-noprefix-test-bundle-jf9n-grafana\":{\"stripPrefix\":{\"prefixes\":[\"/test-bundle-jf9n-grafana\"]}},\"juju-sidecar-noprefix-test-bundle-jf9n-loki-0\":{\"stripPrefix\":{\"prefixes\":[\"/test-bundle-jf9n-loki-0\"]}},\"juju-sidecar-noprefix-test-bundle-jf9n-prometheus-0\":{\"stripPrefix\":{\"prefixes\":[\"/test-bundle-jf9n-prometheus-0\"]}}},\"serversTransports\":{\"endToEndTLS\":{}}},\"tcp\":{},\"udp\":{},\"tls\":{\"stores\":{\"default\":{}}}}" providerName=file
    time="2024-03-19T20:35:38Z" level=debug msg="Skipping unchanged configuration." providerName=file
    time="2024-03-19T20:35:39Z" level=info msg="I have to go..."
    time="2024-03-19T20:35:39Z" level=info msg="Stopping server gracefully"
    time="2024-03-19T20:35:39Z" level=debug msg="Waiting 10s seconds before killing connections." entryPointName=websecure
    time="2024-03-19T20:35:39Z" level=debug msg="Waiting 10s seconds before killing connections." entryPointName=diagnostics
    time="2024-03-19T20:35:39Z" level=debug msg="Waiting 10s seconds before killing connections." entryPointName=web
    time="2024-03-19T20:35:39Z" level=error msg="accept tcp [::]:443: use of closed network connection" entryPointName=websecure
    time="2024-03-19T20:35:39Z" level=error msg="Error while starting server: accept tcp [::]:443: use of closed network connection" entryPointName=websecure
    time="2024-03-19T20:35:39Z" level=error msg="accept tcp [::]:8082: use of closed network connection" entryPointName=diagnostics
    time="2024-03-19T20:35:39Z" level=error msg="Error while starting server: accept tcp [::]:8082: use of closed network connection" entryPointName=diagnostics
    time="2024-03-19T20:35:39Z" level=error msg="accept tcp [::]:80: use of closed network connection" entryPointName=web
    time="2024-03-19T20:35:39Z" level=error msg="Error while starting server: accept tcp [::]:80: use of closed network connection" entryPointName=web
    time="2024-03-19T20:35:39Z" level=debug msg="Entry point websecure closed" entryPointName=websecure
    time="2024-03-19T20:35:39Z" level=debug msg="Entry point diagnostics closed" entryPointName=diagnostics
    time="2024-03-19T20:35:39Z" level=debug msg="Entry point web closed" entryPointName=web
    time="2024-03-19T20:35:39Z" level=info msg="Server stopped"
    time="2024-03-19T20:35:39Z" level=info msg="Shutting down"
    2024/03/19 20:35:42 command /bin/traefik error: field not found, node: [0]
2024-03-19T20:35:42Z ERROR cannot start service: exited quickly with code 1
```


## Solution
Use dict, not tuple notation.


## Context
This was discovered in the bundle tests because we have TLS tests there, but not here.


## Testing
1. Run bundle tests `tox -e integration -- --keep-models` (they will fail).
2. Refresh traefik from this PR: `juju refresh --path ./traefik-k8s_ubuntu-20.04-amd64.charm traefik --trust`.