### PR TITLE
fix: tell type checkers that the config options are strings

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,7 @@ import itertools
 import json
 import logging
 import socket
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, cast
 from urllib.parse import urlparse
 
 import yaml
@@ -946,7 +946,7 @@ class TraefikIngressCharm(CharmBase):
         returns None. Only use this directly when external_host is allowed to be None.
         """
         if external_hostname := self.model.config.get("external_hostname"):
-            return external_hostname
+            return cast(str, external_hostname)
 
         return _get_loadbalancer_status(namespace=self.model.name, service_name=self.app.name)
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

ops<=2.12 wrongly has `self.config[x]` typed as `str`, when actually it could be an int, float, bool, or str, depending on the config type. We're fixing this in [ops:#1183](https://github.com/canonical/operator/pull/1183), but that will break static checking that currently assumes that the config is a str (because ops doesn't validate the schema, so all options will be bool|int|float|str).

## Solution
<!-- A summary of the solution addressing the above issue -->

This PR adds a `typing.cast` call where the config values are loaded and used where the type should be str.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

N/A

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Run `tox -e static-charm` with / without this change, with ops 2.12 and ops 2.13 (or the PR linked above if before that release).

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->

N/A