### PR TITLE
fix server_cert return type

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -344,6 +344,7 @@ class TraefikIngressCharm(CharmBase):
         """Server certificate path for tls tracing."""
         if self._is_tls_enabled():
             return SERVER_CERT_PATH
+        return None
 
     def _is_tls_enabled(self) -> bool:
         """Return True if TLS is enabled."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -342,7 +342,8 @@ class TraefikIngressCharm(CharmBase):
     @property
     def server_cert(self) -> Optional[str]:
         """Server certificate path for tls tracing."""
-        return SERVER_CERT_PATH
+        if self._is_tls_enabled():
+            return SERVER_CERT_PATH
 
     def _is_tls_enabled(self) -> bool:
         """Return True if TLS is enabled."""


### PR DESCRIPTION
return none from server_cert if tls is disabled. Otherwise tracing will raise an OSError when it fails to find the cert at that path.
