### PR TITLE
Open ServicePort for entrypoints passed via static traefik_route

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -448,6 +448,17 @@ class TraefikIngressCharm(CharmBase):
                     entrypoint_name = self._get_prefix(data)  # type: ignore
                     entrypoints[entrypoint_name] = data["port"]
 
+        # for each static config sent via traefik_route add provided entryPoints to open a ServicePort
+        static_configs = self._traefik_route_static_configs()
+        for config in static_configs:
+            if "entryPoints" in config:
+                provided_entrypoints = config["entryPoints"]
+                for entrypoint_name, value in provided_entrypoints.items():
+                    # TODO names can be only lower-case alfanumeric with dashes. Should we validate and replace?
+                    # ref https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+                    if "address" in value:
+                        entrypoints[entrypoint_name] = value["address"].replace(":", "")
+
         return entrypoints
 
     def _configure_traefik(self):

--- a/src/charm.py
+++ b/src/charm.py
@@ -454,7 +454,7 @@ class TraefikIngressCharm(CharmBase):
             if "entryPoints" in config:
                 provided_entrypoints = config["entryPoints"]
                 for entrypoint_name, value in provided_entrypoints.items():
-                    # TODO names can be only lower-case alfanumeric with dashes. Should we validate and replace?
+                    # TODO names can be only lower-case alphanumeric with dashes. Should we validate and replace?
                     # ref https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
                     if "address" in value:
                         entrypoints[entrypoint_name] = value["address"].replace(":", "")

--- a/tests/integration/test_charm_route.py
+++ b/tests/integration/test_charm_route.py
@@ -63,12 +63,12 @@ async def test_static_config_updated(ops_test: OpsTest):
     contents = proc.stdout.read()
     contents_yaml = yaml.safe_load(contents)
     # the route tester charm does:
-    # static = {"entryPoints": {"testPort": {"address": ":4545"}}},
-    assert contents_yaml["entryPoints"]["testPort"] == {"address": ":4545"}
+    # static = {"entryPoints": {"test-port": {"address": ":4545"}}},
+    assert contents_yaml["entryPoints"]["test-port"] == {"address": ":4545"}
 
 
 async def test_added_entrypoint_reachable(ops_test: OpsTest):
-    traefik_ip = await get_address(ops_test, APP_NAME, unit_num=0)
+    traefik_ip = await get_address(ops_test, APP_NAME)
 
     req = Request(f"http://{traefik_ip}:4545")
 

--- a/tests/integration/testers/route/src/charm.py
+++ b/tests/integration/testers/route/src/charm.py
@@ -15,7 +15,7 @@ class RouteRequirerMock(CharmBase):
         if self.traefik_route.is_ready():
             self.traefik_route.submit_to_traefik(
                 config={"some": "config"},
-                static={"entryPoints": {"testPort": {"address": ":4545"}}},
+                static={"entryPoints": {"test-port": {"address": ":4545"}}},
             )
         self.unit.status = ActiveStatus("ready")
 

--- a/tests/unit/test_route.py
+++ b/tests/unit/test_route.py
@@ -1,6 +1,7 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 """Helpers for unit testing charms which use this library."""
+import os
 from unittest.mock import Mock, patch
 
 import ops
@@ -315,6 +316,5 @@ def test_static_config_updates_tcp_entrypoints(harness: Harness[TraefikIngressCh
     tcp_entrypoints = charm._tcp_entrypoints()
     assert tcp_entrypoints["shondaland"] == "6767"
 
-    # AND open one more service port next to web, websecure
-    service_ports = charm._service_ports
-    assert len(service_ports) == 3
+    # AND that shows up in the service ports
+    assert [p for p in charm._service_ports if p.port == 6767][0]

--- a/tests/unit/test_route.py
+++ b/tests/unit/test_route.py
@@ -280,3 +280,41 @@ def test_static_config_partially_broken(harness: Harness[TraefikIngressCharm]):
     assert generated_config["barbaras"] == {"rhabarber": "bar"}
     assert generated_config["entryPoints"]["shondaland"]["address"] == ":6767"
     assert generated_config["foo"] == {"bar": "baz"}
+
+
+def test_static_config_updates_tcp_entrypoints(harness: Harness[TraefikIngressCharm]):
+    tr_relation_id, relation = initialize_and_setup_tr_relation(harness)
+    config = yaml.dump(CONFIG)
+    static = yaml.safe_dump({"entryPoints": {"shondaland": {"address": ":6767"}}})
+
+    with harness.hooks_disabled():
+        # don't emit yet: we need to reinitialize Traefik first.
+        harness.update_relation_data(
+            tr_relation_id,
+            REMOTE_APP_NAME,
+            {
+                "config": config,
+                "static": static,
+            },
+        )
+
+    # reinitialize Traefik, else _traefik_route_static_configs won't be passed to Traefik on init.
+    charm = harness.charm
+    charm.traefik = Traefik(
+        container=charm.container,
+        routing_mode=charm._routing_mode,
+        tcp_entrypoints=charm._tcp_entrypoints(),
+        tls_enabled=charm._is_tls_enabled(),
+        experimental_forward_auth_enabled=charm._is_forward_auth_enabled,
+        traefik_route_static_configs=charm._traefik_route_static_configs(),
+    )
+
+    charm.traefik_route.on.ready.emit(charm.model.get_relation("traefik-route"))
+
+    # THEN Traefik can list the provided entrypoints
+    tcp_entrypoints = charm._tcp_entrypoints()
+    assert tcp_entrypoints["shondaland"] == "6767"
+
+    # AND open one more service port next to web, websecure
+    service_ports = charm._service_ports
+    assert len(service_ports) == 3

--- a/tests/unit/test_route.py
+++ b/tests/unit/test_route.py
@@ -1,7 +1,6 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 """Helpers for unit testing charms which use this library."""
-import os
 from unittest.mock import Mock, patch
 
 import ops


### PR DESCRIPTION
## Issue
After #325 we started to add provided `entryPoints` to the static config so that it was possible to route to traefik on custom entrypoints. However, trying to call the same port on juju application ip:${PORT} failed with `Connection refused`. Both in automated and manual tests we verified it by calling the unit's IP, not the external IP (which is later passed in tracing databags).


## Solution
Open ServicePort for entrypoints that are provided via `traefik_route`.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
I updated integration tests for `route`, you can run them with:
```
tox -re integration -- -k test_charm_route --keep-models
````
in order to have a working model you can test manually too. Remember though that the last test removes the relation so you'll need to re-relate tester charm with traefik.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->