### PR TITLE
fix issue with cert not present on charm container

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -730,7 +730,6 @@ class TraefikIngressCharm(CharmBase):
             raise IngressSetupError("traefik is not ready")
 
         provider = self._provider_from_relation(relation)
-        logger.warning(f"provider: {provider}")
 
         if not provider.is_ready(relation):
             logger.debug(f"Provider {provider} not ready; resetting ingress configurations.")

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,7 +10,7 @@ import itertools
 import json
 import logging
 import socket
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union, cast
 from urllib.parse import urlparse
 
 import yaml
@@ -412,7 +412,11 @@ class TraefikIngressCharm(CharmBase):
             and self.config.get("tls-cert", None)
             and self.config.get("tls-key", None)
         ):
-            return self.config["tls-cert"], self.config["tls-key"], self.config["tls-ca"]
+            return (
+                cast(str, self.config["tls-cert"]),
+                cast(str, self.config["tls-key"]),
+                cast(str, self.config["tls-ca"]),
+            )
         return cert_handler.chain, cert_handler.private_key, cert_handler.ca_cert
 
     def _on_show_proxied_endpoints(self, event: ActionEvent):
@@ -1058,7 +1062,7 @@ class TraefikIngressCharm(CharmBase):
         returns None. Only use this directly when external_host is allowed to be None.
         """
         if external_hostname := self.model.config.get("external_hostname"):
-            return external_hostname
+            return cast(str, external_hostname)
 
         return _get_loadbalancer_status(namespace=self.model.name, service_name=self.app.name)
 

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -162,6 +162,8 @@ class Traefik:
     ):
         """Update the server cert, ca, and key configuration files."""
         if cert:
+            # write it to the charm container too, for charm tracing.
+            Path(SERVER_CERT_PATH).write_text(cert)
             self._container.push(SERVER_CERT_PATH, cert, make_dirs=True)
         else:
             self._container.remove_path(SERVER_CERT_PATH, recursive=True)

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -163,7 +163,9 @@ class Traefik:
         """Update the server cert, ca, and key configuration files."""
         if cert:
             # write it to the charm container too, for charm tracing.
-            Path(SERVER_CERT_PATH).write_text(cert)
+            local_cert_path = Path(SERVER_CERT_PATH)
+            local_cert_path.parent.mkdir(parents=True, exist_ok=True)
+            local_cert_path.write_text(cert)
             self._container.push(SERVER_CERT_PATH, cert, make_dirs=True)
         else:
             self._container.remove_path(SERVER_CERT_PATH, recursive=True)

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,8 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    pytest
+    # pinned for https://github.com/charmed-kubernetes/pytest-operator/issues/131
+    pytest==8.1.1
 
     # fix for https://github.com/pytest-dev/pytest-asyncio/releases/tag/v0.23.0 making pytest-operator b0rk
     pytest-asyncio==0.21.0


### PR DESCRIPTION
## Issue

`server_cert` returns `SERVER_CERT_PATH`, but the cert is only ever pushed to the workload container, never written to the charm container. Consequently charm tracing breaks with tls because the path doesn't exist.

Also, removed a pointless warning log.


## Solution
when you push the cert to the workload container, also write it to the charm container


## Testing Instructions
deploy with tls enabled and watch it burn because other things are broken with tls. But this is definitely an issue too.

