### PR TITLE
Refactor `_get_loadbalancer_status`

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1141,7 +1141,6 @@ def _get_loadbalancer_status(namespace: str, service_name: str) -> Optional[str]
     return ingress_address.hostname or ingress_address.ip
 
 
-
 def _get_relation_type(relation: Relation) -> _IngressRelationType:
     if relation.name == "ingress":
         return _IngressRelationType.per_app

--- a/src/charm.py
+++ b/src/charm.py
@@ -1138,7 +1138,7 @@ def _get_loadbalancer_status(namespace: str, service_name: str) -> Optional[str]
     if not (ingress_address := ingress_addresses[0]):
         return None
 
-    return ingress_address.hostname or ingress_address.ip
+    return ingress_address.ip
 
 
 def _get_relation_type(relation: Relation) -> _IngressRelationType:

--- a/src/charm.py
+++ b/src/charm.py
@@ -1129,12 +1129,17 @@ def _get_loadbalancer_status(namespace: str, service_name: str) -> Optional[str]
     client = Client()  # type: ignore
     traefik_service = client.get(Service, name=service_name, namespace=namespace)
 
-    if status := traefik_service.status:  # type: ignore
-        if load_balancer_status := status.loadBalancer:
-            if ingress_addresses := load_balancer_status.ingress:
-                if ingress_address := ingress_addresses[0]:
-                    return ingress_address.hostname or ingress_address.ip
-    return None
+    if not (status := traefik_service.status):  # type: ignore
+        return None
+    if not (load_balancer_status := status.loadBalancer):
+        return None
+    if not (ingress_addresses := load_balancer_status.ingress):
+        return None
+    if not (ingress_address := ingress_addresses[0]):
+        return None
+
+    return ingress_address.hostname or ingress_address.ip
+
 
 
 def _get_relation_type(relation: Relation) -> _IngressRelationType:

--- a/src/charm.py
+++ b/src/charm.py
@@ -1138,6 +1138,8 @@ def _get_loadbalancer_status(namespace: str, service_name: str) -> Optional[str]
     if not (ingress_address := ingress_addresses[0]):
         return None
 
+    # `return ingress_address.hostname` removed since the hostname (external hostname)
+    # is configured through juju config so it is not necessary to retrieve that from K8s.
     return ingress_address.ip
 
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR refactors `_get_loadbalancer_status` function. 

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

This PR:
- Removes `return ingress_address.hostname` since the hostname (external hostname) is [configured through juju config](https://github.com/canonical/traefik-k8s-operator/blob/main/src/charm.py#L1064) so it is not necessary to retrieve that from K8s
- Remove unnecessary indentation.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Run tests


