### PR TITLE
Use LokiPushApiConsumer not to fetch promtail

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -24,7 +24,7 @@ from charms.certificate_transfer_interface.v0.certificate_transfer import (
     CertificateTransferRequires,
 )
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
-from charms.loki_k8s.v1.loki_push_api import LogProxyConsumer
+from charms.loki_k8s.v1.loki_push_api import LokiPushApiConsumer
 from charms.oathkeeper.v0.forward_auth import (
     AuthConfigChangedEvent,
     AuthConfigRemovedEvent,
@@ -71,7 +71,6 @@ from ops.model import (
 from ops.pebble import PathError
 from traefik import (
     CA,
-    LOG_PATH,
     SERVER_CERT_PATH,
     RoutingMode,
     StaticConfigMergeConflictError,
@@ -200,12 +199,8 @@ class TraefikIngressCharm(CharmBase):
         self._grafana_dashboards = GrafanaDashboardProvider(
             self, relation_name="grafana-dashboard"
         )
-        # Enable log forwarding for Loki and other charms that implement loki_push_api
-        self._logging = LogProxyConsumer(
-            self,
-            logs_scheme={_TRAEFIK_CONTAINER_NAME: {"log-files": [LOG_PATH]}},
-            relation_name="logging",
-        )
+        # Enable logging relation for Loki and other charms that implement loki_push_api
+        self._logging = LokiPushApiConsumer(self)
         self.metrics_endpoint = MetricsEndpointProvider(
             charm=self,
             jobs=self.traefik.scrape_jobs,


### PR DESCRIPTION
## Issue
Traefik was using `LogProxyConsumer` that fetches and uses promtail to gather logs. This can cause issues in airgapped environments where promtail binary might not be accessible.
Fixes canonical/prometheus-k8s-operator#580.

## Solution
As we cannot move to `LogForwarder` yet (requires Juju 3.4+) and traefik's logs are already known not to show up in Loki at the moment, keep the `logging` integration for future use (see canonical/loki-k8s-operator#392) and no upgrade surprises in environments where that relation can already be present; however replace it with `LokiPushApiConsumer` that doesn't fetch promtail (and without configuration doesn't pass logs either).


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
Deploy the following bundle and verify promtail isn't present on charm container (`/tmp`) and workload container (`/etc`):
```
bundle: kubernetes
applications:
  alertmanager:
    charm: alertmanager-k8s
    channel: latest/edge
    revision: 115
    resources:
      alertmanager-image: 91
    scale: 1
    constraints: arch=amd64
    storage:
      data: kubernetes,1,1024M
    trust: true
  catalogue:
    charm: catalogue-k8s
    channel: latest/edge
    revision: 39
    resources:
      catalogue-image: 32
    scale: 1
    options:
      description: "Canonical Observability Stack Lite, or COS Lite, is a light-weight,
        highly-integrated, \nJuju-based observability suite running on Kubernetes.\n"
      tagline: Model-driven Observability Stack deployed with a single command.
      title: Canonical Observability Stack
    constraints: arch=amd64
    trust: true
  grafana:
    charm: grafana-k8s
    channel: latest/edge
    revision: 113
    resources:
      grafana-image: 68
      litestream-image: 43
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  loki:
    charm: loki-k8s
    channel: latest/edge
    revision: 148
    resources:
      loki-image: 95
      node-exporter-image: 1
    scale: 1
    constraints: arch=amd64
    storage:
      active-index-directory: kubernetes,1,1024M
      loki-chunks: kubernetes,1,1024M
    trust: true
  prometheus:
    charm: prometheus-k8s
    channel: latest/edge
    revision: 189
    resources:
      prometheus-image: 144
    scale: 1
    constraints: arch=amd64
    storage:
      database: kubernetes,1,1024M
    trust: true
  traefik-k8s:
    charm: local:traefik-k8s-0
    scale: 1
    constraints: arch=amd64
    storage:
      configurations: kubernetes,1,1024M
    trust: true
relations:
- - prometheus:alertmanager
  - alertmanager:alerting
- - grafana:grafana-source
  - prometheus:grafana-source
- - grafana:grafana-source
  - loki:grafana-source
- - grafana:grafana-source
  - alertmanager:grafana-source
- - loki:alertmanager
  - alertmanager:alerting
- - prometheus:metrics-endpoint
  - alertmanager:self-metrics-endpoint
- - prometheus:metrics-endpoint
  - loki:metrics-endpoint
- - prometheus:metrics-endpoint
  - grafana:metrics-endpoint
- - grafana:grafana-dashboard
  - loki:grafana-dashboard
- - grafana:grafana-dashboard
  - prometheus:grafana-dashboard
- - grafana:grafana-dashboard
  - alertmanager:grafana-dashboard
- - catalogue:catalogue
  - grafana:catalogue
- - catalogue:catalogue
  - prometheus:catalogue
- - catalogue:catalogue
  - alertmanager:catalogue
- - catalogue:catalogue
  - loki:catalogue
- - loki:logging
  - traefik-k8s:logging
- - traefik-k8s:ingress
  - alertmanager:ingress
- - traefik-k8s:ingress
  - catalogue:ingress
- - traefik-k8s:grafana-dashboard
  - grafana:grafana-dashboard
- - traefik-k8s:traefik-route
  - grafana:ingress
- - traefik-k8s:ingress-per-unit
  - loki:ingress
- - traefik-k8s:ingress-per-unit
  - prometheus:ingress
- - traefik-k8s:metrics-endpoint
  - prometheus:metrics-endpoint
```




## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
