### PR TITLE
better error for proxied endpoints failure

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -430,7 +430,8 @@ class TraefikIngressCharm(CharmBase):
             try:
                 result.update(provider.proxied_endpoints)
             except Exception as e:
-                msg = f"failed to fetch proxied endpoints from provider {provider} with error {e}."
+                name = provider.app.name
+                msg = f"failed to fetch proxied endpoints from {name} with error {e}."
                 event.log(msg)
 
         event.set_results({"proxied-endpoints": json.dumps(result)})

--- a/src/charm.py
+++ b/src/charm.py
@@ -430,8 +430,8 @@ class TraefikIngressCharm(CharmBase):
             try:
                 result.update(provider.proxied_endpoints)
             except Exception as e:
-                name = provider.app.name
-                msg = f"failed to fetch proxied endpoints from {name} with error {e}."
+                name = provider.relations[0].app.name
+                msg = f"failed to fetch proxied endpoints from remote app {name!r} with error {e}."
                 event.log(msg)
 
         event.set_results({"proxied-endpoints": json.dumps(result)})

--- a/src/charm.py
+++ b/src/charm.py
@@ -430,8 +430,15 @@ class TraefikIngressCharm(CharmBase):
             try:
                 result.update(provider.proxied_endpoints)
             except Exception as e:
-                name = provider.relations[0].app.name
-                msg = f"failed to fetch proxied endpoints from remote app {name!r} with error {e}."
+                remote_app_names = [
+                    # relation.app could be None
+                    (relation.app.name if relation.app else "<unknown-remote>")
+                    for relation in provider.relations
+                ]
+                msg = (
+                    f"failed to fetch proxied endpoints from (at least one of) the "
+                    f"remote apps {remote_app_names!r} with error {e}."
+                )
                 event.log(msg)
 
         event.set_results({"proxied-endpoints": json.dumps(result)})


### PR DESCRIPTION
## Issue
right now you get:

```
❯ j run trfk/0 show-proxied-endpoints                                                                                                                           
Running operation 1 with 1 task                                                                                                                                 
  - task 2 on unit-trfk-0                                                                                                                                       
                                                                                                                                                                
Waiting for task 2...                                                                                                                                           
14:11:28 failed to fetch proxied endpoints from provider <charms.traefik_k8s.v1.ingress.IngressPerAppProvider object at 0x7bdba14b4d90> with error This applicat
ion did not `publish_url` yet..                                                                                                                                 
                                                                                                                                                                
proxied-endpoints: '{"trfk": {"url": "http://10.64.140.44"}}'                                                                       
```

## Solution

Much nicer:

```
❯ j run trfk/0 show-proxied-endpoints                                                                                                                           
Running operation 1 with 1 task                                                                                                                                 
  - task 2 on unit-trfk-0                                                                                                                                       
                                                                                                                                                                
Waiting for task 2...                                                                                                                                           
14:11:28 failed to fetch proxied endpoints from [name-of-remote-app] with error This applicat
ion did not `publish_url` yet..                                                                                                                                 
                                                                                                                                                                
proxied-endpoints: '{"trfk": {"url": "http://10.64.140.44"}}'                                                                       
```

## Testing Instructions
`juju deploy tempo-k8s`
`juju relate traefik:ingress tempo-k8s`
# soon after (don't wait for idle):
`juju run show-proxied-endpoints` 
