### PR TITLE
Drop 'v' prefix from workload version

### DIFF
--- a/src/traefik.py
+++ b/src/traefik.py
@@ -663,13 +663,13 @@ class Traefik:
         """Traefik workload version."""
         version_output, _ = self._container.exec([BIN_PATH, "version"]).wait_output()
         # Output looks like this:
-        # Version:      2.9.6
-        # Codename:     banon
-        # Go version:   go1.18.9
-        # Built:        2022-12-07_04:28:37PM
+        # Version:      v2.11.0
+        # Codename:     mimolette
+        # Go version:   go1.22.1
+        # Built:        2024-03-14_05:12:45PM
         # OS/Arch:      linux/amd64
 
-        if result := re.search(r"Version:\s*(.+)", version_output):
+        if result := re.search(r"Version:\s*v?(.+)", version_output):
             return result.group(1)
         return None
 


### PR DESCRIPTION
## Issue
Traefik's workload version has a 'v' prefix, which is redundant under the "Version" column.

```
App           Version  Status  Scale  Charm                     Channel      Rev  Address         Exposed  Message
alertmanager  0.27.0   active      1  alertmanager-k8s          latest/edge  119  10.152.183.222  no       
ca                     active      1  self-signed-certificates  latest/edge  144  10.152.183.246  no       
catalogue              active      1  catalogue-k8s             latest/edge   43  10.152.183.108  no       
grafana       9.5.3    active      1  grafana-k8s               latest/edge  114  10.152.183.198  no       
loki          2.9.6    active      1  loki-k8s                  latest/edge  151  10.152.183.238  no       
prometheus    2.50.1   active      1  prometheus-k8s            latest/edge  189  10.152.183.83   no       
traefik       v2.11.0  active      1  traefik-k8s               latest/edge  194  10.152.183.196  no       Serving at 10.196.135.67
```


## Solution
Drop potential 'v' prefix.