### PR TITLE
adapted charm and tracing test code ready for new tracing and charm_tracing libs

### DIFF
--- a/tests/scenario/test_tracing_integration.py
+++ b/tests/scenario/test_tracing_integration.py
@@ -4,7 +4,7 @@ import opentelemetry
 import pytest
 import yaml
 from charms.tempo_k8s.v1.charm_tracing import charm_tracing_disabled
-from charms.tempo_k8s.v2.tracing import Receiver, TracingProviderAppData
+from charms.tempo_k8s.v2.tracing import ProtocolType, Receiver, TracingProviderAppData
 from scenario import Relation, State
 from traefik import CA_CERT_PATH, DYNAMIC_TRACING_PATH
 
@@ -13,7 +13,12 @@ from traefik import CA_CERT_PATH, DYNAMIC_TRACING_PATH
 def tracing_relation():
     db = {}
     TracingProviderAppData(
-        host="foo.com", receivers=[Receiver(protocol="otlp_http", port=81)]
+        receivers=[
+            Receiver(
+                url="http://foo.com:81",
+                protocol=ProtocolType(name="otlp_http", type="http"),
+            )
+        ]
     ).dump(db)
     tracing = Relation("tracing", remote_app_data=db)
     return tracing


### PR DESCRIPTION
Currently the CI is bork because the new tracing lib has a new tracing protocol interface version.
Also charm_tracing has some changes we want to try out.

This will need to wait for tempo to release the new charm_tracing and tracing libraries.

https://github.com/canonical/tempo-k8s-operator/pull/135
https://github.com/canonical/tempo-k8s-operator/pull/136



Once that is done, we can fetch_lib and this branch should work.