### PR TITLE
feat: disable checknewversion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,6 @@ markers = [
     "teardown: tests that mutate the model topology by removing stuff (deselect with '-m \"not teardown\"')",
 ]
 
-[tool.pyright]
-reportTypedDictNotRequiredAccess = false
-
 # Formatting tools configuration
 [tool.black]
 line-length = 99
@@ -38,5 +35,14 @@ ignore = ["E501", "D107", "N818", "RET504"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
 per-file-ignores = {"*tests/*" = ["D100","D101","D102","D103","D104"]}
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
+
+[tool.pyright]
+reportTypedDictNotRequiredAccess = false
+extraPaths = ["lib"]
+pythonVersion = "3.8"
+pythonPlatform = "All"
+
+[tool.codespell]
+skip = ".git,.tox,build,venv*"

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -238,8 +238,13 @@ class Traefik:
                 "redirections": {"entryPoint": {"to": "websecure", "scheme": "https"}},
             }
 
-        # TODO Disable static config with telemetry and check new version
         static_config = {
+            "global": {
+                "checknewversion": False,
+                # TODO add juju config to disable anonymous usage
+                # https://github.com/canonical/observability/blob/main/decision-records/2026-06-27--upstream-telemetry.md
+                "sendanonymoususage": True,
+            },
             "log": {
                 "level": "DEBUG",
             },

--- a/tox.ini
+++ b/tox.ini
@@ -40,8 +40,7 @@ deps =
     codespell
 commands =
     codespell {[vars]lib_path}
-    codespell . --skip .git --skip .tox --skip build --skip lib --skip venv* \
-      --skip .mypy_cache --skip icon.svg
+    codespell .
     ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 


### PR DESCRIPTION
## Issue
Closes #314.


## Solution
Disable the global `checknewversion` option in the static config.
I also added the `sendanonymoususage` (send anonymous usage) config option, leaving it to its default value of `True`. According to the ADR I linked, we should have a config option to turn it off, but I'm leaving that out of this PR :)

