### PR TITLE
revert return line of _get_loadbalancer_status function

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -1188,9 +1188,7 @@ def _get_loadbalancer_status(namespace: str, service_name: str) -> Optional[str]
     if not (ingress_address := ingress_addresses[0]):
         return None
 
-    # `return ingress_address.hostname` removed since the hostname (external hostname)
-    # is configured through juju config so it is not necessary to retrieve that from K8s.
-    return ingress_address.ip
+    return ingress_address.hostname or ingress_address.ip
 
 
 def _get_relation_type(relation: Relation) -> _IngressRelationType:


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR fixes  #378

## Solution
<!-- A summary of the solution addressing the above issue -->

We only reverted the `return` statement of `_get_loadbalancer_status` function
