### PR TITLE
test: increase coverage by testing dynamic TLS config generation for TCP routes

### DIFF
--- a/tests/unit/test_route.py
+++ b/tests/unit/test_route.py
@@ -29,6 +29,20 @@ CONFIG = {
                 "loadBalancer": {"servers": [{"url": "http://foo.testmodel-endpoints.local:8080"}]}
             }
         },
+    },
+    "tcp": {
+        "routers": {
+            "juju-bar-router": {
+                "entryPoints": ["web"],
+                "rule": "PathPrefix(`/path`)",
+                "service": "juju-bar-service",
+            }
+        },
+        "services": {
+            "juju-bar-service": {
+                "loadBalancer": {"servers": [{"url": "http://bar.testmodel-endpoints.local:8080"}]}
+            }
+        },
     }
 }
 
@@ -57,6 +71,33 @@ CONFIG_WITH_TLS = {
         "services": {
             "juju-foo-service": {
                 "loadBalancer": {"servers": [{"url": "http://foo.testmodel-endpoints.local:8080"}]}
+            }
+        },
+    },
+    "tcp": {
+        "routers": {
+            "juju-bar-router": {
+                "entryPoints": ["web"],
+                "rule": "PathPrefix(`/path`)",
+                "service": "juju-bar-service",
+            },
+            "juju-bar-router-tls": {
+                "entryPoints": ["web"],
+                "rule": "PathPrefix(`/path`)",
+                "service": "juju-bar-service",
+                "tls": {
+                    "domains": [
+                        {
+                            "main": "testhostname",
+                            "sans": ["*.testhostname"],
+                        },
+                    ],
+                },
+            },
+        },
+        "services": {
+            "juju-bar-service": {
+                "loadBalancer": {"servers": [{"url": "http://bar.testmodel-endpoints.local:8080"}]}
             }
         },
     }


### PR DESCRIPTION
This PR add to the unit tests coverage in the function `_update_dynamic_config_route`, for the cases where `'tcp'` routes are passed in the Charm configuration

## Issue
The unit tests do not cover the case of dynamic TLS configuration generation for TCP routes.


## Solution
In the mock configuration passed to the unit tests, add TCP routes as well as their expected TLS auto-generated configuration.


