### PR TITLE
fix: reorder imports for ruff 0.6.x

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -70,6 +70,7 @@ from ops.model import (
     WaitingStatus,
 )
 from ops.pebble import PathError
+
 from traefik import (
     CA,
     SERVER_CERT_PATH,

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -18,6 +18,7 @@ import yaml
 from charms.oathkeeper.v0.forward_auth import ForwardAuthConfig
 from ops import Container
 from ops.pebble import LayerDict, PathError
+
 from utils import is_hostname
 
 logger = logging.getLogger(__name__)

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -3,10 +3,11 @@
 from unittest.mock import patch
 
 import pytest
-from charm import TraefikIngressCharm
 from interface_tester import InterfaceTester
 from ops.pebble import Layer
 from scenario.state import Container, ExecOutput, State
+
+from charm import TraefikIngressCharm
 
 
 # Interface tests are centrally hosted at https://github.com/canonical/charm-relation-interfaces.

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -1,9 +1,10 @@
 from unittest.mock import PropertyMock, patch
 
 import pytest
-from charm import TraefikIngressCharm
 from ops import pebble
 from scenario import Container, Context, ExecOutput, Model, Mount
+
+from charm import TraefikIngressCharm
 
 MOCK_EXTERNAL_HOSTNAME = "testhostname"
 

--- a/tests/scenario/test_setup.py
+++ b/tests/scenario/test_setup.py
@@ -5,8 +5,9 @@
 
 from unittest.mock import PropertyMock, patch
 
-from charm import TraefikIngressCharm
 from scenario import Container, Context, State
+
+from charm import TraefikIngressCharm
 from traefik import Traefik
 
 

--- a/tests/scenario/test_tracing_integration.py
+++ b/tests/scenario/test_tracing_integration.py
@@ -6,6 +6,7 @@ import yaml
 from charms.tempo_k8s.v1.charm_tracing import charm_tracing_disabled
 from charms.tempo_k8s.v2.tracing import ProtocolType, Receiver, TracingProviderAppData
 from scenario import Relation, State
+
 from traefik import CA_CERT_PATH, DYNAMIC_TRACING_PATH
 
 

--- a/tests/scenario/test_workload_version.py
+++ b/tests/scenario/test_workload_version.py
@@ -4,9 +4,10 @@
 import unittest
 from unittest.mock import PropertyMock, patch
 
-from charm import TraefikIngressCharm
 from ops.model import ActiveStatus
 from scenario import Container, Context, State
+
+from charm import TraefikIngressCharm
 
 
 @patch("charm.KubernetesServicePatch")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,12 +8,13 @@ from unittest.mock import Mock, patch
 
 import ops.testing
 import yaml
-from charm import TraefikIngressCharm
 from charms.traefik_k8s.v2.ingress import IngressRequirerAppData, IngressRequirerUnitData
 from ops.charm import ActionEvent
 from ops.model import ActiveStatus, Application, BlockedStatus, Relation, WaitingStatus
 from ops.pebble import PathError
 from ops.testing import Harness
+
+from charm import TraefikIngressCharm
 from traefik import STATIC_CONFIG_PATH
 
 ops.testing.SIMULATE_CAN_CONNECT = True

--- a/tests/unit/test_deep_merge.py
+++ b/tests/unit/test_deep_merge.py
@@ -1,4 +1,5 @@
 import pytest
+
 from traefik import StaticConfigMergeConflictError, static_config_deep_merge
 
 

--- a/tests/unit/test_route.py
+++ b/tests/unit/test_route.py
@@ -6,8 +6,9 @@ from unittest.mock import Mock, patch
 import ops
 import pytest
 import yaml
-from charm import TraefikIngressCharm
 from ops.testing import Harness
+
+from charm import TraefikIngressCharm
 from traefik import StaticConfigMergeConflictError, Traefik
 
 MODEL_NAME = "test-model"

--- a/tests/unit/test_tls_certificates.py
+++ b/tests/unit/test_tls_certificates.py
@@ -5,8 +5,9 @@ import unittest
 from unittest.mock import patch
 
 import ops.testing
-from charm import TraefikIngressCharm
 from ops.testing import Harness
+
+from charm import TraefikIngressCharm
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 


### PR DESCRIPTION
## Issue
Linting currently fails due to change in how ruff 0.6.x orders imports

## Solution
Run `tox -e fmt`

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
