### PR TITLE
basic auth support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,15 @@ options:
       This feature is experimental and may be unstable.
     type: boolean
     default: False
+  basic_auth_user:
+    description: |
+      Enables the `basicAuth` middleware for **all** routes on this proxy. 
+      The format of this string must be: `name:hashed-password`, generated with e.g. htpasswd.
+      Supported hashing algorithms are: MD5, SHA1, BCrypt.
+      For more documentation see https://doc.traefik.io/traefik/middlewares/http/basicauth/
+      Once this config option is set, the username/password pair will be required to authenticate 
+      http requests on all routes proxied by this traefik app.
+    type: string
   external_hostname:
     description: |
       The DNS name to be used by Traefik ingress.

--- a/src/charm.py
+++ b/src/charm.py
@@ -304,7 +304,7 @@ class TraefikIngressCharm(CharmBase):
 
         As we can't reject it, we assume it's correctly formatted.
         """
-        return self.config.get("basic_auth_user", None)
+        return cast(Optional[str], self.config.get("basic_auth_user", None))
 
     def _on_forward_auth_config_changed(self, event: AuthConfigChangedEvent):
         if self._is_forward_auth_enabled:

--- a/src/charm.py
+++ b/src/charm.py
@@ -127,9 +127,7 @@ class TraefikIngressCharm(CharmBase):
         super().__init__(*args)
 
         self._stored.set_default(
-            current_external_host=None,
-            current_routing_mode=None,
-            current_forward_auth_mode=self.config["enable_experimental_forward_auth"],
+            config_hash=None,
         )
 
         self.container = self.unit.get_container(_TRAEFIK_CONTAINER_NAME)
@@ -173,6 +171,7 @@ class TraefikIngressCharm(CharmBase):
             tls_enabled=self._is_tls_enabled(),
             experimental_forward_auth_enabled=self._is_forward_auth_enabled,
             traefik_route_static_configs=self._traefik_route_static_configs(),
+            basic_auth_user=self._basic_auth_user,
         )
 
         self.service_patch = KubernetesServicePatch(
@@ -298,6 +297,14 @@ class TraefikIngressCharm(CharmBase):
         if self.config["enable_experimental_forward_auth"]:
             return True
         return False
+
+    @property
+    def _basic_auth_user(self) -> Optional[str]:
+        """A single user for the global basic auth configuration.
+
+        As we can't reject it, we assume it's correctly formatted.
+        """
+        return self.config.get("basic_auth_user", None)
 
     def _on_forward_auth_config_changed(self, event: AuthConfigChangedEvent):
         if self._is_forward_auth_enabled:
@@ -535,29 +542,41 @@ class TraefikIngressCharm(CharmBase):
         self._process_status_and_configurations()
         self._set_workload_version()
 
+    @property
+    def _config_hash(self) -> int:
+        """A hash of the config of this application.
+
+        Only include here the config options that, should they change, should trigger a recalculation of
+        the traefik config files.
+        The main goal of this logic is to avoid recalculating status and configs on each event,
+        since it can be quite expensive.
+        """
+        return hash(
+            (
+                self._external_host,
+                self.config["routing_mode"],
+                self._is_forward_auth_enabled,
+                self._basic_auth_user,
+                self._is_tls_enabled(),
+            )
+        )
+
     def _on_config_changed(self, _: ConfigChangedEvent):
-        # If the external hostname is changed since we last processed it, we need to
-        # reconsider all data sent over the relations and all configs
-        new_external_host = self._external_host
-        new_routing_mode = self.config["routing_mode"]
-        new_forward_auth_mode = self._is_forward_auth_enabled
+        """Handle the ops.ConfigChanged event."""
+        # that we're processing a config-changed event, doesn't necessarily mean that our config has changed (duh!)
 
-        # TODO set BlockedStatus here when compound_status is introduced
-        #  https://github.com/canonical/operator/issues/665
+        # If the config hash has changed since we last calculated it, we need to
+        # recompute our state from scratch, based on all data sent over the relations and all configs
+        new_config_hash = self._config_hash
+        if self._stored.config_hash != new_config_hash:
+            self._stored.config_hash = new_config_hash
 
-        if (
-            self._stored.current_external_host != new_external_host  # type: ignore
-            or self._stored.current_routing_mode != new_routing_mode  # type: ignore
-            or self._stored.current_forward_auth_mode != new_forward_auth_mode  # type: ignore
-        ):
-            self._process_status_and_configurations()
-            self._stored.current_external_host = new_external_host  # type: ignore
-            self._stored.current_routing_mode = new_routing_mode  # type: ignore
-            self._stored.current_forward_auth_mode = new_forward_auth_mode  # type: ignore
+            if self._is_tls_enabled():
+                # we keep this nested under the hash-check because, unless the tls config has
+                # changed, we don't need to redo this.
+                self._update_cert_configs()
+                self._configure_traefik()
 
-        if self._is_tls_enabled():
-            self._update_cert_configs()
-            self._configure_traefik()
             self._process_status_and_configurations()
 
     def _process_status_and_configurations(self):

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -104,6 +104,7 @@ class Traefik:
         experimental_forward_auth_enabled: bool,
         tcp_entrypoints: Dict[str, int],
         traefik_route_static_configs: Iterable[Dict[str, Any]],
+        basic_auth_user: Optional[str] = None,
     ):
         self._container = container
         self._tcp_entrypoints = tcp_entrypoints
@@ -111,6 +112,7 @@ class Traefik:
         self._routing_mode = routing_mode
         self._tls_enabled = tls_enabled
         self._experimental_forward_auth_enabled = experimental_forward_auth_enabled
+        self._basic_auth_user = basic_auth_user
 
     @property
     def scrape_jobs(self) -> list:
@@ -536,6 +538,14 @@ class Traefik:
           "cannot create middleware: multi-types middleware not supported, consider declaring two
           different pieces of middleware instead"
         """
+        basicauth_middleware = {}
+        if basicauth_user := self._basic_auth_user:
+            basicauth_middleware[f"juju-basic-auth-{prefix}"] = {
+                "basicAuth": {
+                    "users": [basicauth_user],
+                }
+            }
+
         forwardauth_middleware = {}
         if self._experimental_forward_auth_enabled:
             if forward_auth_app:
@@ -560,7 +570,12 @@ class Traefik:
                 "redirectScheme": {"scheme": "https", "port": 443, "permanent": True}
             }
 
-        return {**forwardauth_middleware, **no_prefix_middleware, **redir_scheme_middleware}
+        return {
+            **forwardauth_middleware,
+            **no_prefix_middleware,
+            **redir_scheme_middleware,
+            **basicauth_middleware,
+        }
 
     @staticmethod
     def generate_tls_config_for_route(

--- a/tests/integration/test_basic_auth.py
+++ b/tests/integration/test_basic_auth.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 import asyncio
 import subprocess
+import time
 import urllib.request
 from urllib.error import HTTPError
 
@@ -18,9 +19,13 @@ from tests.integration.conftest import (
 USERNAME = "admin"
 PASSWORD = "admin"
 
+# we don't expect a 200 because ipa-tester has no real server listening
+SUCCESS_EXIT_CODE = 502
+
 # user:hashed-password pair generated via https://www.transip.nl/htpasswd/
 TEST_AUTH_USER = r"admin:$2a$13$XOHdzKdVS4mPKT0LvOfXru4LqyLbwcEvFlssXGS3laC6d/i6cKrLS"
 APP_NAME = "traefik"
+IPA = "ipa-tester"
 
 
 @pytest.mark.abort_on_fail
@@ -28,31 +33,32 @@ APP_NAME = "traefik"
 async def test_deployment(ops_test: OpsTest, traefik_charm, ipa_tester_charm):
     await asyncio.gather(
         ops_test.model.deploy(traefik_charm, application_name=APP_NAME, resources=trfk_resources),
-        ops_test.model.deploy(ipa_tester_charm, "ipa-tester"),
+        ops_test.model.deploy(ipa_tester_charm, IPA),
     )
 
-    await ops_test.model.wait_for_idle([APP_NAME, "ipa-tester"], status="active", timeout=1000)
+    await ops_test.model.wait_for_idle([APP_NAME, IPA], status="active", timeout=1000)
 
 
 @pytest.mark.abort_on_fail
 @pytest.mark.skip_on_deployed
 async def test_relate(ops_test: OpsTest):
     await ops_test.model.add_relation("ipa-tester:ingress", f"{APP_NAME}:ingress")
-    await ops_test.model.wait_for_idle([APP_NAME, "ipa-tester"])
+    await ops_test.model.wait_for_idle([APP_NAME, IPA])
 
 
-def get_tester_url(ops_test: OpsTest):
+def get_tester_url(model):
     data = get_relation_data(
-        requirer_endpoint="ipa-tester/0:ingress",
+        requirer_endpoint=f"{IPA}/0:ingress",
         provider_endpoint=f"{APP_NAME}/0:ingress",
-        model=ops_test.model_full_name,
+        model=model,
     )
     provider_app_data = yaml.safe_load(data.provider.application_data["ingress"])
     return provider_app_data["url"]
 
 
 @retry(stop=stop_after_delay(60 * 1))  # 5 minutes
-def get_url(url: str, expected: int, auth: str = None):
+def assert_get_url_returns(url: str, expected: int, auth: str = None):
+    print(f"attempting to curl {url} (with auth? {'yes' if auth else 'no'})")
     if auth:
         passman = urllib.request.HTTPPasswordMgrWithDefaultRealm()
         passman.add_password(None, url, USERNAME, PASSWORD)
@@ -65,55 +71,63 @@ def get_url(url: str, expected: int, auth: str = None):
     except HTTPError as e:
         if e.code == expected:
             return True
-        raise
+
+        print(f"unexpected exit code {e.code}")
+        time.sleep(0.1)
+        raise AssertionError
+
     if expected == 200:
         return True
+
+    print("unexpected 200")
+    time.sleep(0.1)
     raise AssertionError
 
 
+@pytest.fixture
+def model(ops_test):
+    return ops_test.model_full_name
+
+
 def set_basic_auth(model: str, user: str):
+    print(f"setting basic auth to {user!r}")
     option = f"basic_auth_user={user}" if user else "basic_auth_user="
     subprocess.run(["juju", "config", "-m", model, APP_NAME, option])
 
 
-async def test_ipa_charm_ingress_noauth(ops_test: OpsTest):
+def test_ipa_charm_ingress_noauth(model):
     # GIVEN basic auth is disabled (initial condition)
-    model_name = ops_test.model_full_name
-    set_basic_auth(model_name, "")
-    tester_url = get_tester_url(ops_test)
+    set_basic_auth(model, "")
+    tester_url = get_tester_url(model)
 
     # WHEN we GET the tester url
     # THEN we get it fine
-    assert get_url(tester_url, expected=200)
+    assert_get_url_returns(tester_url, expected=SUCCESS_EXIT_CODE)
 
 
-@pytest.mark.abort_on_fail
-async def test_ipa_charm_ingress_auth(ops_test: OpsTest):
+def test_ipa_charm_ingress_auth(model):
     # GIVEN basic auth is disabled (previous test)
-    model_name = ops_test.model_full_name
-    tester_url = get_tester_url(ops_test)
+    tester_url = get_tester_url(model)
 
     # WHEN we enable basic auth
-    set_basic_auth(model_name, TEST_AUTH_USER)
+    set_basic_auth(model, TEST_AUTH_USER)
 
     # THEN we can't GET the tester url
     # might take a little bit to apply the new config
     # 401 unauthorized
-    assert get_url(tester_url, expected=401)
+    assert_get_url_returns(tester_url, expected=401)
 
     # UNLESS we use auth
-    assert get_url(tester_url, expected=401, auth=TEST_AUTH_USER)
+    assert_get_url_returns(tester_url, expected=SUCCESS_EXIT_CODE, auth=TEST_AUTH_USER)
 
 
-@pytest.mark.abort_on_fail
-async def test_ipa_charm_ingress_auth_disable(ops_test: OpsTest):
+def test_ipa_charm_ingress_auth_disable(model):
     # GIVEN auth is enabled (previous test)
-    model_name = ops_test.model_full_name
-    tester_url = get_tester_url(ops_test)
+    tester_url = get_tester_url(model)
 
     # WHEN we disable it again
-    set_basic_auth(model_name, "")
+    set_basic_auth(model, "")
 
     # THEN we eventually can GET the endpoint without auth
     # might take a little bit to apply the new config
-    assert get_url(tester_url, expected=200)
+    assert_get_url_returns(tester_url, expected=SUCCESS_EXIT_CODE)

--- a/tests/integration/test_basic_auth.py
+++ b/tests/integration/test_basic_auth.py
@@ -1,0 +1,124 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+import asyncio
+import subprocess
+import urllib.request
+from contextlib import contextmanager
+from urllib.error import HTTPError
+
+import pytest
+import yaml
+from pytest_operator.plugin import OpsTest
+from tenacity import Retrying, stop_after_delay
+
+from tests.integration.conftest import (
+    get_relation_data,
+    trfk_resources,
+)
+
+USERNAME = "admin"
+PASSWORD = "admin"
+
+# user:hashed-password pair generated via https://www.transip.nl/htpasswd/
+TEST_AUTH_USER = r"admin:$2a$13$XOHdzKdVS4mPKT0LvOfXru4LqyLbwcEvFlssXGS3laC6d/i6cKrLS"
+APP_NAME = "traefik"
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_on_deployed
+async def test_deployment(ops_test: OpsTest, traefik_charm, ipa_tester_charm):
+    await asyncio.gather(
+        ops_test.model.deploy(traefik_charm, application_name=APP_NAME, resources=trfk_resources),
+        ops_test.model.deploy(ipa_tester_charm, "ipa-tester"),
+    )
+
+    await ops_test.model.wait_for_idle([APP_NAME, "ipa-tester"], status="active", timeout=1000)
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_on_deployed
+async def test_relate(ops_test: OpsTest):
+    await ops_test.model.add_relation("ipa-tester:ingress", f"{APP_NAME}:ingress")
+    await ops_test.model.wait_for_idle([APP_NAME, "ipa-tester"])
+
+
+def get_tester_url(ops_test: OpsTest):
+    data = get_relation_data(
+        requirer_endpoint="ipa-tester/0:ingress",
+        provider_endpoint=f"{APP_NAME}/0:ingress",
+        model=ops_test.model_full_name,
+    )
+    provider_app_data = yaml.safe_load(data.provider.application_data["ingress"])
+    return provider_app_data["url"]
+
+
+def get_url(url: str, auth: str = None):
+    if auth:
+        passman = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+        passman.add_password(None, url, USERNAME, PASSWORD)
+        authhandler = urllib.request.HTTPBasicAuthHandler(passman)
+        opener = urllib.request.build_opener(authhandler)
+        urllib.request.install_opener(opener)
+
+    try:
+        urllib.request.urlopen(url, timeout=1)
+    except HTTPError as e:
+        return e.code
+    return 200
+
+
+def set_basic_auth(model: str, user: str):
+    option = f"basic_auth_user={user}" if user else "basic_auth_user="
+    subprocess.run(["juju", "config", "-m", model, APP_NAME, option])
+
+
+@contextmanager
+def keep_trying(minutes: int = 5):
+    for attempt in Retrying(stop=stop_after_delay(60 * minutes)):
+        with attempt:
+            yield
+
+
+@pytest.mark.abort_on_fail
+async def test_ipa_charm_ingress_noauth(ops_test: OpsTest):
+    # GIVEN basic auth is disabled (initial condition)
+    model_name = ops_test.model_full_name
+    set_basic_auth(model_name, "")
+    tester_url = get_tester_url(ops_test)
+
+    # WHEN we GET the tester url
+    # THEN we get it fine
+    with keep_trying():
+        assert get_url(tester_url) == 200
+
+
+@pytest.mark.abort_on_fail
+async def test_ipa_charm_ingress_auth(ops_test: OpsTest):
+    # GIVEN basic auth is disabled (previous test)
+    model_name = ops_test.model_full_name
+    tester_url = get_tester_url(ops_test)
+
+    # WHEN we enable basic auth
+    set_basic_auth(model_name, TEST_AUTH_USER)
+
+    # THEN we can't GET the tester url
+    with keep_trying():  # might take a little bit to apply the new config
+        # 401 unauthorized
+        assert get_url(tester_url) == 401
+
+    # UNLESS we use auth
+    assert get_url(tester_url, TEST_AUTH_USER) == 401
+
+
+@pytest.mark.abort_on_fail
+async def test_ipa_charm_ingress_auth_disable(ops_test: OpsTest):
+    # GIVEN auth is enabled (previous test)
+    model_name = ops_test.model_full_name
+    tester_url = get_tester_url(ops_test)
+
+    # WHEN we disable it again
+    set_basic_auth(model_name, "")
+
+    # THEN we eventually can GET the endpoint without auth
+    with keep_trying():  # might take a little bit to apply the new config
+        assert get_url(tester_url) == 200

--- a/tests/integration/test_basic_auth.py
+++ b/tests/integration/test_basic_auth.py
@@ -51,7 +51,6 @@ def get_tester_url(ops_test: OpsTest):
     return provider_app_data["url"]
 
 
-
 @retry(stop=stop_after_delay(60 * 1))  # 5 minutes
 def get_url(url: str, expected: int, auth: str = None):
     if auth:
@@ -85,7 +84,7 @@ async def test_ipa_charm_ingress_noauth(ops_test: OpsTest):
 
     # WHEN we GET the tester url
     # THEN we get it fine
-    assert get_url(tester_url,  expected=200)
+    assert get_url(tester_url, expected=200)
 
 
 @pytest.mark.abort_on_fail
@@ -100,10 +99,10 @@ async def test_ipa_charm_ingress_auth(ops_test: OpsTest):
     # THEN we can't GET the tester url
     # might take a little bit to apply the new config
     # 401 unauthorized
-    assert get_url(tester_url,  expected=401)
+    assert get_url(tester_url, expected=401)
 
     # UNLESS we use auth
-    assert get_url(tester_url,  expected=401, auth=TEST_AUTH_USER)
+    assert get_url(tester_url, expected=401, auth=TEST_AUTH_USER)
 
 
 @pytest.mark.abort_on_fail
@@ -117,4 +116,4 @@ async def test_ipa_charm_ingress_auth_disable(ops_test: OpsTest):
 
     # THEN we eventually can GET the endpoint without auth
     # might take a little bit to apply the new config
-    assert get_url(tester_url,  expected=200)
+    assert get_url(tester_url, expected=200)

--- a/tests/integration/test_basic_auth.py
+++ b/tests/integration/test_basic_auth.py
@@ -3,7 +3,6 @@
 import asyncio
 import subprocess
 import urllib.request
-from contextlib import contextmanager
 from urllib.error import HTTPError
 
 import pytest
@@ -72,14 +71,6 @@ def set_basic_auth(model: str, user: str):
     subprocess.run(["juju", "config", "-m", model, APP_NAME, option])
 
 
-@contextmanager
-def keep_trying(minutes: int = 5):
-    for attempt in Retrying(stop=stop_after_delay(60 * minutes)):
-        with attempt:
-            yield
-
-
-@pytest.mark.abort_on_fail
 async def test_ipa_charm_ingress_noauth(ops_test: OpsTest):
     # GIVEN basic auth is disabled (initial condition)
     model_name = ops_test.model_full_name
@@ -88,8 +79,9 @@ async def test_ipa_charm_ingress_noauth(ops_test: OpsTest):
 
     # WHEN we GET the tester url
     # THEN we get it fine
-    with keep_trying():
-        assert get_url(tester_url) == 200
+    for attempt in Retrying(stop=stop_after_delay(60 * 5)):  # 5 minutes
+        with attempt:
+            assert get_url(tester_url) == 200
 
 
 @pytest.mark.abort_on_fail
@@ -102,9 +94,11 @@ async def test_ipa_charm_ingress_auth(ops_test: OpsTest):
     set_basic_auth(model_name, TEST_AUTH_USER)
 
     # THEN we can't GET the tester url
-    with keep_trying():  # might take a little bit to apply the new config
-        # 401 unauthorized
-        assert get_url(tester_url) == 401
+    for attempt in Retrying(stop=stop_after_delay(60 * 5)):  # 5 minutes
+        with attempt:
+            # might take a little bit to apply the new config
+            # 401 unauthorized
+            assert get_url(tester_url) == 401
 
     # UNLESS we use auth
     assert get_url(tester_url, TEST_AUTH_USER) == 401
@@ -120,5 +114,7 @@ async def test_ipa_charm_ingress_auth_disable(ops_test: OpsTest):
     set_basic_auth(model_name, "")
 
     # THEN we eventually can GET the endpoint without auth
-    with keep_trying():  # might take a little bit to apply the new config
-        assert get_url(tester_url) == 200
+    for attempt in Retrying(stop=stop_after_delay(60 * 5)):  # 5 minutes
+        with attempt:
+            # might take a little bit to apply the new config
+            assert get_url(tester_url) == 200


### PR DESCRIPTION
This PR adds basic auth support for traefik.
This is an all-or-nothing, single-user basic implementation. In the future we might choose to extend it supporting per-route auth, as well as multi-user support.

## Testing Instructions
Deploy traefik from this branch and relate it over any ingress, ingress-per-unit or traefik-route relation to another charm.
Go to https://www.transip.nl/htpasswd/ and enter some testing username/password pair. Copy the output string.

`juju config traefik basic_auth_user='<that string>'`

(make sure to escape any weird characters)

Now verify that you need to enter that user/password pair when trying to CURL or GET any urls proxied by traefik
