### PR TITLE
Publish `traefik_route` v0 library

### DIFF
--- a/lib/charms/traefik_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_k8s/v0/traefik_route.py
@@ -15,7 +15,7 @@ To get started using the library, you just need to fetch the library using `char
 
 ```shell
 cd some-charm
-charmcraft fetch-lib charms.traefik_route_k8s.v0.traefik_route
+charmcraft fetch-lib charms.traefik_k8s.v0.traefik_route
 ```
 
 To use the library from the provider side (Traefik):
@@ -28,7 +28,7 @@ requires:
 ```
 
 ```python
-from charms.traefik_route_k8s.v0.traefik_route import TraefikRouteProvider
+from charms.traefik_k8s.v0.traefik_route import TraefikRouteProvider
 
 class TraefikCharm(CharmBase):
   def __init__(self, *args):
@@ -56,7 +56,7 @@ requires:
 
 ```python
 # ...
-from charms.traefik_route_k8s.v0.traefik_route import TraefikRouteRequirer
+from charms.traefik_k8s.v0.traefik_route import TraefikRouteRequirer
 
 class TraefikRouteCharm(CharmBase):
   def __init__(self, *args):
@@ -88,7 +88,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 1
 
 log = logging.getLogger(__name__)
 
@@ -254,8 +254,10 @@ class TraefikRouteProvider(Object):
 
     def get_config(self, relation: Relation) -> Optional[str]:
         """Renamed to ``get_dynamic_config``."""
-        log.warning("``TraefikRouteProvider.get_config`` is deprecated. "
-                    "Use ``TraefikRouteProvider.get_dynamic_config`` instead")
+        log.warning(
+            "``TraefikRouteProvider.get_config`` is deprecated. "
+            "Use ``TraefikRouteProvider.get_dynamic_config`` instead"
+        )
         return self.get_dynamic_config(relation)
 
     def get_dynamic_config(self, relation: Relation) -> Optional[str]:
@@ -356,7 +358,7 @@ class TraefikRouteRequirer(Object):
         """Is the TraefikRouteRequirer ready to submit data to Traefik?"""
         return self._relation is not None
 
-    def submit_to_traefik(self, config: dict, static: dict=None):
+    def submit_to_traefik(self, config: dict, static: Optional[dict] = None):
         """Relay an ingress configuration data structure to traefik.
 
         This will publish to the traefik-route relation databag

--- a/src/charm.py
+++ b/src/charm.py
@@ -37,16 +37,16 @@ from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServ
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from charms.tempo_k8s.v1.charm_tracing import trace_charm
 from charms.tempo_k8s.v2.tracing import TracingEndpointRequirer
+from charms.traefik_k8s.v0.traefik_route import (
+    TraefikRouteProvider,
+    TraefikRouteRequirerReadyEvent,
+)
 from charms.traefik_k8s.v1.ingress import IngressPerAppProvider as IPAv1
 from charms.traefik_k8s.v1.ingress_per_unit import (
     DataValidationError,
     IngressPerUnitProvider,
 )
 from charms.traefik_k8s.v2.ingress import IngressPerAppProvider as IPAv2
-from charms.traefik_route_k8s.v0.traefik_route import (
-    TraefikRouteProvider,
-    TraefikRouteRequirerReadyEvent,
-)
 from deepmerge import always_merger
 from lightkube.core.client import Client
 from lightkube.core.exceptions import ApiError

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -72,7 +72,7 @@ def copy_traefik_library_into_tester_charms(ops_test):
         "traefik_k8s/v2/ingress.py",
         "traefik_k8s/v1/ingress_per_unit.py",
         "observability_libs/v1/kubernetes_service_patch.py",
-        "traefik_route_k8s/v0/traefik_route.py",
+        "traefik_k8s/v0/traefik_route.py",
     ]
     for tester in ["forward-auth", "ipa", "ipu", "tcp", "route"]:
         for lib in libraries:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -101,40 +101,85 @@ async def traefik_charm(ops_test):
 @timed_memoizer
 async def forward_auth_tester_charm(ops_test):
     charm_path = (Path(__file__).parent / "testers" / "forward-auth").absolute()
-    charm = await ops_test.build_charm(charm_path, verbosity="debug")
-    return charm
+    count = 0
+    while True:
+        try:
+            charm = await ops_test.build_charm(charm_path, verbosity="debug")
+            return charm
+        except RuntimeError:
+            logger.warning("Failed to build forward auth tester. Trying again!")
+            count += 1
+
+            if count == 3:
+                raise
 
 
 @pytest.fixture(scope="module")
 @timed_memoizer
 async def ipa_tester_charm(ops_test):
     charm_path = (Path(__file__).parent / "testers" / "ipa").absolute()
-    charm = await ops_test.build_charm(charm_path, verbosity="debug")
-    return charm
+    count = 0
+    while True:
+        try:
+            charm = await ops_test.build_charm(charm_path, verbosity="debug")
+            return charm
+        except RuntimeError:
+            logger.warning("Failed to build ipa tester. Trying again!")
+            count += 1
+
+            if count == 3:
+                raise
 
 
 @pytest.fixture(scope="module")
 @timed_memoizer
 async def ipu_tester_charm(ops_test):
     charm_path = (Path(__file__).parent / "testers" / "ipu").absolute()
-    charm = await ops_test.build_charm(charm_path, verbosity="debug")
-    return charm
+    count = 0
+    while True:
+        try:
+            charm = await ops_test.build_charm(charm_path, verbosity="debug")
+            return charm
+        except RuntimeError:
+            logger.warning("Failed to build ipu tester. Trying again!")
+            count += 1
+
+            if count == 3:
+                raise
 
 
 @pytest.fixture(scope="module")
 @timed_memoizer
 async def tcp_tester_charm(ops_test):
     charm_path = (Path(__file__).parent / "testers" / "tcp").absolute()
-    charm = await ops_test.build_charm(charm_path, verbosity="debug")
-    return charm
+    count = 0
+    while True:
+        try:
+            charm = await ops_test.build_charm(charm_path, verbosity="debug")
+            return charm
+        except RuntimeError:
+            logger.warning("Failed to build tcp tester. Trying again!")
+            count += 1
+
+            if count == 3:
+                raise
 
 
 @pytest.fixture(scope="module")
 @timed_memoizer
 async def route_tester_charm(ops_test):
     charm_path = (Path(__file__).parent / "testers" / "route").absolute()
-    charm = await ops_test.build_charm(charm_path, verbosity="debug")
-    return charm
+    count = 0
+    while True:
+        try:
+            charm = await ops_test.build_charm(charm_path, verbosity="debug")
+            return charm
+        except RuntimeError:
+            logger.warning("Failed to build route tester. Trying again!")
+            count += 1
+
+            if count == 3:
+                raise
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/spellbook/build_all_caches.py
+++ b/tests/integration/spellbook/build_all_caches.py
@@ -23,9 +23,7 @@ def main():
     spellbook_fetch(
         charm_name="route-tester",
         charm_root=testers_root / "route",
-        pull_libs=[
-            traefik_root / "lib" / "charms" / "traefik_route_k8s" / "v0" / "traefik_route.py"
-        ],
+        pull_libs=[traefik_root / "lib" / "charms" / "traefik_k8s" / "v0" / "traefik_route.py"],
     )
     spellbook_fetch(
         charm_name="ipa-tester",

--- a/tests/integration/testers/forward-auth/charmcraft.yaml
+++ b/tests/integration/testers/forward-auth/charmcraft.yaml
@@ -13,5 +13,6 @@ parts:
     charm-binary-python-packages:
       - jsonschema
       - ops
+      - pydantic-core
     build-packages:
       - git

--- a/tests/integration/testers/ipa/charmcraft.yaml
+++ b/tests/integration/testers/ipa/charmcraft.yaml
@@ -12,5 +12,6 @@ parts:
   charm:
     charm-binary-python-packages:
       - ops
+      - pydantic-core
     build-packages:
       - git

--- a/tests/integration/testers/ipu/charmcraft.yaml
+++ b/tests/integration/testers/ipu/charmcraft.yaml
@@ -12,5 +12,6 @@ parts:
   charm:
     charm-binary-python-packages:
       - ops
+      - pydantic-core
     build-packages:
       - git

--- a/tests/integration/testers/route/charmcraft.yaml
+++ b/tests/integration/testers/route/charmcraft.yaml
@@ -12,5 +12,6 @@ parts:
   charm:
     charm-binary-python-packages:
       - ops
+      - pydantic-core
     build-packages:
       - git

--- a/tests/integration/testers/route/src/charm.py
+++ b/tests/integration/testers/route/src/charm.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
-from charms.traefik_route_k8s.v0.traefik_route import TraefikRouteRequirer
+from charms.traefik_k8s.v0.traefik_route import TraefikRouteRequirer
 from ops.charm import CharmBase
 from ops.model import ActiveStatus
 

--- a/tests/integration/testers/tcp/charmcraft.yaml
+++ b/tests/integration/testers/tcp/charmcraft.yaml
@@ -13,5 +13,6 @@ parts:
     charm-binary-python-packages:
       - ops
       - lightkube
+      - pydantic-core
     build-packages:
       - git


### PR DESCRIPTION
## Issue
Contributes to fixing https://github.com/canonical/traefik-route-k8s-operator/issues/55 and https://github.com/canonical/traefik-k8s-operator/issues/379

## Solution
- Publish `v0 traefik_route` library with `LIBPATCH=1` under `traefik_k8s`
- Change old references to `traefik_route_k8s` to `traefik_k8s`
- drive-by: Add retry to charm building + `pydantic-core` for rust compiler error

## Context
https://github.com/canonical/traefik-route-k8s-operator/pull/60

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
