### PR TITLE
Change alert rule to be for 5 minutes

### DIFF
--- a/src/prometheus_alert_rules/unit_unavailable.rule
+++ b/src/prometheus_alert_rules/unit_unavailable.rule
@@ -1,6 +1,6 @@
 alert: TraefikIngressUnitIsUnavailable
 expr: up < 1
-for: 0m
+for: 5m
 labels:
   severity: critical
 annotations:


### PR DESCRIPTION
## Issue
The TraefikIngressUnitIsUnavailable is very unreliable and triggers constantly on COS installs. It should wait for 5 minutes before firing the alert.


## Solution
Add `for: 5m` to the alert rule.


## Testing Instructions
None really


## Upgrade Notes
Traefik alert rules are now more stable.
