### PR TITLE
[tf] Update the outputs.tf with endpoints nomenclature

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -9,7 +9,6 @@ output "endpoints" {
     experimental_forward_auth = "experimental-forward-auth",
     logging                   = "logging",
     tracing                   = "tracing",
-    
     # Provides
     grafana_dashboard = "grafana-dashboard",
     ingress           = "ingress",

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -4,14 +4,17 @@ output "app_name" {
 
 output "endpoints" {
   value = {
+    # Requires
     certificates              = "certificates",
     experimental_forward_auth = "experimental-forward-auth",
-    grafana_dashboard         = "grafana-dashboard",
-    ingress                   = "ingress",
-    ingress_per_unit          = "ingress-per-unit",
     logging                   = "logging",
-    metrics_endpoint          = "metrics-endpoint",
     tracing                   = "tracing",
-    traefik_route             = "traefik-route",
+    
+    # Provides
+    grafana_dashboard = "grafana-dashboard",
+    ingress           = "ingress",
+    ingress_per_unit  = "ingress-per-unit",
+    metrics_endpoint  = "metrics-endpoint",
+    traefik_route     = "traefik-route",
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -2,21 +2,16 @@ output "app_name" {
   value = juju_application.traefik.name
 }
 
-output "requires" {
+output "endpoints" {
   value = {
     certificates              = "certificates",
     experimental_forward_auth = "experimental-forward-auth",
+    grafana_dashboard         = "grafana-dashboard",
+    ingress                   = "ingress",
+    ingress_per_unit          = "ingress-per-unit",
     logging                   = "logging",
+    metrics_endpoint          = "metrics-endpoint",
     tracing                   = "tracing",
-  }
-}
-
-output "provides" {
-  value = {
-    grafana_dashboard = "grafana-dashboard",
-    ingress           = "ingress",
-    ingress_per_unit  = "ingress-per-unit",
-    metrics_endpoint  = "metrics-endpoint",
-    traefik_route     = "traefik-route",
+    traefik_route             = "traefik-route",
   }
 }


### PR DESCRIPTION
To remove implementation detail of the TF module when another module inherits it, it makes sense to replace the `requires` and `provides` output variables with `endpoints`.

Coordinating PR
- https://github.com/canonical/observability/pull/226