### PR TITLE
IngressPerAppRequirer: retry when IP is not available

### DIFF
--- a/tests/unit/test_lib_per_app_requires.py
+++ b/tests/unit/test_lib_per_app_requires.py
@@ -12,6 +12,7 @@ from charms.traefik_k8s.v2.ingress import (
     IngressPerAppReadyEvent,
     IngressPerAppRequirer,
     IngressPerAppRevokedEvent,
+    IpNotAvailableError,
 )
 from ops.charm import CharmBase
 from ops.testing import Harness
@@ -157,12 +158,5 @@ class TestIPAEventsEmission(unittest.TestCase):
             self.harness.begin_with_initial_hooks()
             self.rel_id = self.harness.add_relation("ingress", "traefik-app")
             self.harness.add_relation_unit(self.rel_id, "traefik-app/0")
-            self.harness.charm.ipa.provide_ingress_requirements(port=80)
-
-            self.assertEqual(
-                # None is default so it gets omitted
-                self.harness.get_relation_data(self.rel_id, "ipa-requirer/0").get(
-                    "ip", "<OMITTED>"
-                ),
-                "<OMITTED>",
-            )
+            with self.assertRaises(IpNotAvailableError):
+                self.harness.charm.ipa.provide_ingress_requirements(port=80)


### PR DESCRIPTION
## Issue
We recently encountered a production failure where the ingress requirer temporarily failed to retrieve unit IP information from Juju. As a result, the IP field in the ingress per-app integration unit data bag was missing, causing the ingress provider to fail in generating ingress resources for the ingress requirer. The investigation revealed that the ingress charm library does not attempt to retry retrieving IP information from Juju after the initial failure, thereby preventing the charm from automatically recovering from this situation.

## Solution
There are several potential solutions to address this issue. For instance, the charm library could listen to all events and update the integration data on every event, or the charm could defer the integration event when IP retrieval fails, allowing it to retry in the next event. The defer solution appears to require the least modification and is the least invasive option.

## Context
<!-- Provide any specialized knowledge relevant to this project/technology -->

## Testing Instructions
Unit tests and scenario tests have been updated to validate this new behavior.

## Upgrade Notes
Charms that invoke the `provide_ingress_requirements` method might encounter an exception when IP information is unavailable from Juju due to the current implementation. However, charms using the implicit ingress requirements provisioning will not experience any exceptions.