### PR TITLE
Skip tls config when passthrough is enabled

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -826,10 +826,10 @@ class TraefikIngressCharm(CharmBase):
                 entrypoints = router_details.get("entryPoints", [])
                 tls_config = router_details.get("tls", {})
 
-                # Skip generating new routes if passthrough is already set
+                # Skip generating new routes if passthrough is True
                 if tls_config.get("passthrough", False):
                     logger.debug(
-                        f"Skipping TLS generation for {protocol} router {router_name} (passthrough already set)."
+                        f"Skipping TLS generation for {protocol} router {router_name} (passthrough True)."
                     )
                     continue
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -818,60 +818,47 @@ class TraefikIngressCharm(CharmBase):
         self._update_dynamic_config_route(relation, dct)
 
     def _update_dynamic_config_route(self, relation: Relation, config: dict):
-        if "http" in config.keys():
-            route_config = config["http"].get("routers", {})
-            # we want to generate and add a new router with TLS config for each routed path.
-            # as we mutate the dict, we need to work on a copy
-            for router_name in route_config.copy().keys():
-                route_rule = route_config.get(router_name, {}).get("rule", "")
-                service_name = route_config.get(router_name, {}).get("service", "")
-                entrypoints = route_config.get(router_name, {}).get("entryPoints", [])
-                if len(entrypoints) > 0:
-                    # if entrypoint exists, we check if it's a custom entrypoint to pass it to generated TLS config
-                    entrypoint = entrypoints[0] if entrypoints[0] != "web" else None
-                else:
-                    entrypoint = None
+        def _process_routes(route_config, protocol):
+            for router_name in list(route_config.keys()):  # Work on a copy of the keys
+                router_details = route_config[router_name]
+                route_rule = router_details.get("rule", "")
+                service_name = router_details.get("service", "")
+                entrypoints = router_details.get("entryPoints", [])
+                tls_config = router_details.get("tls", {})
+
+                # Skip generating new routes if passthrough is already set
+                if tls_config.get("passthrough", False):
+                    logger.debug(
+                        f"Skipping TLS generation for {protocol} router {router_name} (passthrough already set)."
+                    )
+                    continue
+
+                entrypoint = entrypoints[0] if entrypoints else None
+                if protocol == "http" and entrypoint == "web":
+                    entrypoint = None  # Ignore "web" entrypoint for HTTP
 
                 if not all([router_name, route_rule, service_name]):
-                    logger.debug("Not enough information to generate a TLS config!")
-                else:
-                    config["http"]["routers"].update(
-                        self.traefik.generate_tls_config_for_route(
-                            router_name,
-                            route_rule,
-                            service_name,
-                            # we're behind an is_ready guard, so this is guaranteed not to raise
-                            self.external_host,
-                            entrypoint,
-                        )
+                    logger.debug(
+                        f"Not enough information to generate a TLS config for {protocol} router {router_name}!"
                     )
-        if "tcp" in config.keys():
-            route_config = config["tcp"].get("routers", {})
-            # we want to generate and add a new router with TLS config for each routed path.
-            # as we mutate the dict, we need to work on a copy
-            for router_name in route_config.copy().keys():
-                route_rule = route_config.get(router_name, {}).get("rule", "")
-                service_name = route_config.get(router_name, {}).get("service", "")
-                entrypoints = route_config.get(router_name, {}).get("entryPoints", [])
-                if len(entrypoints) > 0:
-                    # for grpc, all entrypoints are custom
-                    entrypoint = entrypoints[0]
-                else:
-                    entrypoint = None
+                    continue
 
-                if not all([router_name, route_rule, service_name]):
-                    logger.debug("Not enough information to generate a TLS config!")
-                else:
-                    config["tcp"]["routers"].update(
-                        self.traefik.generate_tls_config_for_route(
-                            router_name,
-                            route_rule,
-                            service_name,
-                            # we're behind an is_ready guard, so this is guaranteed not to raise
-                            self.external_host,
-                            entrypoint,
-                        )
+                config[protocol]["routers"].update(
+                    self.traefik.generate_tls_config_for_route(
+                        router_name,
+                        route_rule,
+                        service_name,
+                        self.external_host,
+                        entrypoint,
                     )
+                )
+
+        if "http" in config:
+            _process_routes(config["http"].get("routers", {}), protocol="http")
+
+        if "tcp" in config:
+            _process_routes(config["tcp"].get("routers", {}), protocol="tcp")
+
         self._push_configurations(relation, config)
 
     def _provide_ingress(

--- a/tests/unit/test_route.py
+++ b/tests/unit/test_route.py
@@ -35,6 +35,42 @@ CONFIG = {
     }
 }
 
+TCP_CONFIG_WITH_PASSTHROUGH = {
+    "tcp": {
+        "routers": {
+            "juju-foo-router": {
+                "entryPoints": ["websecure"],
+                "rule": "HostSNI(`*`)",
+                "service": "juju-foo-service",
+                "tls": {"passthrough": True},  # Passthrough enabled
+            }
+        },
+        "services": {
+            "juju-foo-service": {
+                "loadBalancer": {"servers": [{"address": "foo.testmodel-endpoints.local:8080"}]}
+            }
+        },
+    }
+}
+
+HTTP_CONFIG_WITH_PASSTHROUGH = {
+    "http": {
+        "routers": {
+            "juju-foo-router": {
+                "entryPoints": ["web"],
+                "rule": "PathPrefix(`/path`)",
+                "service": "juju-foo-service",
+                "tls": {"passthrough": True},  # Passthrough enabled
+            }
+        },
+        "services": {
+            "juju-foo-service": {
+                "loadBalancer": {"servers": [{"url": "http://foo.testmodel-endpoints.local:8080"}]}
+            }
+        },
+    }
+}
+
 CONFIG_WITH_TLS = {
     "http": {
         "routers": {
@@ -339,3 +375,51 @@ def test_static_config_updates_tcp_entrypoints(
 
     # AND that shows up in the service ports
     assert [p for p in charm._service_ports if p.port == 6767][0]
+
+
+def test_tls_http_passthrough_no_tls_added(harness: Harness[TraefikIngressCharm]):
+    """Ensure no TLS configuration is generated for routes with tls.passthrough."""
+    tr_relation_id, relation = initialize_and_setup_tr_relation(harness)
+    charm = harness.charm
+
+    # Update relation with the passthrough configuration
+    config = yaml.dump(HTTP_CONFIG_WITH_PASSTHROUGH)
+    harness.update_relation_data(tr_relation_id, REMOTE_APP_NAME, {"config": config})
+
+    # Verify the relation is ready and the configuration is loaded
+    assert charm.traefik_route.is_ready(relation)
+    assert charm.traefik_route.get_config(relation) == config
+
+    # Check the dynamic configuration written to the container
+    file = f"/opt/traefik/juju/juju_ingress_{relation.name}_{relation.id}_{relation.app.name}.yaml"
+    dynamic_config = yaml.safe_load(charm.container.pull(file).read())
+
+    # Ensure the passthrough configuration is preserved
+    assert dynamic_config == HTTP_CONFIG_WITH_PASSTHROUGH
+
+    # Check no additional TLS configurations are added
+    assert "juju-foo-router-tls" not in dynamic_config["http"]["routers"]
+
+
+def test_tls_tcp_passthrough_no_tls_added(harness: Harness[TraefikIngressCharm]):
+    """Ensure no TLS configuration is generated for routes with tls.passthrough."""
+    tr_relation_id, relation = initialize_and_setup_tr_relation(harness)
+    charm = harness.charm
+
+    # Update relation with the passthrough configuration
+    config = yaml.dump(TCP_CONFIG_WITH_PASSTHROUGH)
+    harness.update_relation_data(tr_relation_id, REMOTE_APP_NAME, {"config": config})
+
+    # Verify the relation is ready and the configuration is loaded
+    assert charm.traefik_route.is_ready(relation)
+    assert charm.traefik_route.get_config(relation) == config
+
+    # Check the dynamic configuration written to the container
+    file = f"/opt/traefik/juju/juju_ingress_{relation.name}_{relation.id}_{relation.app.name}.yaml"
+    dynamic_config = yaml.safe_load(charm.container.pull(file).read())
+
+    # Ensure the passthrough configuration is preserved
+    assert dynamic_config == TCP_CONFIG_WITH_PASSTHROUGH
+
+    # Check no additional TLS configurations are added
+    assert "juju-foo-router-tls" not in dynamic_config["tcp"]["routers"]


### PR DESCRIPTION
## Issue
Fixes #425 


## Solution
Skip the generation of tls dynamic config in traffic when passthrough is set

## Context
When `tls.passthrough: true` is set for a route, Traefik forwards the raw TLS traffic directly to the backend service without terminating the TLS connection.
This means Traefik doesn't need to handle certificates, nor does it need additional TLS configuration 

## Testing Instructions
1- juju deploy traefik-k8s 
2- juju deploy [wazuh-server-operator](https://github.com/canonical/wazuh-server-operator)
3- juju relate traefik-k8s wazuh-server-operator
4- Fetch traefik's dynamic config and validate no tls entry is created and main entry has `tls.passthrough: true`

