### PR TITLE
Remove deprecated call to ops.main

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -65,7 +65,7 @@ from ops.charm import (
     UpdateStatusEvent,
 )
 from ops.framework import StoredState
-from ops.main import main
+from ops import main
 from ops.model import (
     ActiveStatus,
     BlockedStatus,

--- a/src/charm.py
+++ b/src/charm.py
@@ -54,6 +54,7 @@ from lightkube.core.client import Client
 from lightkube.core.exceptions import ApiError
 from lightkube.models.core_v1 import ServicePort
 from lightkube.resources.core_v1 import Service
+from ops import main
 from ops.charm import (
     ActionEvent,
     CharmBase,
@@ -65,7 +66,6 @@ from ops.charm import (
     UpdateStatusEvent,
 )
 from ops.framework import StoredState
-from ops import main
 from ops.model import (
     ActiveStatus,
     BlockedStatus,


### PR DESCRIPTION
## Issue
Charm logs have the following for every hook:
```
./src/charm.py:1255: DeprecationWarning: Calling `ops.main.main()` is deprecated, call `ops.main()` instead
  main(TraefikIngressCharm, use_juju_for_storage=True)
```


## Solution
Use `ops.main` instead of `ops.main.main`.
