### PR TITLE
cleanup logging output during scenario tests due to charm-tracing being enabled by default

### DIFF
--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -1,6 +1,7 @@
 from unittest.mock import PropertyMock, patch
 
 import pytest
+from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
 from ops import pebble
 from scenario import Container, Context, ExecOutput, Model, Mount
 
@@ -11,13 +12,14 @@ MOCK_LB_ADDRESS = "1.2.3.4"
 
 @pytest.fixture
 def traefik_charm():
-    with patch("lightkube.core.client.GenericSyncClient"):
-        with patch(
-            "charm.TraefikIngressCharm._get_loadbalancer_status",
-            new_callable=PropertyMock,
-            return_value=MOCK_LB_ADDRESS,
-        ):
-            yield TraefikIngressCharm
+    with charm_tracing_disabled():
+        with patch("lightkube.core.client.GenericSyncClient"):
+            with patch(
+                "charm.TraefikIngressCharm._get_loadbalancer_status",
+                new_callable=PropertyMock,
+                return_value=MOCK_LB_ADDRESS,
+            ):
+                yield TraefikIngressCharm
 
 
 @pytest.fixture

--- a/tests/scenario/test_tracing_integration.py
+++ b/tests/scenario/test_tracing_integration.py
@@ -1,9 +1,13 @@
+import os
 from unittest.mock import patch
 
 import opentelemetry
 import pytest
 import yaml
-from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
+from charms.tempo_coordinator_k8s.v0.charm_tracing import (
+    CHARM_TRACING_ENABLED,
+    charm_tracing_disabled,
+)
 from charms.tempo_coordinator_k8s.v0.tracing import ProtocolType, Receiver, TracingProviderAppData
 from scenario import Relation, State
 
@@ -50,6 +54,7 @@ def test_charm_trace_collection(traefik_ctx, traefik_container, caplog, charm_tr
         "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter.export"
     ) as f:
         f.return_value = opentelemetry.sdk.trace.export.SpanExportResult.SUCCESS
+        os.environ[CHARM_TRACING_ENABLED] = "1"
         # WHEN traefik receives <any event>
         traefik_ctx.run(charm_tracing_relation.changed_event, state_in)
 


### PR DESCRIPTION
adds a call into charm_logging_disabled contextmgr from the conftest.py fixture for traefik.