### PR TITLE
Add the IP address of the resolved hostname to the certificate SANS

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 
 """Charmed traefik operator."""
+
 import contextlib
 import enum
 import itertools
@@ -197,7 +198,9 @@ class TraefikIngressCharm(CharmBase):
         self.ingress_per_unit = IngressPerUnitProvider(charm=self)
 
         self.traefik_route = TraefikRouteProvider(
-            charm=self, external_host=self._external_host, scheme=self._scheme  # type: ignore
+            charm=self,
+            external_host=self._external_host,  # type: ignore
+            scheme=self._scheme,  # type: ignore
         )
 
         self._topology = JujuTopology.from_charm(self)
@@ -1272,7 +1275,9 @@ class TraefikIngressCharm(CharmBase):
             name, _, _ = socket.gethostbyaddr(target)  # type: ignore
             # Do not return "hostname" like '10-43-8-149.kubernetes.default.svc.cluster.local'
             if is_hostname(name) and not name.endswith(".svc.cluster.local"):
-                return [name]
+                # In case we can do a DNS lookup on that IP address,
+                #  return the resolved hostname as well as the IP address to be both included in the certificate SANS.
+                return [name, target] if target else [name]
 
         # If all else fails, we'd rather use the bare IP
         return [target] if target else []


### PR DESCRIPTION
## Issue
Potentially fix the issue where TLS communication to Traefik fails in environments where the Loadbalancer IP can be resolved back to a hostname on the machine running the workloads.

Potentially fix https://github.com/canonical/traefik-k8s-operator/issues/347
Fixes #461
@PietroPasotti to confirm.


## Solution
If an IP address can be resolved back to a hostname, return both the hostname as well as the IP address to be used in the certificate SANS. The reason is that charms related to Traefik over ingress will communicate with Traefik via this IP address and thus it should be contained in the server certificate SANS.


