### PR TITLE
Traefik appends a `tls` route even when `tls` routes are explicitly provided

### DIFF
--- a/lib/charms/traefik_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_k8s/v0/traefik_route.py
@@ -66,7 +66,7 @@ class TraefikRouteCharm(CharmBase):
     traefik_route = TraefikRouteRequirer(
         self, self.model.relations.get("traefik-route"),
         "traefik-route",
-        raw_config=False  # Default: Traefik will append TLS configs
+        raw=False  # Default: Traefik will append TLS configs
     )
     if traefik_route.is_ready():
         traefik_route.submit_to_traefik(
@@ -86,7 +86,7 @@ class TraefikRouteCharm(CharmBase):
     traefik_route = TraefikRouteRequirer(
         self, self.model.relations.get("traefik-route"),
         "traefik-route",
-        raw_config=True  # Traefik will not modify TLS settings on non HTTP routes
+        raw=True  # Traefik will not modify TLS settings on non HTTP routes
     )
     if self.traefik_route.is_ready():
         self.traefik_route.submit_to_traefik(
@@ -350,11 +350,8 @@ class TraefikRouteRequirer(Object):
 
         if self._raw:
             log.warning(
-                "WARNING: 'raw' flag is set.\n"
-                "This will prevent Traefik from generating TLS routes for non-HTTP protocols,\n"
-                "even if a TLS provider is configured.\n"
-                "Charm authors should only use this option if they fully understand the implications\n"
-                "and intentionally do not require the appended TLS routes."
+                "Raw mode enabled: TLS routes for non-HTTP protocols will not be auto-generated. "
+                "Enable this only if you fully understand and intend to bypass the additional TLS configuration."
             )
 
         self.framework.observe(

--- a/src/charm.py
+++ b/src/charm.py
@@ -934,51 +934,7 @@ class TraefikIngressCharm(CharmBase):
         if not dct:
             return
 
-        self._update_dynamic_config_route(relation, dct)
-
-    def _update_dynamic_config_route(self, relation: Relation, config: dict):
-        def _process_routes(route_config, protocol):
-            for router_name in list(route_config.keys()):  # Work on a copy of the keys
-                router_details = route_config[router_name]
-                route_rule = router_details.get("rule", "")
-                service_name = router_details.get("service", "")
-                entrypoints = router_details.get("entryPoints", [])
-                tls_config = router_details.get("tls", {})
-
-                # Skip generating new routes if passthrough is True
-                if tls_config.get("passthrough", False):
-                    logger.debug(
-                        f"Skipping TLS generation for {protocol} router {router_name} (passthrough True)."
-                    )
-                    continue
-
-                entrypoint = entrypoints[0] if entrypoints else None
-                if protocol == "http" and entrypoint == "web":
-                    entrypoint = None  # Ignore "web" entrypoint for HTTP
-
-                if not all([router_name, route_rule, service_name]):
-                    logger.debug(
-                        f"Not enough information to generate a TLS config for {protocol} router {router_name}!"
-                    )
-                    continue
-
-                config[protocol]["routers"].update(
-                    self.traefik.generate_tls_config_for_route(
-                        router_name,
-                        route_rule,
-                        service_name,
-                        self.external_host,
-                        entrypoint,
-                    )
-                )
-
-        if "http" in config:
-            _process_routes(config["http"].get("routers", {}), protocol="http")
-
-        if "tcp" in config:
-            _process_routes(config["tcp"].get("routers", {}), protocol="tcp")
-
-        self._push_configurations(relation, config)
+        self._push_configurations(relation, dct)
 
     def _provide_ingress(
         self,

--- a/src/charm.py
+++ b/src/charm.py
@@ -935,13 +935,9 @@ class TraefikIngressCharm(CharmBase):
             return
 
         is_raw = self.traefik_route.is_raw_enabled(relation)
+        self._update_dynamic_config_route(relation, dct, is_raw)
 
-        if is_raw:
-            self._push_configurations(relation, config)
-        else:
-            self._update_dynamic_config_route(relation, dct)
-
-    def _update_dynamic_config_route(self, relation: Relation, config: dict):
+    def _update_dynamic_config_route(self, relation: Relation, config: dict, is_raw: bool):
         def _process_routes(route_config, protocol):
             for router_name in list(route_config.keys()):  # Work on a copy of the keys
                 router_details = route_config[router_name]
@@ -968,12 +964,13 @@ class TraefikIngressCharm(CharmBase):
                         entrypoint,
                     )
                 )
-
+        
         if "http" in config:
             _process_routes(config["http"].get("routers", {}), protocol="http")
 
-        if "tcp" in config:
-            _process_routes(config["tcp"].get("routers", {}), protocol="tcp")
+        if not is_raw:
+            if "tcp" in config:
+                _process_routes(config["tcp"].get("routers", {}), protocol="tcp")
 
         self._push_configurations(relation, config)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -957,7 +957,7 @@ class TraefikIngressCharm(CharmBase):
                         entrypoint,
                     )
                 )
-        
+
         if "http" in config:
             _process_routes(config["http"].get("routers", {}), protocol="http")
 


### PR DESCRIPTION
## Issue
Fixes #430

## Context
For every route, `traefik` created a duplicate route `ROUTENAME-tls` for the same rule and service but with additional TLS configuration. Both applied to the same rule and thus conflict, and the new `ROUTENAME-tls` route takes precedence over the original `ROUTENAME` because its name is longer. 

## Solution
- **New Parameter:** Introduce a new boolean argument `raw` in the interface.
- **Conditional Behavior:**  
  - When `raw` is set to `True`, Traefik will **only** append TLS routes to HTTP routes.
  - TLS routes for non-HTTP protocols will not be generated, preventing the duplicate `ROUTENAME-tls` routes.

## Testing
**Tandem PR**: https://github.com/canonical/grafana-k8s-operator/pull/391