### PR TITLE
Disable  flag in forward_auth tests

### DIFF
--- a/tests/integration/test_forward_auth.py
+++ b/tests/integration/test_forward_auth.py
@@ -53,7 +53,6 @@ async def test_deployment(ops_test: OpsTest, traefik_charm, forward_auth_tester_
     await ops_test.model.deploy(
         OATHKEEPER_CHARM,
         channel="latest/edge",
-        config={"dev": "True"},
         trust=True,
     )
 


### PR DESCRIPTION
IAM-610

Update tests, the `dev` flag is not needed with the latest version of oathkeeper

Closes https://github.com/canonical/oathkeeper-operator/issues/46