### PR TITLE
Do not do a reverse DNS lookup for the SANs

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -3,13 +3,11 @@
 # See LICENSE file for licensing details.
 
 """Charmed traefik operator."""
-import contextlib
 import enum
 import itertools
 import json
 import logging
 import re
-import socket
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 from urllib.parse import urlparse
 
@@ -1266,13 +1264,6 @@ class TraefikIngressCharm(CharmBase):
         if is_hostname(target):
             assert isinstance(target, str), target  # for type checker
             return [target]
-
-        # This is an IP address. Try to look up the hostname.
-        with contextlib.suppress(OSError, TypeError):
-            name, _, _ = socket.gethostbyaddr(target)  # type: ignore
-            # Do not return "hostname" like '10-43-8-149.kubernetes.default.svc.cluster.local'
-            if is_hostname(name) and not name.endswith(".svc.cluster.local"):
-                return [name]
 
         # If all else fails, we'd rather use the bare IP
         return [target] if target else []


### PR DESCRIPTION
## Issue
Fixes #305


## Solution
We no longer do a reverse DNS lookup to populate the SANs. This was  probably a bad idea in the first place.


## Testing Instructions
Relate to an ingress TLS provider without setting external_hostname. Ensure that the SANS do not include a domain name.