### PR TITLE
disable cyclomatic complexity linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ extend-exclude = ["__pycache__", "*.egg_info"]
 select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
 # Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["E501", "D107", "N818", "RET504"]
+# Ignore C90 because we do not check cyclomatic complexity as a rule
+ignore = ["C90", "E501", "D107", "N818", "RET504"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
 per-file-ignores = {"*tests/*" = ["D100","D101","D102","D103","D104"]}
 


### PR DESCRIPTION
Disable this check because we agreed not to do it a long time ago.