### PR TITLE
Fix missing substitution in log message

### DIFF
--- a/lib/charms/traefik_k8s/v2/ingress.py
+++ b/lib/charms/traefik_k8s/v2/ingress.py
@@ -595,8 +595,8 @@ class IngressPerAppProvider(_IngressPerAppBase):
             # If we cannot validate the url as valid, publish an empty databag and log the error.
             log.error(f"Failed to validate ingress url '{url}' - got ValidationError {e}")
             log.error(
-                "url was not published to ingress relation for {relation.app}.  This error is likely due to an"
-                " error or misconfiguration of the charm calling this library."
+                f"url was not published to ingress relation for {relation.app}.  This error is likely due to an"
+                f" error or misconfiguration of the charm calling this library."
             )
             IngressProviderAppData(ingress=None).dump(relation.data[self.app])  # type: ignore
 


### PR DESCRIPTION
# Issue
Fixes #439 - Log message shows unformatted `{relation.app}` instead of actual app name.

## Solution
- Fixed string formatting in `relation.py` to interpolate `relation.app`

## Context

## Upgrade Notes