### PR TITLE
Rebase reverse chain fix

### DIFF
--- a/lib/charms/observability_libs/v1/cert_handler.py
+++ b/lib/charms/observability_libs/v1/cert_handler.py
@@ -68,7 +68,7 @@ logger = logging.getLogger(__name__)
 
 LIBID = "b5cd5cd580f3428fa5f59a8876dcbe6a"
 LIBAPI = 1
-LIBPATCH = 15
+LIBPATCH = 16
 
 VAULT_SECRET_LABEL = "cert-handler-private-vault"
 
@@ -609,7 +609,7 @@ class CertHandler(Object):
         cert = self.get_cert()
         if not cert:
             return None
-        chain = cert.chain_as_pem()
+        chain = cert.chain_as_pem_string()
         if cert.certificate not in chain:
             # add server cert to chain
             chain = cert.certificate + "\n\n" + chain

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -144,8 +144,8 @@ async def deploy_tempo_cluster(ops_test: OpsTest):
     """Deploys tempo in its HA version together with minio and s3-integrator."""
     tempo_app = "tempo"
     worker_app = "tempo-worker"
-    tempo_worker_charm_url, worker_channel = "tempo-worker-k8s", "2/edge"
-    tempo_coordinator_charm_url, coordinator_channel = "tempo-coordinator-k8s", "2/edge"
+    tempo_worker_charm_url, worker_channel = "tempo-worker-k8s", "1/stable"
+    tempo_coordinator_charm_url, coordinator_channel = "tempo-coordinator-k8s", "1/stable"
     await ops_test.model.deploy(
         tempo_worker_charm_url, application_name=worker_app, channel=worker_channel, trust=True
     )

--- a/tests/integration/test_charm_health.py
+++ b/tests/integration/test_charm_health.py
@@ -13,7 +13,6 @@ from tests.integration.conftest import (
     trfk_resources,
 )
 from tests.integration.helpers import (
-    delete_k8s_service,
     get_k8s_service_address,
     remove_application,
 )
@@ -104,5 +103,4 @@ async def test_health(ops_test: OpsTest):
 
 
 async def test_cleanup(ops_test):
-    await delete_k8s_service(ops_test, "traefik-k8s-lb")
     await remove_application(ops_test, "traefik-k8s", timeout=60)

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -14,7 +14,6 @@ from tests.integration.conftest import (
     trfk_resources,
 )
 from tests.integration.helpers import (
-    delete_k8s_service,
     dequote,
     get_k8s_service_address,
     remove_application,
@@ -104,5 +103,4 @@ async def test_remove_relation(ops_test: OpsTest):
 
 
 async def test_cleanup(ops_test):
-    await delete_k8s_service(ops_test, "traefik-k8s-lb")
     await remove_application(ops_test, "traefik-k8s", timeout=60)

--- a/tests/integration/test_charm_ipu.py
+++ b/tests/integration/test_charm_ipu.py
@@ -13,7 +13,6 @@ from tests.integration.conftest import (
     get_relation_data,
 )
 from tests.integration.helpers import (
-    delete_k8s_service,
     dequote,
     get_k8s_service_address,
     remove_application,
@@ -95,5 +94,4 @@ async def test_remove_relation(ops_test: OpsTest):
 
 
 async def test_cleanup(ops_test):
-    await delete_k8s_service(ops_test, "traefik-k8s-lb")
     await remove_application(ops_test, "traefik-k8s", timeout=60)

--- a/tests/integration/test_charm_route.py
+++ b/tests/integration/test_charm_route.py
@@ -14,7 +14,6 @@ from tests.integration.conftest import (
     trfk_resources,
 )
 from tests.integration.helpers import (
-    delete_k8s_service,
     get_k8s_service_address,
     remove_application,
 )
@@ -91,5 +90,4 @@ async def test_remove_relation(ops_test: OpsTest):
 
 
 async def test_cleanup(ops_test):
-    await delete_k8s_service(ops_test, f"{APP_NAME}-lb")
     await remove_application(ops_test, APP_NAME, timeout=60)

--- a/tests/integration/test_charm_tcp.py
+++ b/tests/integration/test_charm_tcp.py
@@ -10,7 +10,6 @@ from pytest_operator.plugin import OpsTest
 
 from tests.integration.conftest import deploy_traefik_if_not_deployed, get_relation_data
 from tests.integration.helpers import (
-    delete_k8s_service,
     get_k8s_service_address,
     remove_application,
 )
@@ -114,5 +113,4 @@ async def test_remove_relation(ops_test: OpsTest):
 
 
 async def test_cleanup(ops_test):
-    await delete_k8s_service(ops_test, "traefik-k8s-lb")
     await remove_application(ops_test, "traefik-k8s", timeout=60)

--- a/tests/integration/test_forward_auth.py
+++ b/tests/integration/test_forward_auth.py
@@ -7,7 +7,7 @@ from os.path import join
 import pytest
 import requests
 import yaml
-from helpers import delete_k8s_service, get_k8s_service_address, remove_application
+from helpers import get_k8s_service_address, remove_application
 from lightkube import Client
 from lightkube.resources.core_v1 import ConfigMap
 from pytest_operator.plugin import OpsTest
@@ -195,5 +195,4 @@ async def test_remove_forward_auth_integration(ops_test: OpsTest):
 
 
 async def test_cleanup(ops_test):
-    await delete_k8s_service(ops_test, "traefik-k8s-lb")
     await remove_application(ops_test, "traefik-k8s", timeout=60)

--- a/tests/integration/test_tcp_ipa_compatibility.py
+++ b/tests/integration/test_tcp_ipa_compatibility.py
@@ -10,7 +10,7 @@ from tests.integration.conftest import (
     deploy_traefik_if_not_deployed,
     safe_relate,
 )
-from tests.integration.helpers import delete_k8s_service, remove_application
+from tests.integration.helpers import remove_application
 from tests.integration.test_charm_ipa import assert_ipa_charm_has_ingress  # noqa
 from tests.integration.test_charm_ipu import assert_ipu_charm_has_ingress  # noqa
 from tests.integration.test_charm_tcp import (  # noqa
@@ -46,5 +46,4 @@ async def test_tcp_ipa_compatibility(ops_test, tcp_ipa_deployment):
 
 
 async def test_cleanup(ops_test):
-    await delete_k8s_service(ops_test, "traefik-k8s-lb")
     await remove_application(ops_test, "traefik-k8s", timeout=60)

--- a/tests/integration/test_tcp_ipu_compatibility.py
+++ b/tests/integration/test_tcp_ipu_compatibility.py
@@ -10,7 +10,7 @@ from tests.integration.conftest import (
     deploy_traefik_if_not_deployed,
     safe_relate,
 )
-from tests.integration.helpers import delete_k8s_service, remove_application
+from tests.integration.helpers import remove_application
 from tests.integration.test_charm_ipa import assert_ipa_charm_has_ingress  # noqa
 from tests.integration.test_charm_ipu import assert_ipu_charm_has_ingress  # noqa
 from tests.integration.test_charm_tcp import (  # noqa
@@ -56,5 +56,4 @@ async def test_tcp_ipu_compatibility(ops_test, tcp_ipu_deployment):
 
 
 async def test_cleanup(ops_test):
-    await delete_k8s_service(ops_test, "traefik-k8s-lb")
     await remove_application(ops_test, "traefik-k8s", timeout=60)


### PR DESCRIPTION
Rebase of the changes recently pushed to revision 238 for issue #491.

In order to be backwards compatible, we separate the chain (which is a string of the form `"{cert}\n\n{cert}\n\n...{cert}"`). We then check to see if the first element of the chain is the same as the leaf cert. If it is not we reverse the chain.

This does not cover the case of any poorly ordered chain. It only covers the case of reverse order that is sent by old versions of `self-signed-certificates`. This is okay as providers of the interface should be send in order. We are only catching a specific known wrong ordering and we will remove this check after sufficient time has passed. This means that if a different provider charm sends the chain in the wrong order, there is a chance we can find the error.