### PR TITLE
Enhance the TLS cipher suite to exclude CBC

### DIFF
--- a/src/traefik.py
+++ b/src/traefik.py
@@ -35,6 +35,18 @@ RECV_CA_TEMPLATE = Template(f"{CA_CERTS_PATH}/receive-ca-cert-$rel_id-ca.crt")
 BIN_PATH = "/usr/bin/traefik"
 LOG_PATH = "/var/log/traefik.log"
 
+# Based on Mozilla's intermediate profile guideline
+TLS_MIN_VERSION = "VersionTLS12"
+TLS_CURVE_PREFERENCES = ["X25519", "CurveP256", "CurveP384"]
+TLS_CIPHER_SUITES = [
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+]
+
 _DIAGNOSTICS_PORT = 8082  # Prometheus metrics, healthcheck/ping
 
 
@@ -147,6 +159,13 @@ class Traefik:
                                 "certFile": SERVER_CERT_PATH,
                                 "keyFile": SERVER_KEY_PATH,
                             },
+                        },
+                    },
+                    "options": {
+                        "default": {
+                            "minVersion": TLS_MIN_VERSION,
+                            "curvePreferences": TLS_CURVE_PREFERENCES,
+                            "cipherSuites": TLS_CIPHER_SUITES,
                         },
                     },
                 }


### PR DESCRIPTION
The new list is based on Mozilla's intermediate profile guideline.

## Issue
<!-- What issue is this PR trying to solve? -->

Fixes: #534

## Solution
<!-- A summary of the solution addressing the above issue -->

Add the default cipher list for TLS based on Mozilla's intermediate guideline.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Deploy a new charm with some backends and enable TLS. After that, `testssl.sh` tool can be run against the Traefik endpoint to see if CBC is disabled or not.

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
