### PR TITLE
ISD-4203 guard against container.remove_file and add cleanup logic for TLS

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -357,10 +357,7 @@ class TraefikIngressCharm(CharmBase):
         addrs = {
             urlparse(endpoint["url"]).hostname
             for endpoint in self._get_proxied_endpoints(use_gateway_address=True).values()
-            if "url" in endpoint
-            and urlparse(
-                endpoint["url"]
-            ).scheme
+            if "url" in endpoint and urlparse(endpoint["url"]).scheme
         }
         csrs = []
         for addr in addrs:
@@ -620,6 +617,7 @@ class TraefikIngressCharm(CharmBase):
         self._configure()
 
     def _update_cert_configs(self) -> None:
+        """Update the server cert, ca, and key configuration files."""
         self.traefik.update_cert_configuration(self._get_certs())
 
     def _get_certs(self) -> dict:

--- a/src/charm.py
+++ b/src/charm.py
@@ -57,7 +57,7 @@ from lightkube.models.core_v1 import ServicePort, ServiceSpec
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Service
 from lightkube_extensions.batch import KubernetesResourceManager, create_charm_default_labels
-from ops import main
+from ops import EventBase, main
 from ops.charm import (
     ActionEvent,
     CharmBase,
@@ -115,6 +115,8 @@ QUALIFIED_NAME_PATTERN = re.compile(r"^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$
 LB_LABEL = "traefik-loadbalancer"
 
 PYDANTIC_IS_V1 = int(pydantic.version.VERSION.split(".")[0]) < 2
+
+CERTIFICATES_RELATION_NAME = "certificates"
 
 
 class _IngressRelationType(enum.Enum):
@@ -271,7 +273,7 @@ class TraefikIngressCharm(CharmBase):
         ]
         self.certs = TLSCertificatesRequiresV4(
             charm=self,
-            relationship_name="certificates",
+            relationship_name=CERTIFICATES_RELATION_NAME,
             certificate_requests=self.csrs,
             mode=Mode.UNIT,
             refresh_events=certs_refresh_events,
@@ -350,6 +352,27 @@ class TraefikIngressCharm(CharmBase):
         # Action handlers
         observe(self.on.show_proxied_endpoints_action, self._on_show_proxied_endpoints)  # type: ignore
         observe(self.on.show_external_endpoints_action, self._on_show_external_endpoints)  # type: ignore
+
+        # Hook hollistic method
+        observe(self.on.traefik_pebble_ready, self.cleanup_tls_configuration)  # type: ignore
+        observe(self.on.start, self.cleanup_tls_configuration)
+        observe(self.on.update_status, self.cleanup_tls_configuration)
+        observe(self.on.config_changed, self.cleanup_tls_configuration)
+        observe(
+            self.on[CERTIFICATES_RELATION_NAME].relation_broken,  # pyright: ignore
+            self.cleanup_tls_configuration,
+        )
+
+    def cleanup_tls_configuration(self, _: EventBase) -> None:
+        """Clean up Traefik's TLS configuration.
+
+        This method hooks almost every event the charm is currently acting on, checks if TLS is
+        enabled and cleans up Traefik's TLS configuration if TLS is not enabled.
+
+        It is intentional that this method is ran on almost all events as this method will evolve
+        as we refactor the charm to be more hollistic.
+        """
+        self.traefik._cleanup_tls_configuration()
 
     def _get_cert_requests(self) -> list:
         # For a TCP route there will be no scheme which will cause urlparse()
@@ -590,7 +613,7 @@ class TraefikIngressCharm(CharmBase):
 
     def _is_tls_enabled(self) -> bool:
         """Return True if TLS is enabled."""
-        if self.model.relations.get("certificates"):
+        if self.model.relations.get(CERTIFICATES_RELATION_NAME):
             return True
         if (
             self.config.get("tls-ca", None)

--- a/src/charm.py
+++ b/src/charm.py
@@ -326,6 +326,11 @@ class TraefikIngressCharm(CharmBase):
             self.certs.on.certificate_available,  # pyright: ignore
             self._on_cert_changed,
         )
+        # Also run update logic on relation broken to properly update the status message.
+        observe(
+            self.on[CERTIFICATES_RELATION_NAME].relation_broken,  # pyright: ignore
+            self._on_cert_changed,
+        )
         observe(
             self.recv_ca_cert.on.certificate_available,  # pyright: ignore
             self._on_recv_ca_cert_available,

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -365,7 +365,7 @@ class Traefik:
                 if _raise:
                     raise e
                 logger.exception(
-                    f"Failed to merge {extra_config} into Traefik's static config.Skipping..."
+                    f"Failed to merge {extra_config} into Traefik's static config. Skipping..."
                 )
                 # roll back any changes static_config_deep_merge might have done to static_config
                 static_config = previous

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -3,6 +3,7 @@
 # See LICENSE file for licensing details.
 
 """Traefik workload interface."""
+
 import dataclasses
 import enum
 import logging
@@ -197,17 +198,9 @@ class Traefik:
             for path in CERTS_DIR.iterdir():
                 if path.name.endswith(".cert") and path.name[:5] not in certs:
                     path.unlink()
-        if self._container.isdir(CERTS_DIR):
-            for path in self._container.list_files(CERTS_DIR):
-                if path.name.endswith(".cert") and path.name[:5] not in certs:
-                    self._container.remove_path(path.path)
-                if path.name.endswith(".key") and path.name[:4] not in certs:
-                    self._container.remove_path(path.path)
-        if self._container.isdir(CA_CERTS_DIR):
-            for path in self._container.list_files(CA_CERTS_DIR):
-                # There could be other .crt files here so make sure the names are identifiable.
-                if path.name.endswith(".traefik-charm.crt") and path.name[:18] not in certs:
-                    self._container.remove_path(path.path)
+
+        self._clean_up_certificates_in_traefik_container(excluded_certs=certs)
+
         for hostname, cert in certs.items():
             with (CERTS_DIR / f"{hostname}.cert").open("w") as f:
                 f.write(cert["chain"])
@@ -218,6 +211,35 @@ class Traefik:
             )
 
         self.update_ca_certs()
+
+    def _clean_up_certificates_in_traefik_container(self, excluded_certs: dict) -> None:
+        """Clean up certificates in the remote traefik container.
+
+        Args:
+            excluded_certs: Certificates to exclude from cleaning up.
+        """
+        if self._container.isdir(CERTS_DIR):
+            for path in self._container.list_files(CERTS_DIR):
+                try:
+                    if path.name.endswith(".cert") and path.name[:5] not in excluded_certs:
+                        self._container.remove_path(path.path)
+                    if path.name.endswith(".key") and path.name[:4] not in excluded_certs:
+                        self._container.remove_path(path.path)
+                except PathError:
+                    logger.exception("Error removing cert file.")
+                    continue
+        if self._container.isdir(CA_CERTS_DIR):
+            for path in self._container.list_files(CA_CERTS_DIR):
+                # There could be other .crt files here so make sure the names are identifiable.
+                try:
+                    if (
+                        path.name.endswith(".traefik-charm.crt")
+                        and path.name[:18] not in excluded_certs
+                    ):
+                        self._container.remove_path(path.path)
+                except PathError:
+                    logger.exception("Error removing ca cert file.")
+                    continue
 
     def add_cas(self, cas: Iterable[CA]):
         """Add any number of CAs to Traefik.
@@ -343,7 +365,7 @@ class Traefik:
                 if _raise:
                     raise e
                 logger.exception(
-                    f"Failed to merge {extra_config} into Traefik's static config." "Skipping..."
+                    f"Failed to merge {extra_config} into Traefik's static config.Skipping..."
                 )
                 # roll back any changes static_config_deep_merge might have done to static_config
                 static_config = previous

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -794,7 +794,7 @@ class Traefik:
 
     def _cleanup_tls_configuration(self):
         """Remove the Traefik certificates configuration if TLS is disabled."""
-        if not self._tls_enabled:
+        if not self._tls_enabled and self._container.can_connect():
             # Remove certificates.yaml if TLS is not configured.
             if self._container.exists(DYNAMIC_CERTS_PATH):
                 try:


### PR DESCRIPTION
fixes #504, fixes #480, fixes #514

Add a `try/except` guard to the `remove_path` call when removing old certificates.

Add a cleanup method for TLS configuration.
