### PR TITLE
chore: bump cosl so new charm libs succeed

### DIFF
--- a/lib/charms/tls_certificates_interface/v4/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v4/tls_certificates.py
@@ -1,7 +1,26 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Charm library for managing TLS certificates (V4).
+"""Legacy Charmhub-hosted lib, deprecated in favour of ``charmlibs.interfaces.tls_certificates``.
+
+WARNING: This library is deprecated.
+It will not receive feature updates or bugfixes.
+``charmlibs.interfaces.tls_certificates`` 1.0 is a bug-for-bug compatible migration of this library.
+
+To migrate:
+1. Add 'charmlibs-interfaces-tls-certificates~=1.0' to your charm's dependencies,
+   and remove this Charmhub-hosted library from your charm.
+2. You can also remove any dependencies added to your charm only because of this library.
+3. Replace `from charms.tls_certificates_interface.v4 import tls_certificates`
+   with `from charmlibs.interfaces import tls_certificates`.
+
+Read more:
+- https://documentation.ubuntu.com/charmlibs
+- https://pypi.org/project/charmlibs-interfaces-tls-certificates
+
+---
+
+Charm library for managing TLS certificates (V4).
 
 This library contains the Requires and Provides classes for handling the tls-certificates
 interface.
@@ -22,10 +41,10 @@ import json
 import logging
 import uuid
 from contextlib import suppress
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import FrozenSet, List, MutableMapping, Optional, Tuple, Union
+from typing import Dict, FrozenSet, List, MutableMapping, Optional, Tuple, Union
 
 import pydantic
 from cryptography import x509
@@ -46,7 +65,7 @@ LIBAPI = 4
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 22
+LIBPATCH = 24
 
 PYDEPS = [
     "cryptography>=43.0.0",
@@ -55,6 +74,48 @@ PYDEPS = [
 IS_PYDANTIC_V1 = int(pydantic.version.VERSION.split(".")[0]) < 2
 
 logger = logging.getLogger(__name__)
+
+NESTED_JSON_KEY = "owasp_event"
+
+
+@dataclass
+class _OWASPLogEvent:
+    """OWASP-compliant log event."""
+
+    datetime: str
+    event: str
+    level: str
+    description: str
+    type: str = "security"
+    labels: Dict[str, str] = field(default_factory=dict)
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), ensure_ascii=False)
+
+    def to_dict(self) -> Dict:
+        log_event = dict(asdict(self), **self.labels)
+        log_event.pop("labels", None)
+        return {k: v for k, v in log_event.items() if v is not None}
+
+
+class _OWASPLogger:
+    """OWASP-compliant logger for security events."""
+
+    def __init__(self, application: Optional[str] = None):
+        self.application = application
+        self._logger = logging.getLogger(__name__)
+
+    def log_event(self, event: str, level: int, description: str, **labels: str):
+        if self.application and "application" not in labels:
+            labels["application"] = self.application
+        log = _OWASPLogEvent(
+            datetime=datetime.now(timezone.utc).astimezone().isoformat(),
+            event=event,
+            level=logging.getLevelName(level),
+            description=description,
+            labels=labels,
+        )
+        self._logger.log(level, log.to_json(), extra={NESTED_JSON_KEY: log.to_dict()})
 
 
 class TLSCertificatesError(Exception):
@@ -726,7 +787,14 @@ def generate_private_key(
         format=serialization.PrivateFormat.TraditionalOpenSSL,
         encryption_algorithm=serialization.NoEncryption(),
     )
-    return PrivateKey.from_string(key_bytes.decode())
+    key = PrivateKey.from_string(key_bytes.decode())
+    _OWASPLogger().log_event(
+        event="private_key_generated",
+        level=logging.INFO,
+        description="Private key generated",
+        key_size=str(key_size),
+    )
+    return key
 
 
 def calculate_relative_datetime(target_time: datetime, fraction: float) -> datetime:
@@ -950,6 +1018,13 @@ def generate_ca(
         builder = builder.add_extension(san_extension, critical=False)
     cert = builder.sign(private_key_object, hashes.SHA256())  # type: ignore[arg-type]
     ca_cert_str = cert.public_bytes(serialization.Encoding.PEM).decode().strip()
+    _OWASPLogger().log_event(
+        event="ca_certificate_generated",
+        level=logging.INFO,
+        description="CA certificate generated",
+        common_name=common_name,
+        validity_days=str(validity.days),
+    )
     return Certificate.from_string(ca_cert_str)
 
 
@@ -1026,6 +1101,14 @@ def generate_certificate(
 
     cert = certificate_builder.sign(private_key, hashes.SHA256())  # type: ignore[arg-type]
     cert_bytes = cert.public_bytes(serialization.Encoding.PEM)
+    _OWASPLogger().log_event(
+        event="certificate_generated",
+        level=logging.INFO,
+        description="Certificate generated from CSR",
+        common_name=csr.common_name,
+        is_ca=str(is_ca),
+        validity_days=str(validity.days),
+    )
     return Certificate.from_string(cert_bytes.decode().strip())
 
 
@@ -1212,7 +1295,7 @@ class TLSCertificatesRequiresV4(Object):
             raise TLSCertificatesError("Invalid private key")
         if renewal_relative_time <= 0.5 or renewal_relative_time > 1.0:
             raise TLSCertificatesError(
-                "Invalid renewal relative time. Must be between 0.0 and 1.0"
+                "Invalid renewal relative time. Must be between 0.5 and 1.0"
             )
         self._private_key = private_key
         self.renewal_relative_time = renewal_relative_time
@@ -1222,6 +1305,7 @@ class TLSCertificatesRequiresV4(Object):
         self.framework.observe(charm.on.secret_remove, self._on_secret_remove)
         for event in refresh_events:
             self.framework.observe(event, self._configure)
+        self._security_logger = _OWASPLogger(application=f"tls-certificates-{charm.app.name}")
 
     def _configure(self, _: Optional[EventBase] = None):
         """Handle TLS Certificates Relation Data.
@@ -1744,6 +1828,7 @@ class TLSCertificatesProvidesV4(Object):
         self.framework.observe(charm.on.update_status, self._configure)
         self.charm = charm
         self.relationship_name = relationship_name
+        self._security_logger = _OWASPLogger(application=f"tls-certificates-{charm.app.name}")
 
     def _configure(self, _: EventBase) -> None:
         """Handle update status and tls relation changed events.
@@ -1889,6 +1974,11 @@ class TLSCertificatesProvidesV4(Object):
             for certificate in provider_certificates:
                 certificate.revoked = True
             self._dump_provider_certificates(relation=relation, certificates=provider_certificates)
+        self._security_logger.log_event(
+            event="all_certificates_revoked",
+            level=logging.WARNING,
+            description="All certificates revoked",
+        )
 
     def set_relation_certificate(
         self,
@@ -1917,6 +2007,13 @@ class TLSCertificatesProvidesV4(Object):
         self._add_provider_certificate(
             relation=certificates_relation,
             provider_certificate=provider_certificate,
+        )
+        self._security_logger.log_event(
+            event="certificate_provided",
+            level=logging.INFO,
+            description="Certificate provided to requirer",
+            relation_id=str(provider_certificate.relation_id),
+            common_name=provider_certificate.certificate.common_name,
         )
 
     def get_issued_certificates(

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.8.*"
 resolution-markers = [
     "python_full_version >= '3.8.6'",
@@ -297,7 +297,7 @@ wheels = [
 
 [[package]]
 name = "cosl"
-version = "1.0.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ops" },
@@ -306,9 +306,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/13/ca147298721702679f2a286022184fd12b9d5236124308bf363e7184e5b5/cosl-1.0.0.tar.gz", hash = "sha256:5cef884faac1313ae6d234fcd6f40db0cbdd44bcdacfd9a6e9ecf9cede219359", size = 40818, upload-time = "2025-05-22T13:26:16.284Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/d5/a9ea4a4c29a374d6d356bbdc2a78348de5dc7aa2d869b932bbd559367d2b/cosl-1.3.1.tar.gz", hash = "sha256:aa836828350398beb5bbd4fe85cb582e796a7b8b5d9a214a5bc6fd855cde11af", size = 45361, upload-time = "2025-10-08T09:58:04.504Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/58/e80bd8436e2a6bb80b62b0317711d48ef1cab4b38e0e9f1efe73d13c0187/cosl-1.0.0-py3-none-any.whl", hash = "sha256:4ed54e818a5614a5164011253c12441cd0bffacfd99c8bd6b5b9740a397e482d", size = 33525, upload-time = "2025-05-22T13:26:14.804Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/54/a72b67cae15af226882dd6c7da011c26ae3c9c5843c36511d0dd1753c298/cosl-1.3.1-py3-none-any.whl", hash = "sha256:8ab9b23b367f041ec0f4eae63d4b1960712431a2b3bf6fb6fdec473efea30f77", size = 36387, upload-time = "2025-10-08T09:58:03.544Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Fixes #568.
### Rationale
The [current automated action to fetch the newest charm libs](https://github.com/canonical/traefik-k8s-operator/pull/563) fails because in the changes is a bump to `grafana_dashboard`. The new version of this lib relies on `cosl` >= 1.3.1. Traefik is currently using 1.0.0.

TLDR: `cosl` should be bumped to allow for update of charm libs. 
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->
Updates:
1. `grafana_k8s.v0.grafana_dashboard` updated to version 0.46.
2. `tls_certificates_interface.v4.tls_certificates` updated to version 4.24
### Checklist

- [ ] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
