### PR TITLE
Feat: Disable telemetry

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -17,29 +17,37 @@ from urllib.parse import urlparse
 
 import pydantic
 import yaml
-from charms.certificate_transfer_interface.v1.certificate_transfer import \
-    CertificatesAvailableEvent as CertificateTransferAvailableEvent
-from charms.certificate_transfer_interface.v1.certificate_transfer import \
-    CertificatesRemovedEvent as CertificateTransferRemovedEvent
-from charms.certificate_transfer_interface.v1.certificate_transfer import \
-    CertificateTransferRequires
+from charms.certificate_transfer_interface.v1.certificate_transfer import (
+    CertificatesAvailableEvent as CertificateTransferAvailableEvent,
+)
+from charms.certificate_transfer_interface.v1.certificate_transfer import (
+    CertificatesRemovedEvent as CertificateTransferRemovedEvent,
+)
+from charms.certificate_transfer_interface.v1.certificate_transfer import (
+    CertificateTransferRequires,
+)
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.loki_k8s.v1.loki_push_api import LokiPushApiConsumer
-from charms.oathkeeper.v0.forward_auth import (AuthConfigChangedEvent,
-                                               AuthConfigRemovedEvent,
-                                               ForwardAuthRequirer,
-                                               ForwardAuthRequirerConfig)
+from charms.oathkeeper.v0.forward_auth import (
+    AuthConfigChangedEvent,
+    AuthConfigRemovedEvent,
+    ForwardAuthRequirer,
+    ForwardAuthRequirerConfig,
+)
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
-from charms.tempo_coordinator_k8s.v0.tracing import (TracingEndpointRequirer,
-                                                     charm_tracing_config)
+from charms.tempo_coordinator_k8s.v0.tracing import TracingEndpointRequirer, charm_tracing_config
 from charms.tls_certificates_interface.v4.tls_certificates import (
-    CertificateRequestAttributes, Mode, TLSCertificatesRequiresV4)
+    CertificateRequestAttributes,
+    Mode,
+    TLSCertificatesRequiresV4,
+)
 from charms.traefik_k8s.v0.traefik_route import (
-    TraefikRouteProvider, TraefikRouteRequirerReadyEvent)
+    TraefikRouteProvider,
+    TraefikRouteRequirerReadyEvent,
+)
 from charms.traefik_k8s.v1.ingress import IngressPerAppProvider as IPAv1
-from charms.traefik_k8s.v1.ingress_per_unit import (DataValidationError,
-                                                    IngressPerUnitProvider)
+from charms.traefik_k8s.v1.ingress_per_unit import DataValidationError, IngressPerUnitProvider
 from charms.traefik_k8s.v2.ingress import IngressPerAppProvider as IPAv2
 from charms.traefik_k8s.v2.ingress import IngressPerAppRequirer
 from cosl import JujuTopology
@@ -49,19 +57,22 @@ from lightkube.core.exceptions import ApiError
 from lightkube.models.core_v1 import ServicePort, ServiceSpec
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Service
-from lightkube_extensions.batch import (KubernetesResourceManager,
-                                        create_charm_default_labels)
+from lightkube_extensions.batch import KubernetesResourceManager, create_charm_default_labels
 from ops import EventBase, main
-from ops.charm import (ActionEvent, CharmBase, PebbleReadyEvent,
-                       RelationBrokenEvent, RelationEvent, StartEvent,
-                       UpdateStatusEvent)
+from ops.charm import (
+    ActionEvent,
+    CharmBase,
+    PebbleReadyEvent,
+    RelationBrokenEvent,
+    RelationEvent,
+    StartEvent,
+    UpdateStatusEvent,
+)
 from ops.framework import StoredState
-from ops.model import (ActiveStatus, BlockedStatus, MaintenanceStatus,
-                       Relation, WaitingStatus)
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, Relation, WaitingStatus
 from ops.pebble import PathError
 
-from traefik import (CA, SERVER_CERT_PATH, RoutingMode,
-                     StaticConfigMergeConflictError, Traefik)
+from traefik import CA, SERVER_CERT_PATH, RoutingMode, StaticConfigMergeConflictError, Traefik
 from utils import is_hostname
 
 # To keep a tidy debug-log, we suppress some DEBUG/INFO logs from some imported libs,

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -133,7 +133,6 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self._topology = topology
         self._basic_auth_user = basic_auth_user
         self._tracing_endpoint = tracing_endpoint
-        self._anonymous_telemetry_enabled = anonymous_telemetry_enabled
 
     @property
     def scrape_jobs(self) -> list:


### PR DESCRIPTION

### Overview


Disables anonymous telemetry because it is very likely that the users will be concerned about their data and also the firewalls will not let the telemetry data out of the infrastructure.

Addresses : [Issue 566](https://github.com/canonical/traefik-k8s-operator/issues/566)
<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
