### PR TITLE
Use dedicated product name

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -6,7 +6,7 @@ settings:
     not_planned: rejected
     
   components:
-    - Kubernetes ingress
+    - Traefik
 
   add_gh_comment: true
 


### PR DESCRIPTION
We now have a dedicated product for Traefik.