### PR TITLE
fix: prepend leaf cert to chain when provider omits it

### DIFF
--- a/docs/release-notes/artifacts/pr0639.yaml
+++ b/docs/release-notes/artifacts/pr0639.yaml
@@ -1,0 +1,14 @@
+# --- Release notes artifact ----
+
+schema_version: 1
+changes:
+  - title: Fixed TLS certificate chain when using Vault intermediate CA
+    author: gboutry
+    type: bugfix
+    description: Fixed an issue where traefik served the CA certificate instead of the leaf certificate when using Vault as an intermediate CA provider.
+    urls:
+      pr: https://github.com/canonical/traefik-k8s-operator/pull/641
+      related_doc:
+      related_issue: https://github.com/canonical/traefik-k8s-operator/issues/639
+    visibility: public
+    highlight: false

--- a/src/charm.py
+++ b/src/charm.py
@@ -803,8 +803,16 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
                 logger.debug(f"No cert found for csr: {csr}")
                 continue
             chain = [str(certificate) for certificate in cert.chain]
-            if str(chain[0]) != str(cert.certificate):
-                chain.reverse()
+            leaf = str(cert.certificate)
+            if leaf in chain:
+                # Leaf is in the chain; ensure it's first.
+                # Some versions of the tls library return the chain reversed.
+                if chain[0] != leaf:
+                    chain.reverse()
+            else:
+                # Some providers (e.g. Vault intermediate CA) don't include
+                # the leaf in the chain, only the CA chain. Prepend it.
+                chain.insert(0, leaf)
             certs[csr.common_name] = {
                 "chain": "\n\n".join(chain),
                 "key": str(private_key),

--- a/tests/scenario/test_tls_certificates.py
+++ b/tests/scenario/test_tls_certificates.py
@@ -170,6 +170,55 @@ def test_get_certs(traefik_ctx, traefik_container, mock_provider_certificate):
         )
 
 
+@patch("charm.TraefikIngressCharm.version", PropertyMock(return_value="0.0.0"))
+@patch("traefik.Traefik.update_cert_configuration", MagicMock())
+def test_get_certs_intermediate_ca(traefik_ctx, traefik_container):
+    """Verify _get_certs puts the leaf cert first when chain has only CA certs (Vault scenario)."""
+    leaf = "-----BEGIN CERTIFICATE-----leaf-----END CERTIFICATE-----"
+    intermediate_ca = "-----BEGIN CERTIFICATE-----intermediate ca-----END CERTIFICATE-----"
+    root_ca = "-----BEGIN CERTIFICATE-----root ca-----END CERTIFICATE-----"
+
+    provider_cert = MagicMock()
+    provider_cert.certificate = leaf
+    provider_cert.ca = intermediate_ca
+    # Vault-style chain: only CA certs, no leaf
+    provider_cert.chain = [intermediate_ca, root_ca]
+
+    certs_rel = Relation(
+        endpoint="certificates",
+        remote_app_name="certificates_provider",
+    )
+    peer_rel = PeerRelation(endpoint="peers")
+
+    state = State(
+        leader=True,
+        config={"routing_mode": "path"},
+        relations=[certs_rel, peer_rel],
+        containers=[traefik_container],
+    )
+
+    with traefik_ctx.manager(certs_rel.changed_event, state) as mgr:
+        charm = mgr.charm
+        mock_csr = MagicMock()
+        mock_csr.common_name = "example.com"
+        charm.csrs = [mock_csr]
+
+        with patch.object(
+            charm.certs,
+            "get_assigned_certificate",
+            return_value=(provider_cert, "mock private key"),
+        ):
+            certs = charm._get_certs()
+
+        chain_str = certs["example.com"]["chain"]
+        chain_parts = chain_str.split("\n\n")
+        # Leaf must be first
+        assert chain_parts[0] == leaf
+        # Followed by the CA chain
+        assert chain_parts[1] == intermediate_ca
+        assert chain_parts[2] == root_ca
+
+
 @pytest.mark.parametrize("tls_enabled", [(True,), (False)])
 def test_cleanup_tls_configuration(tls_enabled: bool):
     container_mock = MagicMock(spec=Container)


### PR DESCRIPTION
#### What this PR does

Fixes the TLS certificate chain construction in `_get_certs_from_relation`. When the TLS provider (e.g. Vault intermediate CA) returns a chain that does not include the leaf certificate, the leaf is now prepended. The existing reverse logic for when the leaf is present but in wrong order is preserved.

#### Why we need it

When using Vault as an intermediate CA, the chain returned by the provider contains only CA certificates (`[intermediate_CA, root_CA]`), not the leaf. The old code only handled reordering via `reverse()`, which doesn't help when the leaf is absent — traefik ended up serving the CA cert as the server cert, breaking TLS entirely.

#### Test plan

- Added `test_get_certs_intermediate_ca` covering the Vault scenario (chain without leaf)
- Existing `test_get_certs` covers the reversed-chain scenario (leaf present but last)
- Full unit test suite passes (554 passed)

#### Review focus

- The branching logic at `src/charm.py:806-814`: `if leaf in chain` preserves old reverse behaviour, `else` handles the new missing-leaf case.

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [x] I added a change artifact for user-relevant changes in `docs/release-notes/artifacts`
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)

Closes #639