### PR TITLE
Remove unnecessary annotation value validation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,7 @@ options:
       The format should be: `key1=value1,key2=value2,key3=value3`.
       These annotations are passed directly to the Kubernetes LoadBalancer service, 
       enabling customization for specific cloud provider settings or integrations.
+      Note that "key1=" will be interpreted as {"key1": ""} when passed to k8s. Annotation values can be empty strings.
       
       Example:
         "external-dns.alpha.kubernetes.io/hostname=example.com,service.beta.kubernetes.io/aws-load-balancer-type=nlb"

--- a/docs/release-notes/artifacts/pr0653.yaml
+++ b/docs/release-notes/artifacts/pr0653.yaml
@@ -1,0 +1,14 @@
+# --- Release notes artifact ----
+
+schema_version: 1
+changes:
+  - title: Removed unnecessary validation on k8s annotation values
+    author: mostafaCamel
+    type: trivial
+    description: This PR removes unecessary k8s annotation values as k8s itself does not do such a validation and allows urls as values
+    urls: 
+      pr: https://github.com/canonical/traefik-k8s-operator/pull/653
+      related_doc: 
+      related_issue: https://github.com/canonical/traefik-k8s-operator/issues/647
+    visibility: public
+    highlight: false

--- a/src/charm.py
+++ b/src/charm.py
@@ -105,15 +105,6 @@ logger = logging.getLogger(__name__)
 
 _TRAEFIK_CONTAINER_NAME = "traefik"
 
-
-# Regex for Kubernetes annotation values:
-# - Allows alphanumeric characters, dots (.), dashes (-), and underscores (_)
-# - Matches the entire string
-# - Does not allow empty strings
-# - Example valid: "value1", "my-value", "value.name", "value_name"
-# - Example invalid: "value@", "value#", "value space"
-ANNOTATION_VALUE_PATTERN = re.compile(r"^[\w.\-_]+$")
-
 # Based on https://github.com/kubernetes/apimachinery/blob/v0.31.3/pkg/util/validation/validation.go#L204  # noqa  # pylint: disable=line-too-long
 # Regex for DNS1123 subdomains:
 # - Starts with a lowercase letter or number ([a-z0-9])
@@ -1919,18 +1910,6 @@ def validate_annotation_key(key: str) -> bool:
 
     return True
 
-
-def validate_annotation_value(value: str) -> bool:
-    """Validate the annotation value."""
-    if not ANNOTATION_VALUE_PATTERN.match(value):
-        logger.error(
-            "Invalid annotation value: '%s'. Must follow Kubernetes annotation syntax.", value
-        )
-        return False
-
-    return True
-
-
 def parse_annotations(annotations: Optional[str]) -> Optional[Dict[str, str]]:
     """Parse and validate annotations from a string.
 
@@ -1955,8 +1934,8 @@ def parse_annotations(annotations: Optional[str]) -> Optional[Dict[str, str]]:
         return None
 
     # Validate each key-value pair
-    for key, value in parsed_annotations.items():
-        if not validate_annotation_key(key) or not validate_annotation_value(value):
+    for key, _ in parsed_annotations.items():
+        if not validate_annotation_key(key):
             return None
 
     return parsed_annotations

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -668,22 +668,21 @@ class TestConfigOptionsValidation(unittest.TestCase):
                 "key=value,key.sub-key=value-with-hyphen",
                 {"key": "value", "key.sub-key": "value-with-hyphen"},
             ),
+            ("key=val=ueWithEqual", {"key": "val=ueWithEqual"}),
+            ("kubernetes/key_with_empty_val=", {"kubernetes/key_with_empty_val": ""}),
+            ("key=https://url.com", {"key": "https://url.com"}),
             # Invalid cases
-            ("key1=value1,key2=value2,key=value3,key4=", None),  # Missing value for key4
             (
                 "kubernetes.io/description=this-is-valid,custom.io/key=value",
                 None,
             ),  # Reserved prefix used
             ("key1=value1,key2", None),
             ("key1=value1,example..com/key2=value2", None),  # Invalid domain format (double dot)
-            ("key1=value1,key=value2,key3=", None),  # Trailing equals for key3
             ("key1=value1,=value2", None),  # Missing key
-            ("key1=value1,key=val=ue2", None),  # Extra equals in value
             ("a" * 256 + "=value", None),  # Key exceeds max length (256 characters)
             ("key@=value", None),  # Invalid character in key
             ("key. =value", None),  # Space in key
             ("key,value", None),  # Missing '=' delimiter
-            ("kubernetes/description=", None),  # Key with no value
         ]
 
         for annotations, expected_result in test_cases:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Remove unnnecessary validation on k8s annotation values.

k8s does not do do any validation on the content of the annotation value . See `for k := range annotations {` (which means the validation inside this block is only on the key and not on the value ) in the validation package ([here](https://github.com/kubernetes/kubernetes/blob/03779bbd00da25c7fcd03711ddfe466a3322e1d7/staging/src/k8s.io/apimachinery/pkg/api/validation/objectmeta.go#L46) and [here](https://github.com/kubernetes/apimachinery/blob/72791e98891abe6955b7bcc709f9904c8434c8b0/pkg/api/validation/objectmeta.go#L46))

Also, in the k8s documentation, there is an [example](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set) of a url as an annotation value , which is not allowed in the pattern currently in src/charm.py

### Rationale

Being able to pass annotation values that are pefectly fine from a k8s perspective

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [ x ] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [ x ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ x ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ x ] The documentation is updated
- [ x ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ x ] The `docs/changelog.md` is updated with user-relevant changes.
- [ x ] The `LIBAPI` and `LIBPATCH` values have been incremented for charm libraries owned by this project (if they were modified).

<!-- Explanation for any unchecked items above -->
