### PR TITLE
Fix missing wait

### DIFF
--- a/src/traefik.py
+++ b/src/traefik.py
@@ -728,7 +728,7 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def delete_dynamic_configs(self) -> None:
         """Delete **ALL** yamls from the dynamic config dir."""
         # instead of multiple calls to self._container.remove_path(), delete all files in a swoop
-        self._container.exec(["find", DYNAMIC_CONFIG_DIR, "-name", "*.yaml", "-delete"])
+        self._container.exec(["find", DYNAMIC_CONFIG_DIR, "-name", "*.yaml", "-delete"]).wait()
         logger.debug("Deleted all dynamic configuration files.")
 
     def delete_dynamic_config(self, file_name: str) -> None:

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -728,7 +728,10 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def delete_dynamic_configs(self) -> None:
         """Delete **ALL** yamls from the dynamic config dir."""
         # instead of multiple calls to self._container.remove_path(), delete all files in a swoop
-        self._container.exec(["find", DYNAMIC_CONFIG_DIR, "-name", "*.yaml", "-delete"], timeout=60).wait()
+        self._container.exec(
+            ["find", DYNAMIC_CONFIG_DIR, "-name", "*.yaml", "-delete"],
+            timeout=60,
+        ).wait()
         logger.debug("Deleted all dynamic configuration files.")
 
     def delete_dynamic_config(self, file_name: str) -> None:

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -728,7 +728,7 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def delete_dynamic_configs(self) -> None:
         """Delete **ALL** yamls from the dynamic config dir."""
         # instead of multiple calls to self._container.remove_path(), delete all files in a swoop
-        self._container.exec(["find", DYNAMIC_CONFIG_DIR, "-name", "*.yaml", "-delete"]).wait()
+        self._container.exec(["find", DYNAMIC_CONFIG_DIR, "-name", "*.yaml", "-delete"], timeout=60).wait()
         logger.debug("Deleted all dynamic configuration files.")
 
     def delete_dynamic_config(self, file_name: str) -> None:


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Add `wait()` to a container `exec()`.

### Rationale

<!-- The reason the change is needed -->
The `wait()` call waits for the config file to be deleted before the next `update_tls_configuration` pushes a config file to the same path.

There can be a race condition between the delete and push file if they are executed without waiting for one to complete first.

### Checklist

- [x] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.
- [ ] The `LIBAPI` and `LIBPATCH` values have been incremented for charm libraries owned by this project (if they were modified).

<!-- Explanation for any unchecked items above -->
