### PR TITLE
bug: Ensure hosts ordering

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-05-05
+
+- Ensure hosts ordering in the dynamic configuration files.
+
 ## 2026-04-19
 
 - Removed redundant `relation-created` and `relation-joined` event observers from the ingress v1 and v2 libraries; ingress processing now triggers only on `relation-changed`.

--- a/docs/release-notes/artifacts/pr0673.yaml
+++ b/docs/release-notes/artifacts/pr0673.yaml
@@ -1,0 +1,17 @@
+# --- Release notes artifact ----
+
+schema_version: 1
+changes:
+  - title: Ensure hosts ordering in the dynamic configuration files
+    author: swetha1654
+    type: trivial
+    description: |
+      This PR ensures that the hosts are ordered alphabetically, which is important for consistency 
+      and predictability when managing Traefik configurations. This especially helps when host ordering
+      causes traefik to push different dynamic configurations, resulting in unnecessary reset of traefik health checks.
+    urls: 
+      pr: https://github.com/canonical/traefik-k8s-operator/pull/673
+      related_doc: 
+      related_issue: https://github.com/canonical/traefik-k8s-operator/issues/665
+    visibility: public
+    highlight: false

--- a/docs/release-notes/artifacts/pr0673.yaml
+++ b/docs/release-notes/artifacts/pr0673.yaml
@@ -5,13 +5,11 @@ changes:
   - title: Ensure hosts ordering in the dynamic configuration files
     author: swetha1654
     type: trivial
-    description: |
-      This PR ensures that the hosts are ordered alphabetically, which is important for consistency 
-      and predictability when managing Traefik configurations. This especially helps when host ordering
-      causes traefik to push different dynamic configurations, resulting in unnecessary reset of traefik health checks.
-    urls: 
-      pr: https://github.com/canonical/traefik-k8s-operator/pull/673
-      related_doc: 
+    description: "This PR ensures that the hosts are ordered alphabetically, which is important for consistency \nand predictability when managing Traefik configurations. This especially helps when host ordering\ncauses traefik to push different dynamic configurations, resulting in unnecessary reset of traefik health checks.\n"
+    urls:
+      pr:
+        - https://github.com/canonical/traefik-k8s-operator/pull/673
+      related_doc:
       related_issue: https://github.com/canonical/traefik-k8s-operator/issues/665
     visibility: public
     highlight: false

--- a/src/charm.py
+++ b/src/charm.py
@@ -1561,7 +1561,7 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
             strip_prefix=data.app.strip_prefix,
             port=data.app.port,
             external_host=self.gateway_address,
-            hosts=[udata.host for udata in data.units],
+            hosts=sorted([udata.host for udata in data.units]),
             forward_auth_app=self.forward_auth.is_protected_app(app=data.app.name),
             forward_auth_config=self.forward_auth.get_provider_info(),
             healthcheck_params=(

--- a/tests/unit/test_ingress_per_app.py
+++ b/tests/unit/test_ingress_per_app.py
@@ -393,3 +393,34 @@ def test_ingress_with_hostname_and_routing_mode(
     # event = getattr(ipa, f"changed_event")
     state_out = traefik_ctx.run("config-changed", state)
     assert state_out.relations[0].local_app_data == expected_local_app_data
+
+
+def test_ingress_per_app_servers_are_sorted(traefik_ctx, model, traefik_container):
+    """Check that load-balancer servers are listed in sorted host order."""
+    # GIVEN a multi-unit app whose hosts arrive in reverse alphabetical order
+    hosts = ["z.unit.svc", "m.unit.svc", "a.unit.svc"]
+    ips = ["1.0.0.3", "1.0.0.2", "1.0.0.1"]
+    ipa = create_ingress_relation(port=80, hosts=hosts, ips=ips)
+
+    state = State(
+        model=model,
+        config={"routing_mode": "path", "external_hostname": "foo.com"},
+        containers=[traefik_container],
+        relations=[ipa],
+    )
+
+    # WHEN the relation changed event fires
+    traefik_ctx.run(ipa.changed_event, state)
+
+    generated_config = yaml.safe_load(
+        traefik_container.get_filesystem(traefik_ctx)
+        .joinpath(f"opt/traefik/juju/juju_ingress_ingress_{ipa.relation_id}_remote.yaml")
+        .read_text()
+    )
+
+    servers = generated_config["http"]["services"]["juju-test-model-remote-0-service"][
+        "loadBalancer"
+    ]["servers"]
+
+    # THEN the servers appear in sorted host order regardless of relation-data order
+    assert servers == [{"url": f"http://{h}:80"} for h in sorted(hosts)]


### PR DESCRIPTION
#### What this PR does

Partially fixes #665 
Note: As mentioned in the issue, this does not entirely fix API outages, as the outages also occur due to update status reconciling the lb everytime the hook is run and other underlying k8s objects not serving all the time. We do not ideally have to observe update-status hook, but since this is not a wholistic charm yet, right now the hook is observed to fix any disparities occuring from other hooks.

#### Why we need it

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I added a [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) for user-relevant changes in `docs/release-notes/artifacts`. If no change artifact is necessary, I tagged the PR with the label `no-release-note`.
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this PR modifies charm libraries owned by this project**: I incremented the `LIBAPI` and `LIBPATCH` values

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

