### PR TITLE
fix: Handle traefik-route

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-05-08
+
+- Added `wipe_ingress_data` method to `TraefikRouteProvider` to clear ingress data on traefik-route relations during ingress resets.
+- Simplified the `_handle_traefik_route_ready` handler to delegate to `_process_status_and_configurations`.
+- Included `traefik-route` relations in `_wipe_ingress_for_all_relations` so that route ingress data is also cleared during full resets.
+
 ## 2026-05-07
 
 - Fixed `_on_remove` to only delete the LoadBalancer resource when the application is fully removed (0 planned units), preventing accidental LB deletion during scale-down.

--- a/docs/release-notes/artifacts/pr0677.yaml
+++ b/docs/release-notes/artifacts/pr0677.yaml
@@ -1,0 +1,15 @@
+# Version of the artifact schema
+version_schema: 2
+# The key holding the change(s)
+changes:
+  - title: Added wipe_ingress_data to TraefikRouteProvider and included traefik-route in ingress resets
+    author: swetha1654
+    type: bugfix
+    description: "Added a `wipe_ingress_data` method to `TraefikRouteProvider` so that traefik-route \nrelations are properly cleared during ingress resets. Simplified the `_handle_traefik_route_ready` \nhandler and included traefik-route relations in `_wipe_ingress_for_all_relations`.\n"
+    urls:
+      pr:
+        - https://github.com/canonical/traefik-k8s-operator/pull/677
+      related_doc:
+      related_issue:
+    visibility: public
+    highlight: false

--- a/docs/release-notes/artifacts/pr0677.yaml
+++ b/docs/release-notes/artifacts/pr0677.yaml
@@ -9,6 +9,7 @@ changes:
     urls:
       pr:
         - https://github.com/canonical/traefik-k8s-operator/pull/677
+        - https://github.com/canonical/traefik-k8s-operator/pull/678
       related_doc:
       related_issue:
     visibility: public

--- a/docs/release-notes/artifacts/pr0678.yaml
+++ b/docs/release-notes/artifacts/pr0678.yaml
@@ -8,7 +8,6 @@ changes:
     description: "Added a `wipe_ingress_data` method to `TraefikRouteProvider` so that traefik-route \nrelations are properly cleared during ingress resets. Simplified the `_handle_traefik_route_ready` \nhandler and included traefik-route relations in `_wipe_ingress_for_all_relations`.\n"
     urls:
       pr:
-        - https://github.com/canonical/traefik-k8s-operator/pull/677
         - https://github.com/canonical/traefik-k8s-operator/pull/678
       related_doc:
       related_issue:

--- a/lib/charms/traefik_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_k8s/v0/traefik_route.py
@@ -108,6 +108,7 @@ class TraefikRouteCharm(CharmBase):
 import logging
 from typing import Optional
 
+from ops import ModelError
 import yaml
 from ops.charm import CharmBase, CharmEvents, RelationEvent
 from ops.framework import EventSource, Object, StoredState
@@ -121,7 +122,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 log = logging.getLogger(__name__)
 
@@ -275,6 +276,28 @@ class TraefikRouteProvider(Object):
         # state.
         self._stored.external_host = external_host
         self._stored.scheme = scheme
+    
+    def wipe_ingress_data(self, relation: Relation) -> None:
+        """Clear the provider-side external_host and scheme for a relation.
+
+        This signals to the requirer that the ingress route is no longer active.
+        Only the leader unit is allowed to modify app data.
+        """
+        if not self._charm.unit.is_leader():
+            return
+
+        try:
+            relation.data
+        except ModelError as e:
+            log.warning(
+                "error {} accessing relation data for {!r}. ".format(e, relation.name)
+            )
+            return
+        relation.data[self._charm.app].pop("external_host", None)
+        relation.data[self._charm.app].pop("scheme", None)
+
+        self._stored.external_host = None
+        self._stored.scheme = None
 
     def is_ready(self, relation: Relation) -> bool:
         """Whether TraefikRoute is ready on this relation.

--- a/lib/charms/traefik_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_k8s/v0/traefik_route.py
@@ -422,11 +422,9 @@ class TraefikRouteRequirer(Object):
                     self._stored.scheme = ""
                     return
                 external_host = relation.data[relation.app].get("external_host", "")
-                self._stored.external_host = (
-                    external_host or self._stored.external_host  # pyright: ignore
-                )
+                self._stored.external_host = external_host
                 scheme = relation.data[relation.app].get("scheme", "")
-                self._stored.scheme = scheme or self._stored.scheme  # pyright: ignore
+                self._stored.scheme = scheme
 
     def _on_relation_changed(self, event: RelationEvent) -> None:
         """Update StoredState with external_host and other information from Traefik."""

--- a/lib/charms/traefik_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_k8s/v0/traefik_route.py
@@ -246,11 +246,9 @@ class TraefikRouteProvider(Object):
                 self._stored.scheme = ""
                 return
             external_host = relation.data[relation.app].get("external_host", "")
-            self._stored.external_host = (
-                external_host or self._stored.external_host  # pyright: ignore
-            )
+            self._stored.external_host = external_host
             scheme = relation.data[relation.app].get("scheme", "")
-            self._stored.scheme = scheme or self._stored.scheme  # pyright: ignore
+            self._stored.scheme = scheme
 
     def _on_relation_changed(self, event: RelationEvent) -> None:
         if self.is_ready(event.relation):

--- a/lib/charms/traefik_k8s/v0/traefik_route.py
+++ b/lib/charms/traefik_k8s/v0/traefik_route.py
@@ -108,8 +108,8 @@ class TraefikRouteCharm(CharmBase):
 import logging
 from typing import Optional
 
-from ops import ModelError
 import yaml
+from ops import ModelError
 from ops.charm import CharmBase, CharmEvents, RelationEvent
 from ops.framework import EventSource, Object, StoredState
 from ops.model import Relation
@@ -276,7 +276,7 @@ class TraefikRouteProvider(Object):
         # state.
         self._stored.external_host = external_host
         self._stored.scheme = scheme
-    
+
     def wipe_ingress_data(self, relation: Relation) -> None:
         """Clear the provider-side external_host and scheme for a relation.
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -1340,24 +1340,6 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         if not self.container.can_connect():
             event.defer()
             return
-        if self._static_config_changed:
-            # This will regenerate the static configs and reevaluate all dynamic configs,
-            # including this one.
-            self._update_ingress_configurations()
-
-        else:
-            try:
-                self._process_ingress_relation(event.relation)
-            except IngressSetupError as e:
-                err_msg = e.args[0]
-                logger.error(
-                    "failed processing the ingress relation for "
-                    f"traefik-route ready with: {err_msg!r}"
-                )
-
-                self.unit.status = ActiveStatus("traefik-route relation degraded")
-                return
-
         try:
             self.traefik.generate_static_config(_raise=True)
         except StaticConfigMergeConflictError:
@@ -1368,8 +1350,7 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
                 "Failed to merge traefik-route static configs. Check logs for details."
             )
             return
-        self._reconcile_lb()
-        self.unit.status = ActiveStatus(self.serving_message())
+        self._process_status_and_configurations()
 
     def _process_ingress_relation(self, relation: Relation) -> None:
         # There's a chance that we're processing a relation event which was deferred until after
@@ -1650,7 +1631,11 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
 
     def _wipe_ingress_for_all_relations(self) -> None:
         self.unit.status = MaintenanceStatus("resetting all ingress relations")
-        for relation in self.model.relations["ingress"] + self.model.relations["ingress-per-unit"]:
+        for relation in (
+            self.model.relations["ingress"]
+            + self.model.relations["ingress-per-unit"]
+            + self.model.relations["traefik-route"]
+        ):
             self._wipe_ingress_for_relation(relation)
 
     def _wipe_ingress_for_relation(
@@ -1673,10 +1658,8 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
 
         # Wipe URLs sent to the requesting apps and units, as they are based on a gateway
         # address that is no longer valid.
-        # Skip this for traefik-route because it doesn't have a `wipe_ingress_data` method.
         provider = self._provider_from_relation(relation)
-        if wipe_rel_data and self.unit.is_leader() and provider != self.traefik_route:
-            # this is an ingress-type relation
+        if wipe_rel_data and self.unit.is_leader():
             provider.wipe_ingress_data(relation)  # type: ignore
 
     @staticmethod

--- a/tests/integration/test_charm_route.py
+++ b/tests/integration/test_charm_route.py
@@ -129,35 +129,41 @@ async def test_scale_and_get_external_host(ops_test: OpsTest):
     )
 
 
-@pytest.mark.teardown
-async def test_remove_relation(ops_test: OpsTest):
-    await ops_test.juju(
-        "remove-relation", f"{TESTER_APP_NAME}:traefik-route", f"{APP_NAME}:traefik-route"
-    )
-    await ops_test.model.wait_for_idle([APP_NAME], status="active")
+async def test_wipe_ingress_data_on_config_invalidation(ops_test: OpsTest):
+    """Verify traefik-route relation data is wiped when _wipe_ingress_for_all_relations fires.
 
-
-async def test_ingress_data_wiped_after_relation_removed(ops_test: OpsTest):
-    """After relation removal, re-relate and verify fresh data is published."""
-    # Re-add the relation
-    await ops_test.model.add_relation(
-        f"{TESTER_APP_NAME}:traefik-route", f"{APP_NAME}:traefik-route"
-    )
-    await ops_test.model.wait_for_idle([APP_NAME, TESTER_APP_NAME], status="active", timeout=1000)
-
-    # Verify the requirer can obtain the external host again after re-relating
+    Previously, traefik-route relations were excluded from the wipe. This test
+    confirms the new behavior: setting an invalid config (subdomain mode without
+    external_hostname) triggers a wipe that clears external_host on the
+    traefik-route relation.
+    """
+    # Confirm external_host is published to the requirer (relation is already active)
     unit = ops_test.model.applications[TESTER_APP_NAME].units[0]
     action = await unit.run_action("get-external-host")
     result = await action.wait()
     external_host = result.results.get("external-host")
-    assert external_host, "External host should be set after re-relating"
+    assert external_host, "External host should be set before config invalidation"
 
-    traefik_ip = await get_k8s_service_address(ops_test, f"{APP_NAME}-lb")
-    assert external_host == traefik_ip, (
-        f"External host should match traefik IP after re-relate: {external_host} vs {traefik_ip}"
+    # Trigger _wipe_ingress_for_all_relations by setting routing_mode=subdomain
+    # without external_hostname — this puts traefik into BlockedStatus and wipes all relations.
+    await ops_test.model.applications[APP_NAME].set_config({"routing_mode": "subdomain"})
+    await ops_test.model.wait_for_idle([APP_NAME], status="blocked", timeout=300)
+
+    # Verify that external_host is now cleared on the requirer side
+    action = await unit.run_action("get-external-host")
+    result = await action.wait()
+    external_host_after = result.results.get("external-host")
+    assert not external_host_after, (
+        f"External host should be empty after wipe, got: {external_host_after!r}"
     )
 
-    # Clean up: remove the relation again
+    # Restore valid config
+    await ops_test.model.applications[APP_NAME].set_config({"routing_mode": "path"})
+    await ops_test.model.wait_for_idle([APP_NAME, TESTER_APP_NAME], status="active", timeout=1000)
+
+
+@pytest.mark.teardown
+async def test_remove_relation(ops_test: OpsTest):
     await ops_test.juju(
         "remove-relation", f"{TESTER_APP_NAME}:traefik-route", f"{APP_NAME}:traefik-route"
     )

--- a/tests/integration/test_charm_route.py
+++ b/tests/integration/test_charm_route.py
@@ -137,5 +137,32 @@ async def test_remove_relation(ops_test: OpsTest):
     await ops_test.model.wait_for_idle([APP_NAME], status="active")
 
 
+async def test_ingress_data_wiped_after_relation_removed(ops_test: OpsTest):
+    """After relation removal, re-relate and verify fresh data is published."""
+    # Re-add the relation
+    await ops_test.model.add_relation(
+        f"{TESTER_APP_NAME}:traefik-route", f"{APP_NAME}:traefik-route"
+    )
+    await ops_test.model.wait_for_idle([APP_NAME, TESTER_APP_NAME], status="active", timeout=1000)
+
+    # Verify the requirer can obtain the external host again after re-relating
+    unit = ops_test.model.applications[TESTER_APP_NAME].units[0]
+    action = await unit.run_action("get-external-host")
+    result = await action.wait()
+    external_host = result.results.get("external-host")
+    assert external_host, "External host should be set after re-relating"
+
+    traefik_ip = await get_k8s_service_address(ops_test, f"{APP_NAME}-lb")
+    assert external_host == traefik_ip, (
+        f"External host should match traefik IP after re-relate: {external_host} vs {traefik_ip}"
+    )
+
+    # Clean up: remove the relation again
+    await ops_test.juju(
+        "remove-relation", f"{TESTER_APP_NAME}:traefik-route", f"{APP_NAME}:traefik-route"
+    )
+    await ops_test.model.wait_for_idle([APP_NAME], status="active")
+
+
 async def test_cleanup(ops_test):
     await remove_application(ops_test, APP_NAME, timeout=60)

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -2,13 +2,35 @@ import pathlib
 from unittest.mock import PropertyMock, patch
 
 import pytest
+import yaml
 from charms.tempo_coordinator_k8s.v0.charm_tracing import charm_tracing_disabled
 from ops import pebble
-from scenario import Container, Context, ExecOutput, Model, Mount
+from scenario import Container, Context, ExecOutput, Model, Mount, Relation, State
 
 from charm import TraefikIngressCharm
 
 MOCK_LB_ADDRESS = "1.2.3.4"
+
+ROUTE_CONFIG = yaml.dump(
+    {
+        "http": {
+            "routers": {
+                "juju-foo-router": {
+                    "entryPoints": ["web"],
+                    "rule": "PathPrefix(`/path`)",
+                    "service": "juju-foo-service",
+                }
+            },
+            "services": {
+                "juju-foo-service": {
+                    "loadBalancer": {
+                        "servers": [{"url": "http://foo.testmodel-endpoints.local:8080"}]
+                    }
+                }
+            },
+        }
+    }
+)
 
 
 @pytest.fixture
@@ -71,4 +93,24 @@ def traefik_container(tmp_path):
         },
         service_status={"traefik": pebble.ServiceStatus.ACTIVE},
         mounts={"opt": opt, "/etc/traefik": etc_traefik},
+    )
+
+
+@pytest.fixture
+def tr_rel():
+    return Relation(
+        endpoint="traefik-route",
+        remote_app_name="route-requirer",
+        remote_app_data={"config": ROUTE_CONFIG},
+        local_app_data={"external_host": "10.0.0.1", "scheme": "http"},
+    )
+
+
+@pytest.fixture
+def tr_state(tr_rel, traefik_container):
+    return State(
+        leader=True,
+        config={"external_hostname": "testhostname", "routing_mode": "path"},
+        relations=[tr_rel],
+        containers=[traefik_container],
     )

--- a/tests/scenario/test_traefik_route.py
+++ b/tests/scenario/test_traefik_route.py
@@ -1,0 +1,154 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""Scenario tests for TraefikRouteProvider and related changes."""
+
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import pytest
+import yaml
+from scenario import Relation, State
+
+ROUTE_CONFIG = yaml.dump(
+    {
+        "http": {
+            "routers": {
+                "juju-foo-router": {
+                    "entryPoints": ["web"],
+                    "rule": "PathPrefix(`/path`)",
+                    "service": "juju-foo-service",
+                }
+            },
+            "services": {
+                "juju-foo-service": {
+                    "loadBalancer": {
+                        "servers": [{"url": "http://foo.testmodel-endpoints.local:8080"}]
+                    }
+                }
+            },
+        }
+    }
+)
+
+
+@patch("charm.TraefikIngressCharm.version", PropertyMock(return_value="0.0.0"))
+class TestWipeIngressDataTraefikRoute:
+    """Tests for wipe_ingress_data on TraefikRouteProvider."""
+
+    def test_wipe_ingress_data_clears_relation_data(self, traefik_ctx, traefik_container):
+        """wipe_ingress_data removes external_host and scheme from traefik-route relation."""
+        tr_rel = Relation(
+            endpoint="traefik-route",
+            remote_app_name="route-requirer",
+            remote_app_data={"config": ROUTE_CONFIG},
+            local_app_data={"external_host": "10.0.0.1", "scheme": "http"},
+        )
+
+        state = State(
+            leader=True,
+            config={"external_hostname": "testhostname", "routing_mode": "path"},
+            relations=[tr_rel],
+            containers=[traefik_container],
+        )
+
+        with traefik_ctx.manager(tr_rel.changed_event, state) as mgr:
+            charm = mgr.charm
+            relation = charm.model.get_relation("traefik-route")
+
+            # Pre-set data to simulate published ingress
+            relation.data[charm.app]["external_host"] = "10.0.0.1"
+            relation.data[charm.app]["scheme"] = "http"
+
+            charm.traefik_route.wipe_ingress_data(relation)
+
+            assert "external_host" not in relation.data[charm.app]
+            assert "scheme" not in relation.data[charm.app]
+
+    def test_wipe_ingress_data_resets_stored_state(self, traefik_ctx, traefik_container):
+        """wipe_ingress_data sets stored external_host and scheme to None."""
+        tr_rel = Relation(
+            endpoint="traefik-route",
+            remote_app_name="route-requirer",
+            remote_app_data={"config": ROUTE_CONFIG},
+            local_app_data={"external_host": "10.0.0.1", "scheme": "http"},
+        )
+
+        state = State(
+            leader=True,
+            config={"external_hostname": "testhostname", "routing_mode": "path"},
+            relations=[tr_rel],
+            containers=[traefik_container],
+        )
+
+        with traefik_ctx.manager(tr_rel.changed_event, state) as mgr:
+            charm = mgr.charm
+            relation = charm.model.get_relation("traefik-route")
+
+            # Pre-set stored state
+            charm.traefik_route._stored.external_host = "10.0.0.1"
+            charm.traefik_route._stored.scheme = "http"
+
+            # Pre-set relation data so pop works
+            relation.data[charm.app]["external_host"] = "10.0.0.1"
+            relation.data[charm.app]["scheme"] = "http"
+
+            charm.traefik_route.wipe_ingress_data(relation)
+
+            assert charm.traefik_route._stored.external_host is None
+            assert charm.traefik_route._stored.scheme is None
+
+    def test_wipe_ingress_data_noop_for_non_leader(self, traefik_ctx, traefik_container):
+        """wipe_ingress_data does nothing when the unit is not leader."""
+        tr_rel = Relation(
+            endpoint="traefik-route",
+            remote_app_name="route-requirer",
+            remote_app_data={"config": ROUTE_CONFIG},
+            local_app_data={"external_host": "10.0.0.1", "scheme": "http"},
+        )
+
+        state = State(
+            leader=False,
+            config={"external_hostname": "testhostname", "routing_mode": "path"},
+            relations=[tr_rel],
+            containers=[traefik_container],
+        )
+
+        with traefik_ctx.manager(tr_rel.changed_event, state) as mgr:
+            charm = mgr.charm
+            relation = charm.model.get_relation("traefik-route")
+
+            charm.traefik_route.wipe_ingress_data(relation)
+
+            # Data should remain because non-leader cannot modify app data
+            assert relation.data[charm.app].get("external_host") == "10.0.0.1"
+            assert relation.data[charm.app].get("scheme") == "http"
+
+    def test_wipe_ingress_for_all_relations_includes_traefik_route(
+        self, traefik_ctx, traefik_container
+    ):
+        """_wipe_ingress_for_all_relations clears traefik-route relation data."""
+        tr_rel = Relation(
+            endpoint="traefik-route",
+            remote_app_name="route-requirer",
+            remote_app_data={"config": ROUTE_CONFIG},
+            local_app_data={"external_host": "10.0.0.1", "scheme": "http"},
+        )
+
+        state = State(
+            leader=True,
+            config={"external_hostname": "testhostname", "routing_mode": "path"},
+            relations=[tr_rel],
+            containers=[traefik_container],
+        )
+
+        with traefik_ctx.manager(tr_rel.changed_event, state) as mgr:
+            charm = mgr.charm
+            relation = charm.model.get_relation("traefik-route")
+
+            # Pre-set data
+            relation.data[charm.app]["external_host"] = "10.0.0.1"
+            relation.data[charm.app]["scheme"] = "http"
+
+            charm._wipe_ingress_for_all_relations()
+
+            assert "external_host" not in relation.data[charm.app]
+            assert "scheme" not in relation.data[charm.app]

--- a/tests/scenario/test_traefik_route.py
+++ b/tests/scenario/test_traefik_route.py
@@ -2,9 +2,8 @@
 # See LICENSE file for licensing details.
 """Scenario tests for TraefikRouteProvider and related changes."""
 
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import PropertyMock, patch
 
-import pytest
 import yaml
 from scenario import Relation, State
 

--- a/tests/scenario/test_traefik_route.py
+++ b/tests/scenario/test_traefik_route.py
@@ -4,52 +4,14 @@
 
 from unittest.mock import PropertyMock, patch
 
-import yaml
-from scenario import Relation, State
-
-ROUTE_CONFIG = yaml.dump(
-    {
-        "http": {
-            "routers": {
-                "juju-foo-router": {
-                    "entryPoints": ["web"],
-                    "rule": "PathPrefix(`/path`)",
-                    "service": "juju-foo-service",
-                }
-            },
-            "services": {
-                "juju-foo-service": {
-                    "loadBalancer": {
-                        "servers": [{"url": "http://foo.testmodel-endpoints.local:8080"}]
-                    }
-                }
-            },
-        }
-    }
-)
-
 
 @patch("charm.TraefikIngressCharm.version", PropertyMock(return_value="0.0.0"))
 class TestWipeIngressDataTraefikRoute:
     """Tests for wipe_ingress_data on TraefikRouteProvider."""
 
-    def test_wipe_ingress_data_clears_relation_data(self, traefik_ctx, traefik_container):
+    def test_wipe_ingress_data_clears_relation_data(self, traefik_ctx, tr_rel, tr_state):
         """wipe_ingress_data removes external_host and scheme from traefik-route relation."""
-        tr_rel = Relation(
-            endpoint="traefik-route",
-            remote_app_name="route-requirer",
-            remote_app_data={"config": ROUTE_CONFIG},
-            local_app_data={"external_host": "10.0.0.1", "scheme": "http"},
-        )
-
-        state = State(
-            leader=True,
-            config={"external_hostname": "testhostname", "routing_mode": "path"},
-            relations=[tr_rel],
-            containers=[traefik_container],
-        )
-
-        with traefik_ctx.manager(tr_rel.changed_event, state) as mgr:
+        with traefik_ctx.manager(tr_rel.changed_event, tr_state) as mgr:
             charm = mgr.charm
             relation = charm.model.get_relation("traefik-route")
 
@@ -62,23 +24,9 @@ class TestWipeIngressDataTraefikRoute:
             assert "external_host" not in relation.data[charm.app]
             assert "scheme" not in relation.data[charm.app]
 
-    def test_wipe_ingress_data_resets_stored_state(self, traefik_ctx, traefik_container):
+    def test_wipe_ingress_data_resets_stored_state(self, traefik_ctx, tr_rel, tr_state):
         """wipe_ingress_data sets stored external_host and scheme to None."""
-        tr_rel = Relation(
-            endpoint="traefik-route",
-            remote_app_name="route-requirer",
-            remote_app_data={"config": ROUTE_CONFIG},
-            local_app_data={"external_host": "10.0.0.1", "scheme": "http"},
-        )
-
-        state = State(
-            leader=True,
-            config={"external_hostname": "testhostname", "routing_mode": "path"},
-            relations=[tr_rel],
-            containers=[traefik_container],
-        )
-
-        with traefik_ctx.manager(tr_rel.changed_event, state) as mgr:
+        with traefik_ctx.manager(tr_rel.changed_event, tr_state) as mgr:
             charm = mgr.charm
             relation = charm.model.get_relation("traefik-route")
 
@@ -95,23 +43,13 @@ class TestWipeIngressDataTraefikRoute:
             assert charm.traefik_route._stored.external_host is None
             assert charm.traefik_route._stored.scheme is None
 
-    def test_wipe_ingress_data_noop_for_non_leader(self, traefik_ctx, traefik_container):
+    def test_wipe_ingress_data_noop_for_non_leader(
+        self, traefik_ctx, tr_rel, tr_state
+    ):
         """wipe_ingress_data does nothing when the unit is not leader."""
-        tr_rel = Relation(
-            endpoint="traefik-route",
-            remote_app_name="route-requirer",
-            remote_app_data={"config": ROUTE_CONFIG},
-            local_app_data={"external_host": "10.0.0.1", "scheme": "http"},
-        )
+        non_leader_state = tr_state.replace(leader=False)
 
-        state = State(
-            leader=False,
-            config={"external_hostname": "testhostname", "routing_mode": "path"},
-            relations=[tr_rel],
-            containers=[traefik_container],
-        )
-
-        with traefik_ctx.manager(tr_rel.changed_event, state) as mgr:
+        with traefik_ctx.manager(tr_rel.changed_event, non_leader_state) as mgr:
             charm = mgr.charm
             relation = charm.model.get_relation("traefik-route")
 
@@ -122,24 +60,10 @@ class TestWipeIngressDataTraefikRoute:
             assert relation.data[charm.app].get("scheme") == "http"
 
     def test_wipe_ingress_for_all_relations_includes_traefik_route(
-        self, traefik_ctx, traefik_container
+        self, traefik_ctx, tr_rel, tr_state
     ):
         """_wipe_ingress_for_all_relations clears traefik-route relation data."""
-        tr_rel = Relation(
-            endpoint="traefik-route",
-            remote_app_name="route-requirer",
-            remote_app_data={"config": ROUTE_CONFIG},
-            local_app_data={"external_host": "10.0.0.1", "scheme": "http"},
-        )
-
-        state = State(
-            leader=True,
-            config={"external_hostname": "testhostname", "routing_mode": "path"},
-            relations=[tr_rel],
-            containers=[traefik_container],
-        )
-
-        with traefik_ctx.manager(tr_rel.changed_event, state) as mgr:
+        with traefik_ctx.manager(tr_rel.changed_event, tr_state) as mgr:
             charm = mgr.charm
             relation = charm.model.get_relation("traefik-route")
 


### PR DESCRIPTION
#### What this PR does

Fixes #676 

#### Why we need it

It doesn't make sense to wipe only ingress and ingress-per-unit when traefik is blocked, leaving only traefik-route apart simply because the cleanup method doesn't exist in the lib.

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I added a [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) for user-relevant changes in `docs/release-notes/artifacts`. If no change artifact is necessary, I tagged the PR with the label `no-release-note`.
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [x] **If this PR modifies charm libraries owned by this project**: I incremented the `LIBAPI` and `LIBPATCH` values

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

