### PR TITLE
fix: refresh status after receive-ca-cert relation removal

### DIFF
--- a/docs/release-notes/artifacts/pr0679.yaml
+++ b/docs/release-notes/artifacts/pr0679.yaml
@@ -1,0 +1,19 @@
+# Version of the artifact schema
+version_schema: 2
+# The key holding the change(s)
+changes:
+  - title: Fixed stale restarting status after receive-ca-cert relation removal
+    author: alithethird
+    type: bugfix
+    description: |
+      Fixed a status refresh gap where Traefik could remain in maintenance with
+      `restarting traefik...` after `receive-ca-cert` integration changes until
+      the next `update-status` hook. Status is now reconciled immediately, and
+      unit/integration regression tests were added for this flow.
+    urls:
+      pr:
+        - https://github.com/canonical/traefik-k8s-operator/pull/679
+      related_doc:
+      related_issue: https://github.com/canonical/traefik-k8s-operator/issues/670
+    visibility: public
+    highlight: false

--- a/src/charm.py
+++ b/src/charm.py
@@ -647,6 +647,7 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         self.traefik.remove_ca(str(event.relation_id))
         # Since remove_ca will call update_ca_certs in traefik, a restart is needed.
         self._restart_traefik()
+        self._process_status_and_configurations()
 
     def _is_tls_enabled(self) -> bool:
         """Return True if TLS is enabled."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -620,6 +620,7 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         self._reconcile_lb()
         # We need to restart Traefik now
         self._restart_traefik()
+        self._process_status_and_configurations()
 
     def _update_received_ca_certs(
         self, event: Optional[CertificateTransferAvailableEvent] = None
@@ -648,6 +649,7 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         # Since remove_ca will call update_ca_certs in traefik, a restart is needed.
         self._restart_traefik()
         self._reconcile_lb()
+        self._process_status_and_configurations()
 
     def _is_tls_enabled(self) -> bool:
         """Return True if TLS is enabled."""

--- a/tests/integration/test_receive_ca_cert_status.py
+++ b/tests/integration/test_receive_ca_cert_status.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Regression test for receive-ca-cert status after relation removal (#670)."""
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from pytest_operator.plugin import OpsTest
+
+APP_NAME = "traefik-rca"
+SSC_NAME = "ssc-rca"
+
+METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
+RESOURCES = {"traefik-image": METADATA["resources"]["traefik-image"]["upstream-source"]}
+
+
+async def _workload_status(ops_test: OpsTest, unit_name: str) -> tuple[str, str]:
+    rc, stdout, _ = await ops_test.juju("status", "--format", "json")
+    assert rc == 0
+    status = json.loads(stdout)
+    app_name = unit_name.split("/")[0]
+    unit = status["applications"][app_name]["units"][unit_name]
+    workload_status = unit["workload-status"]
+    return workload_status.get("current", ""), workload_status.get("message", "")
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(ops_test: OpsTest, traefik_charm):
+    await asyncio.gather(
+        ops_test.model.deploy(
+            traefik_charm,
+            resources=RESOURCES,
+            application_name=APP_NAME,
+            trust=True,
+        ),
+        ops_test.model.deploy(
+            "ch:self-signed-certificates",
+            application_name=SSC_NAME,
+            channel="1/stable",
+            trust=True,
+        ),
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, SSC_NAME],
+        status="active",
+        timeout=900,
+        idle_period=20,
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_status_is_not_stuck_restarting_after_receive_ca_cert_removal(ops_test: OpsTest):
+    await ops_test.model.add_relation(f"{SSC_NAME}:send-ca-cert", f"{APP_NAME}:receive-ca-cert")
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, SSC_NAME],
+        status="active",
+        timeout=600,
+        idle_period=20,
+    )
+
+    await ops_test.juju(
+        "remove-relation",
+        f"{SSC_NAME}:send-ca-cert",
+        f"{APP_NAME}:receive-ca-cert",
+    )
+
+    deadline = asyncio.get_running_loop().time() + 180
+    current, message = "", ""
+    while asyncio.get_running_loop().time() < deadline:
+        current, message = await _workload_status(ops_test, f"{APP_NAME}/0")
+        if not (current == "maintenance" and message == "restarting traefik..."):
+            break
+        await asyncio.sleep(5)
+
+    assert not (
+        current == "maintenance" and message == "restarting traefik..."
+    ), "Traefik unit remained in maintenance/restarting after receive-ca-cert removal"
+
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, SSC_NAME],
+        status="active",
+        timeout=600,
+        idle_period=20,
+    )

--- a/tests/integration/test_receive_ca_cert_status.py
+++ b/tests/integration/test_receive_ca_cert_status.py
@@ -4,13 +4,13 @@
 
 """Regression test for receive-ca-cert status after relation removal (#670)."""
 
-import asyncio
-import json
+import os
+import time
 from pathlib import Path
 
+import jubilant
 import pytest
 import yaml
-from pytest_operator.plugin import OpsTest
 
 APP_NAME = "traefik-rca"
 SSC_NAME = "ssc-rca"
@@ -19,72 +19,63 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 RESOURCES = {"traefik-image": METADATA["resources"]["traefik-image"]["upstream-source"]}
 
 
-async def _workload_status(ops_test: OpsTest, unit_name: str) -> tuple[str, str]:
-    rc, stdout, _ = await ops_test.juju("status", "--format", "json")
-    assert rc == 0
-    status = json.loads(stdout)
-    app_name = unit_name.split("/")[0]
-    unit = status["applications"][app_name]["units"][unit_name]
-    workload_status = unit["workload-status"]
-    return workload_status.get("current", ""), workload_status.get("message", "")
+@pytest.fixture(scope="module")
+def juju():
+    with jubilant.temp_model() as juju:
+        juju.wait_timeout = 10 * 60
+        yield juju
 
 
-@pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest, traefik_charm):
-    await asyncio.gather(
-        ops_test.model.deploy(
-            traefik_charm,
-            resources=RESOURCES,
-            application_name=APP_NAME,
-            trust=True,
-        ),
-        ops_test.model.deploy(
-            "ch:self-signed-certificates",
-            application_name=SSC_NAME,
-            channel="1/stable",
-            trust=True,
-        ),
-    )
-
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME, SSC_NAME],
-        status="active",
-        timeout=900,
-        idle_period=20,
+@pytest.fixture(scope="module")
+def traefik_charm():
+    charm_path = os.environ.get("CHARM_PATH")
+    if charm_path:
+        return Path(charm_path)
+    charms = sorted(Path(".").glob("traefik*.charm"))
+    if charms:
+        return charms[0]
+    raise FileNotFoundError(
+        "Set CHARM_PATH to the built traefik charm, "
+        "or place a traefik*.charm file in the repo root."
     )
 
 
-@pytest.mark.abort_on_fail
-async def test_status_is_not_stuck_restarting_after_receive_ca_cert_removal(ops_test: OpsTest):
-    await ops_test.model.add_relation(f"{SSC_NAME}:send-ca-cert", f"{APP_NAME}:receive-ca-cert")
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME, SSC_NAME],
-        status="active",
-        timeout=600,
-        idle_period=20,
+def test_build_and_deploy(juju: jubilant.Juju, traefik_charm):
+    juju.deploy(
+        traefik_charm,
+        APP_NAME,
+        resources=RESOURCES,
+        trust=True,
+    )
+    juju.deploy(
+        "ch:self-signed-certificates",
+        SSC_NAME,
+        channel="1/stable",
+        trust=True,
     )
 
-    await ops_test.juju(
-        "remove-relation",
-        f"{SSC_NAME}:send-ca-cert",
-        f"{APP_NAME}:receive-ca-cert",
-    )
+    juju.wait(jubilant.all_active, timeout=900)
 
-    deadline = asyncio.get_running_loop().time() + 180
+
+def test_status_is_not_stuck_restarting_after_receive_ca_cert_removal(juju: jubilant.Juju):
+    juju.integrate(f"{SSC_NAME}:send-ca-cert", f"{APP_NAME}:receive-ca-cert")
+    juju.wait(jubilant.all_active, timeout=600)
+
+    juju.remove_relation(f"{SSC_NAME}:send-ca-cert", f"{APP_NAME}:receive-ca-cert")
+
+    deadline = time.monotonic() + 180
     current, message = "", ""
-    while asyncio.get_running_loop().time() < deadline:
-        current, message = await _workload_status(ops_test, f"{APP_NAME}/0")
+    while time.monotonic() < deadline:
+        status = juju.status()
+        unit = status.apps[APP_NAME].units[f"{APP_NAME}/0"]
+        current = unit.workload_status.current
+        message = unit.workload_status.message
         if not (current == "maintenance" and message == "restarting traefik..."):
             break
-        await asyncio.sleep(5)
+        time.sleep(5)
 
     assert not (
         current == "maintenance" and message == "restarting traefik..."
     ), "Traefik unit remained in maintenance/restarting after receive-ca-cert removal"
 
-    await ops_test.model.wait_for_idle(
-        apps=[APP_NAME, SSC_NAME],
-        status="active",
-        timeout=600,
-        idle_period=20,
-    )
+    juju.wait(jubilant.all_active, timeout=600)

--- a/tests/scenario/test_certificate_transfer.py
+++ b/tests/scenario/test_certificate_transfer.py
@@ -1,5 +1,6 @@
 import json
 
+from ops import MaintenanceStatus
 from scenario import Relation, State
 
 
@@ -82,3 +83,39 @@ def test_ca_cert_written_from_app_databag_on_pebble_ready(traefik_ctx, traefik_c
     assert not written_content.startswith('"')
     assert not written_content.endswith('"')
     assert written_content == ca_cert
+
+
+def test_relation_add_does_not_leave_status_in_restart(traefik_ctx, traefik_container):
+    """After receive-ca-cert relation changes, unit status must not be stuck in maintenance."""
+    # GIVEN a receive-ca-cert relation (no cert data needed — the charm only restarts on the event)
+    receive_ca_cert_relation = Relation("receive-ca-cert")
+
+    state = State(
+        leader=True,
+        containers=[traefik_container],
+        relations=[receive_ca_cert_relation],
+    )
+
+    # WHEN a certificate_set_updated event fires (triggered by relation-changed)
+    state_out = traefik_ctx.run(receive_ca_cert_relation.changed_event, state)
+
+    # THEN the unit is not stuck with "restarting traefik..." maintenance status
+    assert state_out.unit_status != MaintenanceStatus("restarting traefik...")
+
+
+def test_relation_remove_does_not_leave_status_in_restart(traefik_ctx, traefik_container):
+    """After receive-ca-cert relation is removed, unit status must not be stuck in maintenance."""
+    # GIVEN a receive-ca-cert relation already in the state
+    receive_ca_cert_relation = Relation("receive-ca-cert")
+
+    state = State(
+        leader=True,
+        containers=[traefik_container],
+        relations=[receive_ca_cert_relation],
+    )
+
+    # WHEN a certificates_removed event fires (triggered by relation-broken)
+    state_out = traefik_ctx.run(receive_ca_cert_relation.broken_event, state)
+
+    # THEN the unit is not stuck with "restarting traefik..." maintenance status
+    assert state_out.unit_status != MaintenanceStatus("restarting traefik...")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,7 +10,7 @@ import ops.testing
 import yaml
 from charms.traefik_k8s.v2.ingress import IngressRequirerAppData, IngressRequirerUnitData
 from ops.charm import ActionEvent
-from ops.model import ActiveStatus, Application, BlockedStatus, Relation
+from ops.model import ActiveStatus, Application, BlockedStatus, MaintenanceStatus, Relation
 from ops.pebble import PathError
 from ops.testing import Harness
 
@@ -617,6 +617,47 @@ class TestTraefikCertTransferInterface(unittest.TestCase):
             relation_id=certificate_transfer_rel_id, remote_unit_name=f"{provider_app}/0"
         )
         patch_exec.assert_not_called()
+
+    @patch("ops.model.Container.exec")
+    @patch(
+        "charm.TraefikIngressCharm._get_loadbalancer_status",
+        new_callable=PropertyMock,
+        return_value="10.0.0.1",
+    )
+    def test_relation_add_does_not_leave_status_in_restart(
+        self, mock_get_loadbalancer_status, patch_exec
+    ):
+        provider_app = "self-signed-certificates"
+        self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
+        self.harness.set_can_connect(container=self.container_name, val=True)
+
+        relation_id = self.harness.add_relation("receive-ca-cert", provider_app)
+        self.harness.add_relation_unit(relation_id, f"{provider_app}/0")
+
+        assert not isinstance(self.harness.charm.unit.status, MaintenanceStatus)
+        assert self.harness.charm.unit.status.message != "restarting traefik..."
+
+    @patch("ops.model.Container.exec")
+    @patch(
+        "charm.TraefikIngressCharm._get_loadbalancer_status",
+        new_callable=PropertyMock,
+        return_value="10.0.0.1",
+    )
+    def test_relation_remove_does_not_leave_status_in_restart(
+        self, mock_get_loadbalancer_status, patch_exec
+    ):
+        provider_app = "self-signed-certificates"
+        self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
+        self.harness.set_can_connect(container=self.container_name, val=True)
+
+        relation_id = self.harness.add_relation("receive-ca-cert", provider_app)
+        self.harness.add_relation_unit(relation_id, f"{provider_app}/0")
+        self.harness.remove_relation(relation_id)
+
+        assert not isinstance(self.harness.charm.unit.status, MaintenanceStatus)
+        assert self.harness.charm.unit.status.message != "restarting traefik..."
 
 
 class TestConfigOptionsValidation(unittest.TestCase):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,7 +10,7 @@ import ops.testing
 import yaml
 from charms.traefik_k8s.v2.ingress import IngressRequirerAppData, IngressRequirerUnitData
 from ops.charm import ActionEvent
-from ops.model import ActiveStatus, Application, BlockedStatus, MaintenanceStatus, Relation
+from ops.model import ActiveStatus, Application, BlockedStatus, Relation
 from ops.pebble import PathError
 from ops.testing import Harness
 
@@ -617,47 +617,6 @@ class TestTraefikCertTransferInterface(unittest.TestCase):
             relation_id=certificate_transfer_rel_id, remote_unit_name=f"{provider_app}/0"
         )
         patch_exec.assert_not_called()
-
-    @patch("ops.model.Container.exec")
-    @patch(
-        "charm.TraefikIngressCharm._get_loadbalancer_status",
-        new_callable=PropertyMock,
-        return_value="10.0.0.1",
-    )
-    def test_relation_add_does_not_leave_status_in_restart(
-        self, mock_get_loadbalancer_status, patch_exec
-    ):
-        provider_app = "self-signed-certificates"
-        self.harness.set_leader(True)
-        self.harness.begin_with_initial_hooks()
-        self.harness.set_can_connect(container=self.container_name, val=True)
-
-        relation_id = self.harness.add_relation("receive-ca-cert", provider_app)
-        self.harness.add_relation_unit(relation_id, f"{provider_app}/0")
-
-        assert not isinstance(self.harness.charm.unit.status, MaintenanceStatus)
-        assert self.harness.charm.unit.status.message != "restarting traefik..."
-
-    @patch("ops.model.Container.exec")
-    @patch(
-        "charm.TraefikIngressCharm._get_loadbalancer_status",
-        new_callable=PropertyMock,
-        return_value="10.0.0.1",
-    )
-    def test_relation_remove_does_not_leave_status_in_restart(
-        self, mock_get_loadbalancer_status, patch_exec
-    ):
-        provider_app = "self-signed-certificates"
-        self.harness.set_leader(True)
-        self.harness.begin_with_initial_hooks()
-        self.harness.set_can_connect(container=self.container_name, val=True)
-
-        relation_id = self.harness.add_relation("receive-ca-cert", provider_app)
-        self.harness.add_relation_unit(relation_id, f"{provider_app}/0")
-        self.harness.remove_relation(relation_id)
-
-        assert not isinstance(self.harness.charm.unit.status, MaintenanceStatus)
-        assert self.harness.charm.unit.status.message != "restarting traefik..."
 
 
 class TestConfigOptionsValidation(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Reconcile charm status immediately after `receive-ca-cert` add/remove events by running `_process_status_and_configurations()` after Traefik restart.
- Add unit regression tests that verify Traefik is not left in `MaintenanceStatus(\"restarting traefik...\")` after `receive-ca-cert` relation add/remove.
- Add a dedicated integration regression test reproducing issue #670 flow (`send-ca-cert` integrate + remove) and asserting status is not stuck on restarting.

## Testing
- `uv run --python 3.12 --extra dev pytest -q tests/unit/test_charm.py -k \"relation_add_does_not_leave_status_in_restart or relation_remove_does_not_leave_status_in_restart\"`
- `uv run --python 3.12 --extra dev pytest -q tests/integration/test_receive_ca_cert_status.py --model traefik-670-rca2`
- `uv run --python 3.12 --extra dev pytest -q tests/integration/test_pebble_restart_after_cert_relation_joined.py --model traefik-670-int2`

Closes #670.