### PR TITLE
bug: Add a check before deleting dynamic config

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   pull-request:
     name: PR

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-05-22
+
+- Fixed `delete_dynamic_configs` and `delete_dynamic_config` to guard against missing directory/file, preventing `ExecError` crash on first container start or after pod churn.
+
 ## 2026-05-07
 
 - Fixed `_on_remove` to only delete the LoadBalancer resource when the application is fully removed (0 planned units), preventing accidental LB deletion during scale-down.

--- a/docs/release-notes/artifacts/pr0685.yaml
+++ b/docs/release-notes/artifacts/pr0685.yaml
@@ -1,0 +1,20 @@
+# Version of the artifact schema
+version_schema: 2
+# The key holding the change(s)
+changes:
+  - title: Fixed crash when dynamic config directory does not exist
+    author: swetha1654
+    type: bugfix
+    description: |
+      Added existence guards in `delete_dynamic_configs` and `delete_dynamic_config` to prevent
+      `ExecError` when `/opt/traefik/juju` does not exist on first container start or after a
+      pod churn. Additionally, added a guard in the `_on_traefik_pebble_ready` handler to 
+      defer the event until the container is ready.
+    urls:
+      pr:
+        - https://github.com/canonical/traefik-k8s-operator/pull/685
+      related_doc:
+      related_issue:
+        - https://github.com/canonical/traefik-k8s-operator/issues/684
+    visibility: public
+    highlight: false

--- a/src/charm.py
+++ b/src/charm.py
@@ -1060,9 +1060,12 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
     def _configure_traefik(self) -> None:
         self.traefik.configure()
 
-    def _on_traefik_pebble_ready(self, _: PebbleReadyEvent) -> None:
+    def _on_traefik_pebble_ready(self, event: PebbleReadyEvent) -> None:
         # If the Traefik container comes up, e.g., after a pod churn, we
         # ignore the unit status and start fresh.
+        if not self.traefik.is_ready:
+            event.defer()
+            return
         self._clear_all_configs_and_restart_traefik()
         # push the (fresh new) configs.
         self._configure()
@@ -1074,6 +1077,7 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         # configuration files on a storage volume that survives the pod churn, before
         # we start traefik we clean up all Juju-generated config files to avoid spurious
         # routes.
+            
         self.traefik.delete_dynamic_configs()
 
         # we push the config

--- a/src/charm.py
+++ b/src/charm.py
@@ -1060,7 +1060,7 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
     def _configure_traefik(self) -> None:
         self.traefik.configure()
 
-    def _on_traefik_pebble_ready(self, event: PebbleReadyEvent) -> None:
+    def _on_traefik_pebble_ready(self, _: PebbleReadyEvent) -> None:
         # If the Traefik container comes up, e.g., after a pod churn, we
         # ignore the unit status and start fresh.
         # We need to defer the event if the container is not reachable, as we don't want to lose

--- a/src/charm.py
+++ b/src/charm.py
@@ -1063,7 +1063,9 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
     def _on_traefik_pebble_ready(self, event: PebbleReadyEvent) -> None:
         # If the Traefik container comes up, e.g., after a pod churn, we
         # ignore the unit status and start fresh.
-        if not self.traefik.is_ready:
+        # We need to defer the event if the container is not reachable, as we don't want to lose
+        # the event in a non-wholistic charm.
+        if not self.container.can_connect():
             event.defer()
             return
         self._clear_all_configs_and_restart_traefik()

--- a/src/charm.py
+++ b/src/charm.py
@@ -1064,7 +1064,7 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         # If the Traefik container comes up, e.g., after a pod churn, we
         # ignore the unit status and start fresh.
         # We need to defer the event if the container is not reachable, as we don't want to lose
-        # the event in a non-wholistic charm.
+        # the event in a non-holistic charm.
         if not self.container.can_connect():
             event.defer()
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -1077,7 +1077,7 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         # configuration files on a storage volume that survives the pod churn, before
         # we start traefik we clean up all Juju-generated config files to avoid spurious
         # routes.
-            
+
         self.traefik.delete_dynamic_configs()
 
         # we push the config

--- a/src/charm.py
+++ b/src/charm.py
@@ -1066,7 +1066,7 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         # We need to defer the event if the container is not reachable, as we don't want to lose
         # the event in a non-holistic charm.
         if not self.container.can_connect():
-            event.defer()
+            logger.debug("Container is unreachable")
             return
         self._clear_all_configs_and_restart_traefik()
         # push the (fresh new) configs.

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -727,6 +727,12 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def delete_dynamic_configs(self) -> None:
         """Delete **ALL** yamls from the dynamic config dir."""
+        if not self._container.exists(DYNAMIC_CONFIG_DIR):
+            logger.debug(
+                "Dynamic config dir %s does not exist; nothing to delete.",
+                DYNAMIC_CONFIG_DIR,
+            )
+            return
         # instead of multiple calls to self._container.remove_path(), delete all files in a swoop
         self._container.exec(
             ["find", DYNAMIC_CONFIG_DIR, "-name", "*.yaml", "-delete"],
@@ -736,7 +742,11 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def delete_dynamic_config(self, file_name: str) -> None:
         """Delete a specific yaml from the dynamic config dir."""
-        self._container.remove_path(Path(DYNAMIC_CONFIG_DIR) / file_name)
+        config_path = Path(DYNAMIC_CONFIG_DIR) / file_name
+        if not self._container.exists(config_path):
+            logger.debug("Dynamic config file %s does not exist; nothing to delete.", config_path)
+            return
+        self._container.remove_path(config_path)
         logger.debug("Deleted dynamic configuration file: %s", file_name)
 
     def add_dynamic_config(self, file_name: str, config: str) -> None:

--- a/tests/scenario/test_traefik.py
+++ b/tests/scenario/test_traefik.py
@@ -1,0 +1,100 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Scenario tests for the Traefik workload class."""
+
+from dataclasses import replace
+from unittest.mock import PropertyMock, patch
+
+from ops.model import ActiveStatus
+from scenario import Relation, State
+
+
+@patch("charm.TraefikIngressCharm.version", PropertyMock(return_value="0.0.0"))
+class TestDeleteDynamicConfigs:
+    """Tests for Traefik.delete_dynamic_configs."""
+
+    def test_pebble_ready_no_dynamic_config_dir(self, traefik_ctx, traefik_container):
+        """pebble-ready should not crash when /opt/traefik/juju does not exist.
+
+        This is the scenario from GH issue #684: on first container start the
+        dynamic config directory has not been created yet, and the find command
+        would fail with a non-zero exit code.
+        """
+        # GIVEN a container where /opt/traefik/juju does NOT exist
+        # Remove the find exec mock to prove it's never called (would error otherwise)
+        exec_mock_without_find = {
+            k: v
+            for k, v in traefik_container.exec_mock.items()
+            if k != ("find", "/opt/traefik/juju", "-name", "*.yaml", "-delete")
+        }
+        container = replace(traefik_container, exec_mock=exec_mock_without_find)
+
+        state = State(
+            leader=True,
+            containers=[container],
+        )
+
+        # WHEN pebble-ready fires
+        state_out = traefik_ctx.run(container.pebble_ready_event, state)
+
+        # THEN the charm does not crash and the dynamic config dir is created by configure()
+        traefik_fs = state_out.get_container("traefik").get_filesystem(traefik_ctx)
+        assert (traefik_fs / "opt" / "traefik" / "juju").exists()
+
+    def test_pebble_ready_with_dynamic_config_dir(self, traefik_ctx, traefik_container, tmp_path):
+        """pebble-ready should delete yamls when /opt/traefik/juju exists."""
+        # GIVEN a container where /opt/traefik/juju exists (with a yaml file in it)
+        (tmp_path / "traefik" / "juju").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "traefik" / "juju" / "stale_config.yaml").write_text("http: {}")
+
+        state = State(
+            leader=True,
+            containers=[traefik_container],
+        )
+
+        # WHEN pebble-ready fires
+        # THEN the charm does not crash (find exec is called and mocked successfully)
+        state_out = traefik_ctx.run(traefik_container.pebble_ready_event, state)
+        assert state_out.unit_status.name == "active"
+
+
+@patch("charm.TraefikIngressCharm.version", PropertyMock(return_value="0.0.0"))
+@patch("charm.TraefikIngressCharm._ingressed_address", PropertyMock(return_value="10.0.0.1"))
+@patch("traefik.Traefik.is_ready", PropertyMock(return_value=True))
+@patch("charm.TraefikIngressCharm._static_config_changed", PropertyMock(return_value=False))
+class TestDeleteDynamicConfig:
+    """Tests for Traefik.delete_dynamic_config."""
+
+    def test_relation_broken_no_config_file(self, traefik_ctx, traefik_container, tmp_path):
+        """Relation broken should not crash when the config file doesn't exist.
+
+        When a relation is broken, _wipe_ingress_for_relation calls
+        delete_dynamic_config for a file that may not exist (e.g. if pebble-ready
+        already cleaned it or it was never created).
+        """
+        # GIVEN a container with the dynamic config dir but no config file for the relation
+        (tmp_path / "traefik" / "juju").mkdir(parents=True, exist_ok=True)
+
+        ingress_rel = Relation(
+            endpoint="ingress",
+            remote_app_name="remote-app",
+            remote_app_data={
+                "model": "test-model",
+                "name": "remote-app",
+                "port": "8080",
+            },
+            remote_units_data={0: {"host": '"remote-app-0.remote-app-endpoints"'}},
+        )
+
+        state = State(
+            leader=True,
+            containers=[traefik_container],
+            relations=[ingress_rel],
+            unit_status=ActiveStatus("Serving at https://10.0.0.1"),
+        )
+
+        # WHEN the relation broken event fires
+        # THEN the charm does not crash even though no config file exists for this relation
+        state_out = traefik_ctx.run(ingress_rel.broken_event, state)
+        assert state_out.unit_status.name == "active"


### PR DESCRIPTION
#### What this PR does

Addresses: #684 

#### Why we need it

Added existence guards in `delete_dynamic_configs` and `delete_dynamic_config` to prevent `ExecError` when `/opt/traefik/juju` does not exist on first container start or after a pod churn. Additionally, added a guard in the `_on_traefik_pebble_ready` handler to defer the event until the container is ready.

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I added a [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) for user-relevant changes in `docs/release-notes/artifacts`. If no change artifact is necessary, I tagged the PR with the label `no-release-note`.
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this PR modifies charm libraries owned by this project**: I incremented the `LIBAPI` and `LIBPATCH` values

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

