### PR TITLE
fix: Use rootCAs instead of update-ca-certificates (4 of 5)

### DIFF
--- a/docs/release-notes/artifacts/pr0689.yaml
+++ b/docs/release-notes/artifacts/pr0689.yaml
@@ -1,0 +1,17 @@
+# Version of the artifact schema
+version_schema: 2
+# The key holding the change(s)
+changes:
+  - title: Use serversTransport.rootCAs instead of update-ca-certificates
+    author: swetha1654
+    type: enhancement
+    description: |
+      Replaced exec of `update-ca-certificates` with Traefik's native
+      `serversTransport.rootCAs` static config for backend CA trust.
+    urls:
+      pr:
+        - https://github.com/canonical/traefik-k8s-operator/pull/689
+      related_doc:
+      related_issue:
+    visibility: public
+    highlight: false

--- a/src/charm.py
+++ b/src/charm.py
@@ -1522,7 +1522,6 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         prefix = self._get_prefix(data)  # type: ignore
         config = self.traefik.get_per_leader_http_config(
             prefix=prefix,
-            scheme="http",  # IPL (aka ingress v1) has no https option
             port=data["port"],
             host=data["host"],
             strip_prefix=data.get("strip-prefix", False),

--- a/src/charm.py
+++ b/src/charm.py
@@ -617,6 +617,7 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         if not self.container.can_connect():
             return
         self._update_received_ca_certs(event)
+        self._reconcile_lb()
         # Regenerate static config so rootCAs picks up the new CA, then restart.
         self.traefik.configure()
         self._restart_traefik()
@@ -648,6 +649,7 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         # Regenerate static config so rootCAs reflects the removed CA, then restart.
         self.traefik.configure()
         self._restart_traefik()
+        self._reconcile_lb()
 
     def _is_tls_enabled(self) -> bool:
         """Return True if TLS is enabled."""

--- a/src/charm.py
+++ b/src/charm.py
@@ -617,8 +617,8 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         if not self.container.can_connect():
             return
         self._update_received_ca_certs(event)
-        self._reconcile_lb()
-        # We need to restart Traefik now
+        # Regenerate static config so rootCAs picks up the new CA, then restart.
+        self.traefik.configure()
         self._restart_traefik()
 
     def _update_received_ca_certs(
@@ -645,9 +645,9 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
     def _on_recv_ca_cert_removed(self, event: CertificateTransferRemovedEvent) -> None:
         # Assuming only one cert per relation (this is in line with the original lib design).
         self.traefik.remove_ca(str(event.relation_id))
-        # Since remove_ca will call update_ca_certs in traefik, a restart is needed.
+        # Regenerate static config so rootCAs reflects the removed CA, then restart.
+        self.traefik.configure()
         self._restart_traefik()
-        self._reconcile_lb()
 
     def _is_tls_enabled(self) -> bool:
         """Return True if TLS is enabled."""
@@ -714,10 +714,6 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         """Update the server cert, ca, and key configuration files."""
         self._sync_certs_to_peer_databag()
         self.traefik.update_cert_configuration(self._get_certs())
-
-        # update_cert_configuration relies on traefik.update_ca_certs.
-        # Thus, we should restart traefik with the new CA certs.
-        self._restart_traefik()
 
     def _sync_certs_to_peer_databag(self) -> None:
         """Sync certificates to the peer databag (leader only).
@@ -1057,9 +1053,6 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         """Return UDP entryPoints sent via traefik_route."""
         return self._traefik_route_entrypoints(protocol="udp")
 
-    def _configure_traefik(self) -> None:
-        self.traefik.configure()
-
     def _on_traefik_pebble_ready(self, _: PebbleReadyEvent) -> None:
         # If the Traefik container comes up, e.g., after a pod churn, we
         # ignore the unit status and start fresh.
@@ -1070,8 +1063,8 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
             return
         self._clear_all_configs_and_restart_traefik()
         # push the (fresh new) configs.
-        self._configure()
         self._update_received_ca_certs()
+        self._configure()
         self._set_workload_version()
 
     def _clear_all_configs_and_restart_traefik(self) -> None:
@@ -1084,7 +1077,7 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
 
         # we push the config
         self._update_cert_configs()
-        self._configure_traefik()
+        self.traefik.configure()
         # now we restart traefik
         self._restart_traefik()
 
@@ -1137,7 +1130,7 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
             return
 
         self._update_cert_configs()
-        self._configure_traefik()
+        self.traefik.configure()
         self._restart_traefik()
         self._process_status_and_configurations()
 
@@ -1155,7 +1148,7 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
                 # we keep this nested under the hash-check because, unless the tls config has
                 # changed, we don't need to redo this.
                 self._update_cert_configs()
-                self._configure_traefik()
+                self.traefik.configure()
 
                 self._restart_traefik()
 

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -232,8 +232,6 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 CA_CERTS_DIR / f"{hostname}.traefik-charm.crt", cert["ca"], make_dirs=True
             )
 
-        self.update_ca_certs()
-
     def _clean_up_certificates_in_traefik_container(self, excluded_certs: dict) -> None:
         """Clean up certificates in the remote traefik container.
 
@@ -264,20 +262,12 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     continue
 
     def add_cas(self, cas: Iterable[CA]) -> None:
-        """Add any number of CAs to Traefik.
-
-        Calls update-ca-certificates once done.
-        """
+        """Add any number of CAs to Traefik."""
         for ca in cas:
             self._add_ca(ca)
-        self.update_ca_certs()
 
     def _add_ca(self, ca: CA) -> None:
-        """Add a ca.
-
-        After doing this (any number of times),
-        the caller is responsible for invoking update-ca-certs.
-        """
+        """Add a ca."""
         self._container.push(ca.path, ca.ca, make_dirs=True)
 
     def remove_ca(self, uid: str) -> None:
@@ -287,19 +277,28 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         Traefik watches the dynamic config dir and reloads automatically on change.
         So make sure any traefik config depending on the certificates being there is updated
         **before** the certs are removed, otherwise you might have some downtime.
-
-        Calls update-ca-certificates once done.
         """
         ca_path = RECV_CA_TEMPLATE.substitute(rel_id=uid)
         try:
             self._container.remove_path(ca_path)
         except PathError:
             logger.exception("Error removing cert file %s.", ca_path)
-        self.update_ca_certs()
 
-    def update_ca_certs(self) -> None:
-        """Update ca certificates. Traefik will restart from inside charm.py."""
-        self._container.exec(["update-ca-certificates", "--fresh"]).wait()
+    def _collect_root_ca_paths(self) -> List[str]:
+        """Collect all CA certificate file paths from the CA certs directory.
+
+        This includes both pre-bundled CAs from the container image and
+        charm-managed CAs (from TLS and receive-ca-cert relations).
+        """
+        ca_paths: List[str] = []
+        try:
+            if self._container.can_connect() and self._container.isdir(str(CA_CERTS_DIR)):
+                for f in self._container.list_files(str(CA_CERTS_DIR)):
+                    if f.name.endswith(".crt"):
+                        ca_paths.append(f.path)
+        except (PathError, FileNotFoundError):
+            logger.debug("Could not list CA certs directory.")
+        return sorted(ca_paths)
 
     def generate_static_config(self, _raise: bool = False) -> Dict[str, Any]:
         """Generate Traefik's static config yaml."""
@@ -367,6 +366,17 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                         "endpoint": f"{self._tracing_endpoint}/api/traces?format=jaeger.thrift"
                     },
                 }
+            }
+
+        # Configure rootCAs for outbound backend certificate verification.
+        # This collects all CA certs from /usr/local/share/ca-certificates/
+        # (pre-bundled in the container image + charm-managed CAs) and sets them
+        # in the static serversTransport so Traefik can verify backend server
+        # certificates when proxying to HTTPS services.
+        root_ca_paths = self._collect_root_ca_paths()
+        if root_ca_paths:
+            static_config["serversTransport"] = {
+                "rootCAs": root_ca_paths,
             }
 
         # we attempt to put together the base config with whatever the user
@@ -556,8 +566,8 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         elif is_end_to_end:
             # We cannot assume traefik's CA is the same CA that signed the proxied apps.
-            # Since we use the update_ca_certificates machinery, we don't need to specify the
-            # "rootCAs" entry.
+            # The static serversTransport.rootCAs includes all known CAs, so we don't
+            # need to specify "rootCAs" per-transport here.
             # Keeping the serverTransports section anyway because it is informative ("endToEndTLS"
             # vs "reverseTerminationTransport") when inspecting the config file in production.
             transport_name = "endToEndTLS"

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -287,12 +287,19 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def _collect_root_ca_paths(self) -> List[str]:
         """Collect all CA certificate file paths from the CA certs directory.
 
-        This includes both pre-bundled CAs from the container image and
-        charm-managed CAs (from TLS and receive-ca-cert relations).
+        This includes the system CA bundle (so public CAs remain trusted)
+        plus charm-managed CAs (from TLS and receive-ca-cert relations).
         """
         ca_paths: List[str] = []
         try:
-            if self._container.can_connect() and self._container.isdir(str(CA_CERTS_DIR)):
+            if not self._container.can_connect():
+                return []
+            # Include the system CA bundle so that backends with publicly-signed
+            # certificates remain trusted when rootCAs is set.
+            system_bundle = "/etc/ssl/certs/ca-certificates.crt"
+            if self._container.exists(system_bundle):
+                ca_paths.append(system_bundle)
+            if self._container.isdir(str(CA_CERTS_DIR)):
                 for f in self._container.list_files(str(CA_CERTS_DIR)):
                     if f.name.endswith(".crt"):
                         ca_paths.append(f.path)

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -426,7 +426,6 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         return self._generate_config_block(
             prefix=prefix,
             lb_servers=lb_servers,
-            scheme=scheme,
             strip_prefix=strip_prefix,
             external_host=external_host,
             forward_auth_app=forward_auth_app,
@@ -453,7 +452,6 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         return self._generate_config_block(
             prefix=prefix,
             lb_servers=lb_servers,
-            scheme=scheme,
             strip_prefix=strip_prefix,
             external_host=external_host,
             forward_auth_app=forward_auth_app,
@@ -465,7 +463,6 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self,
         *,
         prefix: str,
-        scheme: str,
         host: str,
         port: int,
         strip_prefix: bool,
@@ -478,7 +475,6 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         return self._generate_config_block(
             prefix=prefix,
             lb_servers=lb_servers,
-            scheme=scheme,
             strip_prefix=strip_prefix,
             external_host=external_host,
             forward_auth_app=forward_auth_app,
@@ -489,7 +485,6 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self,
         prefix: str,
         lb_servers: List[Dict[str, str]],
-        scheme: Optional[str],
         strip_prefix: Optional[bool],
         external_host: str,
         forward_auth_app: bool,
@@ -503,7 +498,6 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         unit and IPA may be more than one).
         """
         # purge any optionals:
-        scheme_: str = scheme if scheme is not None else "http"
         strip_prefix_: bool = strip_prefix if strip_prefix is not None else False
 
         host = external_host
@@ -532,21 +526,6 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 )
             )
 
-        # Add the "rootsCAs" section only if TLS is enabled. If the rootCA section
-        # is empty or the file does not exist, HTTP requests will fail with
-        # "404 page not found".
-        # Note: we're assuming here that the CA that signed traefik's own CSR is
-        # the same CA that signed the service's servers CSRs.
-        external_tls = self._tls_enabled
-
-        # REVERSE TERMINATION: we are providing ingress for a unit who is itself behind https,
-        # but traefik is not.
-        internal_tls = scheme_ == "https"
-
-        is_reverse_termination = not external_tls and internal_tls
-        is_termination = external_tls and not internal_tls
-        is_end_to_end = external_tls and internal_tls
-
         lb_def: Dict[str, Any] = {"servers": lb_servers}
         service_def = {
             "loadBalancer": lb_def,
@@ -554,28 +533,11 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if healthcheck_params:
             service_def["loadBalancer"]["healthCheck"] = healthcheck_params
 
-        if is_reverse_termination:
-            # i.e. traefik itself is not related to tls certificates, but the ingress requirer is
-            transport_name = "reverseTerminationTransport"
-            lb_def["serversTransport"] = transport_name
-            transports = {transport_name: {"insecureSkipVerify": False}}
-
-        elif is_termination:
-            # i.e. traefik itself is related to tls certificates, but the ingress requirer is not
-            transports = {}
-
-        elif is_end_to_end:
-            # We cannot assume traefik's CA is the same CA that signed the proxied apps.
-            # The static serversTransport.rootCAs includes all known CAs, so we don't
-            # need to specify "rootCAs" per-transport here.
-            # Keeping the serverTransports section anyway because it is informative ("endToEndTLS"
-            # vs "reverseTerminationTransport") when inspecting the config file in production.
-            transport_name = "endToEndTLS"
-            lb_def["serversTransport"] = transport_name
-            transports = {transport_name: {"insecureSkipVerify": False}}
-
-        else:
-            transports = {}
+        # For backend TLS verification we rely on the static serversTransport.rootCAs
+        # (set in generate_static_config) which applies to all services that don't reference
+        # a named transport. Named transports do NOT inherit rootCAs from the static config,
+        # so we intentionally avoid assigning one here.
+        # insecureSkipVerify defaults to false, so certificate verification is always on.
 
         config = {
             "http": {
@@ -583,9 +545,6 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 "services": {traefik_service_name: service_def},
             },
         }
-        # Traefik does not accept an empty serversTransports. Add it only if it's non-empty.
-        if transports:
-            config["http"].update({"serversTransports": transports})
 
         middlewares = self._generate_middleware_config(
             strip_prefix=strip_prefix_,

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -381,6 +381,12 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         # in the static serversTransport so Traefik can verify backend server
         # certificates when proxying to HTTPS services.
         root_ca_paths = self._collect_root_ca_paths()
+        if not root_ca_paths and self._container.can_connect():
+            raise RuntimeError(
+                "No root CA certificates found. The system CA bundle "
+                "(/etc/ssl/certs/ca-certificates.crt) is expected to be present in the "
+                "container image."
+            )
         if root_ca_paths:
             static_config["serversTransport"] = {
                 "rootCAs": root_ca_paths,

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -533,12 +533,6 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if healthcheck_params:
             service_def["loadBalancer"]["healthCheck"] = healthcheck_params
 
-        # For backend TLS verification we rely on the static serversTransport.rootCAs
-        # (set in generate_static_config) which applies to all services that don't reference
-        # a named transport. Named transports do NOT inherit rootCAs from the static config,
-        # so we intentionally avoid assigning one here.
-        # insecureSkipVerify defaults to false, so certificate verification is always on.
-
         config = {
             "http": {
                 "routers": router_cfg,

--- a/tests/integration/test_tls_jubilant.py
+++ b/tests/integration/test_tls_jubilant.py
@@ -295,6 +295,6 @@ def test_end_to_end_tls(
         response.status_code,
         response.text[:200],
     )
-    # Without the rootCAs fix, this would be a 502 because traefik can't verify
+    # Without the rootCAs, this would be a 502 because traefik can't verify
     # alertmanager's backend certificate.
     response.raise_for_status()

--- a/tests/integration/test_tls_jubilant.py
+++ b/tests/integration/test_tls_jubilant.py
@@ -113,6 +113,18 @@ def receive_ca_cert_fixture(juju, traefik_app, ssc_app):
     return True
 
 
+@pytest.fixture(scope="module", name="alertmanager_tls")
+def alertmanager_tls_fixture(juju, alertmanager_app, ssc_app, receive_ca_cert_relation):
+    """Integrate alertmanager with SSC for backend TLS (end-to-end scenario).
+
+    After this, alertmanager serves HTTPS and advertises scheme=https to traefik.
+    This triggers the end-to-end TLS path where traefik must verify the backend cert.
+    """
+    juju.integrate(f"{ALERTMANAGER_APP_NAME}:certificates", f"{SSC_APP_NAME}:certificates")
+    juju.wait(jubilant.all_active, timeout=600)
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -238,4 +250,50 @@ def test_https_ingress_accessible_with_root_cas(
 
     response = session.get(alertmanager_url, timeout=30)
     logger.info("Response: status=%s body=%s", response.status_code, response.text[:200])
+    response.raise_for_status()
+
+
+def test_end_to_end_tls(
+    juju: jubilant.Juju,
+    traefik_app,
+    alertmanager_tls,
+    tmp_path: Path,
+):
+    """End-to-end TLS: client -> HTTPS -> traefik -> HTTPS -> alertmanager.
+
+    This exercises the code path where traefik must verify the backend's TLS cert.
+    Without rootCAs in the static serversTransport (or with a named transport that
+    doesn't inherit rootCAs), this would return HTTP 502.
+    """
+    ca_cert_path = _pull_ca_cert(juju, tmp_path)
+    alertmanager_url = _get_alertmanager_url(juju)
+
+    # Verify the URL is HTTPS (alertmanager advertised scheme=https).
+    assert alertmanager_url.startswith("https://"), (
+        f"Expected HTTPS URL after alertmanager TLS integration, got: {alertmanager_url}"
+    )
+
+    # Get traefik unit IP.
+    status = juju.status()
+    unit_ip = status.apps[TRAEFIK_APP_NAME].units[f"{TRAEFIK_APP_NAME}/0"].address
+
+    logger.info(
+        "Testing end-to-end TLS: client -> %s (via %s) -> alertmanager HTTPS backend",
+        alertmanager_url,
+        unit_ip,
+    )
+
+    # Hit the HTTPS endpoint, resolving MOCK_HOSTNAME to traefik's IP.
+    session = requests.Session()
+    session.mount("https://", DNSResolverHTTPSAdapter(MOCK_HOSTNAME, unit_ip))
+    session.verify = str(ca_cert_path)
+
+    response = session.get(alertmanager_url, timeout=30)
+    logger.info(
+        "End-to-end TLS result: status=%s body=%s",
+        response.status_code,
+        response.text[:200],
+    )
+    # Without the rootCAs fix, this would be a 502 because traefik can't verify
+    # alertmanager's backend certificate.
     response.raise_for_status()

--- a/tests/integration/test_tls_jubilant.py
+++ b/tests/integration/test_tls_jubilant.py
@@ -2,7 +2,12 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Test TLS certificates on all traefik units."""
+"""TLS integration tests for Traefik (jubilant framework).
+
+Tests:
+- Frontend TLS on multiple traefik units.
+- serversTransport.rootCAs populated via receive-ca-cert relation.
+"""
 
 import json
 import logging
@@ -30,7 +35,7 @@ NUM_TRAEFIK_UNITS = 2
 
 
 # ---------------------------------------------------------------------------
-# Fixtures (inline — shadows the parent conftest fixtures for this file)
+# Fixtures
 # ---------------------------------------------------------------------------
 @pytest.fixture(scope="module")
 def juju():
@@ -55,7 +60,7 @@ def traefik_charm():
 
 @pytest.fixture(scope="module", name="traefik_app")
 def traefik_fixture(juju, traefik_charm):
-    """Deploy traefik."""
+    """Deploy traefik with external_hostname configured."""
     juju.deploy(
         traefik_charm,
         TRAEFIK_APP_NAME,
@@ -84,7 +89,7 @@ def alertmanager_fixture(juju, traefik_app):
 
 @pytest.fixture(scope="module", name="ssc_app")
 def ssc_fixture(juju, traefik_app):
-    """Deploy self-signed-certificates and integrate with traefik."""
+    """Deploy self-signed-certificates and integrate with traefik for frontend TLS."""
     juju.deploy(
         "ch:self-signed-certificates",
         SSC_APP_NAME,
@@ -97,8 +102,41 @@ def ssc_fixture(juju, traefik_app):
     return SSC_APP_NAME
 
 
+@pytest.fixture(scope="module", name="receive_ca_cert_relation")
+def receive_ca_cert_fixture(juju, traefik_app, ssc_app):
+    """Integrate SSC send-ca-cert with traefik receive-ca-cert.
+
+    This is the relation that triggers serversTransport.rootCAs in static config.
+    """
+    juju.integrate(f"{SSC_APP_NAME}:send-ca-cert", f"{TRAEFIK_APP_NAME}:receive-ca-cert")
+    juju.wait(jubilant.all_active, timeout=600)
+    return True
+
+
 # ---------------------------------------------------------------------------
-# Test
+# Helpers
+# ---------------------------------------------------------------------------
+def _pull_ca_cert(juju, tmp_path):
+    """Pull the SSC CA cert to disk and return the path."""
+    ca_cert_path = tmp_path / "ca.cert"
+    result = juju.run(f"{SSC_APP_NAME}/0", "get-ca-certificate")
+    ca_cert = result.results["ca-certificate"]
+    ca_cert_path.write_text(ca_cert)
+    logger.info("Pulled CA cert (%d bytes) to %s", len(ca_cert), ca_cert_path)
+    return ca_cert_path
+
+
+def _get_alertmanager_url(juju):
+    """Get the alertmanager ingress URL from traefik's proxied-endpoints action."""
+    result = juju.run(f"{TRAEFIK_APP_NAME}/0", "show-proxied-endpoints")
+    endpoints = json.loads(result.results["proxied-endpoints"])
+    url = endpoints[ALERTMANAGER_APP_NAME]["url"]
+    logger.info("Alertmanager URL: %s", url)
+    return url
+
+
+# ---------------------------------------------------------------------------
+# Tests
 # ---------------------------------------------------------------------------
 def test_tls_on_all_units(
     juju: jubilant.Juju, traefik_app, ssc_app, alertmanager_app, tmp_path: Path
@@ -119,17 +157,8 @@ def test_tls_on_all_units(
 
     juju.wait(all_active_and_idle_with_expected_units, timeout=600)
 
-    # Pull the CA certificate from the SSC charm.
-    ca_cert_path = tmp_path / "ca.cert"
-    result = juju.run(f"{ssc_app}/0", "get-ca-certificate")
-    ca_cert = result.results["ca-certificate"]
-    ca_cert_path.write_text(ca_cert)
-    logger.info("Pulled CA cert (%d bytes) to %s", len(ca_cert), ca_cert_path)
-
-    # Get the alertmanager endpoint from traefik's proxied endpoints action.
-    result = juju.run(f"{traefik_app}/0", "show-proxied-endpoints")
-    endpoints = json.loads(result.results["proxied-endpoints"])
-    alertmanager_url = endpoints[alertmanager_app]["url"]
+    ca_cert_path = _pull_ca_cert(juju, tmp_path)
+    alertmanager_url = _get_alertmanager_url(juju)
 
     # Get unit IPs from status
     status = juju.status()
@@ -154,3 +183,59 @@ def test_tls_on_all_units(
             unit_name, response.status_code, response.text[:200],
         )
         response.raise_for_status()
+
+
+def test_root_cas_in_static_config(
+    juju: jubilant.Juju, traefik_app, ssc_app, receive_ca_cert_relation
+):
+    """After receive-ca-cert integration, static config has serversTransport.rootCAs."""
+    # Read the static config from the traefik container.
+    static_config_raw = juju.ssh(
+        f"{TRAEFIK_APP_NAME}/0",
+        "cat /etc/traefik/traefik.yaml",
+        container="traefik",
+    )
+    static_config = yaml.safe_load(static_config_raw)
+    logger.info("Static config keys: %s", list(static_config.keys()))
+
+    assert "serversTransport" in static_config, (
+        "Expected serversTransport in static config after receive-ca-cert integration. "
+        f"Got keys: {list(static_config.keys())}"
+    )
+    root_cas = static_config["serversTransport"].get("rootCAs", [])
+    assert len(root_cas) > 0, "Expected at least one CA path in serversTransport.rootCAs"
+
+    # Verify the paths point to files in the CA certs directory.
+    for ca_path in root_cas:
+        assert ca_path.startswith("/usr/local/share/ca-certificates/"), (
+            f"Unexpected CA path: {ca_path}"
+        )
+        assert ca_path.endswith(".crt"), f"CA path should end in .crt: {ca_path}"
+
+    logger.info("serversTransport.rootCAs contains %d CA path(s): %s", len(root_cas), root_cas)
+
+
+def test_https_ingress_accessible_with_root_cas(
+    juju: jubilant.Juju,
+    traefik_app,
+    ssc_app,
+    receive_ca_cert_relation,
+    alertmanager_app,
+    tmp_path: Path,
+):
+    """HTTPS ingress endpoint is accessible when rootCAs are configured."""
+    ca_cert_path = _pull_ca_cert(juju, tmp_path)
+    alertmanager_url = _get_alertmanager_url(juju)
+
+    # Get traefik unit IP.
+    status = juju.status()
+    unit_ip = status.apps[TRAEFIK_APP_NAME].units[f"{TRAEFIK_APP_NAME}/0"].address
+
+    # Hit the HTTPS endpoint, resolving MOCK_HOSTNAME to traefik's IP.
+    session = requests.Session()
+    session.mount("https://", DNSResolverHTTPSAdapter(MOCK_HOSTNAME, unit_ip))
+    session.verify = str(ca_cert_path)
+
+    response = session.get(alertmanager_url, timeout=30)
+    logger.info("Response: status=%s body=%s", response.status_code, response.text[:200])
+    response.raise_for_status()

--- a/tests/integration/test_tls_jubilant.py
+++ b/tests/integration/test_tls_jubilant.py
@@ -217,9 +217,10 @@ def test_root_cas_in_static_config(
     root_cas = static_config["serversTransport"].get("rootCAs", [])
     assert len(root_cas) > 0, "Expected at least one CA path in serversTransport.rootCAs"
 
-    # Verify the paths point to files in the CA certs directory.
+    # Verify the paths point to known CA locations.
+    allowed_prefixes = ("/usr/local/share/ca-certificates/", "/etc/ssl/certs/")
     for ca_path in root_cas:
-        assert ca_path.startswith("/usr/local/share/ca-certificates/"), (
+        assert ca_path.startswith(allowed_prefixes), (
             f"Unexpected CA path: {ca_path}"
         )
         assert ca_path.endswith(".crt"), f"CA path should end in .crt: {ca_path}"

--- a/tests/scenario/conftest.py
+++ b/tests/scenario/conftest.py
@@ -60,6 +60,12 @@ def traefik_container(tmp_path):
     opt = Mount("/opt/", tmp_path)
     etc_traefik = Mount("/etc/traefik/", tmp_path)
 
+    # Simulate the system CA bundle that's always present in the container image.
+    ssl_certs_dir = tmp_path / "ssl_certs"
+    ssl_certs_dir.mkdir()
+    (ssl_certs_dir / "ca-certificates.crt").write_text("# system CA bundle\n")
+    etc_ssl_certs = Mount("/etc/ssl/certs/", ssl_certs_dir)
+
     return Container(
         name="traefik",
         can_connect=True,
@@ -70,5 +76,5 @@ def traefik_container(tmp_path):
             ("/usr/bin/traefik", "version"): ExecOutput(stdout="42.42"),
         },
         service_status={"traefik": pebble.ServiceStatus.ACTIVE},
-        mounts={"opt": opt, "/etc/traefik": etc_traefik},
+        mounts={"opt": opt, "/etc/traefik": etc_traefik, "/etc/ssl/certs": etc_ssl_certs},
     )

--- a/tests/unit/_utils.py
+++ b/tests/unit/_utils.py
@@ -32,11 +32,6 @@ def _render_config(
     service_spec = {
         "loadBalancer": {"servers": [{"url": f"{scheme}://{host}:{port}"}]},
     }
-    transports = {}
-    if scheme == "https":
-        # service_spec["rootCAs"] = ["/opt/traefik/juju/certificate.cert"]
-        service_spec["loadBalancer"]["serversTransport"] = "reverseTerminationTransport"
-        transports = {"reverseTerminationTransport": {"insecureSkipVerify": False}}
 
     expected = {
         "http": {
@@ -65,9 +60,6 @@ def _render_config(
                 ],
             },
         }
-
-    if transports:
-        expected["http"]["serversTransports"] = transports
 
     if middlewares := _render_middlewares(
         strip_prefix=strip_prefix and routing_mode == "path",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -53,6 +53,12 @@ def traefik_container(tmp_path):
     opt = Mount("/opt/", tmp_path)
     etc_traefik = Mount("/etc/traefik/", tmp_path)
 
+    # Simulate the system CA bundle that's always present in the container image.
+    ssl_certs_dir = tmp_path / "ssl_certs"
+    ssl_certs_dir.mkdir()
+    (ssl_certs_dir / "ca-certificates.crt").write_text("# system CA bundle\n")
+    etc_ssl_certs = Mount("/etc/ssl/certs/", ssl_certs_dir)
+
     return Container(
         name="traefik",
         can_connect=True,
@@ -63,7 +69,7 @@ def traefik_container(tmp_path):
             ("/usr/bin/traefik", "version"): ExecOutput(stdout="42.42"),
         },
         service_status={"traefik": pebble.ServiceStatus.ACTIVE},
-        mounts={"opt": opt, "/etc/traefik": etc_traefik},
+        mounts={"opt": opt, "/etc/traefik": etc_traefik, "/etc/ssl/certs": etc_ssl_certs},
     )
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -158,6 +158,11 @@ class TestTraefikIngressCharm(unittest.TestCase):
             "traefik", ["find", "/opt/traefik/juju", "-name", "*.yaml", "-delete"], result=0
         )
 
+        # Simulate the system CA bundle present in the container image.
+        ca_certs_dir = self.harness.get_filesystem_root("traefik") / "etc" / "ssl" / "certs"
+        ca_certs_dir.mkdir(parents=True, exist_ok=True)
+        (ca_certs_dir / "ca-certificates.crt").write_text("# system CA bundle\n")
+
         patcher = patch.object(TraefikIngressCharm, "version", property(lambda *_: "0.0.0"))
         self.mock_version = patcher.start()
         self.addCleanup(patcher.stop)
@@ -571,6 +576,16 @@ class TestTraefikCertTransferInterface(unittest.TestCase):
         self.harness: Harness[TraefikIngressCharm] = Harness(TraefikIngressCharm)
         self.harness.set_model_name("test-model")
         self.addCleanup(self.harness.cleanup)
+        self.harness.handle_exec("traefik", ["update-ca-certificates", "--fresh"], result=0)
+        self.harness.handle_exec(
+            "traefik", ["find", "/opt/traefik/juju", "-name", "*.yaml", "-delete"], result=0
+        )
+
+        # Simulate the system CA bundle present in the container image.
+        ca_certs_dir = self.harness.get_filesystem_root("traefik") / "etc" / "ssl" / "certs"
+        ca_certs_dir.mkdir(parents=True, exist_ok=True)
+        (ca_certs_dir / "ca-certificates.crt").write_text("# system CA bundle\n")
+
         patcher = patch.object(TraefikIngressCharm, "version", property(lambda *_: "0.0.0"))
         self.mock_version = patcher.start()
         self.addCleanup(patcher.stop)
@@ -646,6 +661,11 @@ class TestConfigOptionsValidation(unittest.TestCase):
         self.harness.handle_exec(
             "traefik", ["find", "/opt/traefik/juju", "-name", "*.yaml", "-delete"], result=0
         )
+
+        # Simulate the system CA bundle present in the container image.
+        ca_certs_dir = self.harness.get_filesystem_root("traefik") / "etc" / "ssl" / "certs"
+        ca_certs_dir.mkdir(parents=True, exist_ok=True)
+        (ca_certs_dir / "ca-certificates.crt").write_text("# system CA bundle\n")
 
         patcher = patch.object(TraefikIngressCharm, "version", property(lambda *_: "0.0.0"))
         self.mock_version = patcher.start()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -583,8 +583,8 @@ class TestTraefikCertTransferInterface(unittest.TestCase):
         return_value="10.0.0.1",
     )
     def test_transferred_ca_certs_are_updated(self, mock_get_loadbalancer_status, patch_exec):
-        # Given container is ready, when receive-ca-cert relation joins,
-        # then ca certs are updated.
+        # Given container is ready, when receive-ca-cert relation joins with cert data,
+        # then the CA cert is pushed and generate_static_config includes rootCAs.
         provider_app = "self-signed-certificates"
         self.harness.set_leader(True)
         self.harness.begin_with_initial_hooks()
@@ -595,8 +595,21 @@ class TestTraefikCertTransferInterface(unittest.TestCase):
         self.harness.add_relation_unit(
             relation_id=certificate_transfer_rel_id, remote_unit_name=f"{provider_app}/0"
         )
-        call_list = patch_exec.call_args_list
-        assert ["update-ca-certificates", "--fresh"] in [call.args[0] for call in call_list]
+        ca_cert = "-----BEGIN CERTIFICATE-----\nMIIFake\n-----END CERTIFICATE-----"
+        self.harness.update_relation_data(
+            certificate_transfer_rel_id,
+            provider_app,
+            {
+                "certificates": json.dumps(sorted([ca_cert])),
+                "version": "1",
+            },
+        )
+        # Verify that generate_static_config includes the CA in rootCAs.
+        static_config = self.harness.charm.traefik.generate_static_config()
+        assert "serversTransport" in static_config
+        root_cas = static_config["serversTransport"]["rootCAs"]
+        expected_path = f"/usr/local/share/ca-certificates/receive-ca-cert-{certificate_transfer_rel_id}-ca.crt"
+        assert expected_path in root_cas
 
     @patch("ops.model.Container.exec")
     @patch(

--- a/tests/unit/test_ingress_per_app.py
+++ b/tests/unit/test_ingress_per_app.py
@@ -52,14 +52,6 @@ def test_ingress_per_app_created(
         "loadBalancer": {"servers": [{"url": f"{scheme}://{host}:{port}"}]},
     }
 
-    if scheme == "https":
-        # traefik has no tls relation, but the requirer does: reverse termination case
-        # service_def["rootCAs"] = ["/opt/traefik/juju/certificate.cert"]
-        service_def["loadBalancer"]["serversTransport"] = "reverseTerminationTransport"
-        # service_def["serversTransports"] = {
-        #     "reverseTerminationTransport": {"insecureSkipVerify": True}
-        # }
-
     assert generated_config["http"]["services"]["juju-test-model-remote-0-service"] == service_def
 
 

--- a/tests/unit/test_route.py
+++ b/tests/unit/test_route.py
@@ -122,6 +122,11 @@ def harness() -> Harness[TraefikIngressCharm]:
         "traefik", ["find", "/opt/traefik/juju", "-name", "*.yaml", "-delete"], result=0
     )
 
+    # Simulate the system CA bundle present in the container image.
+    ca_certs_dir = harness.get_filesystem_root("traefik") / "etc" / "ssl" / "certs"
+    ca_certs_dir.mkdir(parents=True, exist_ok=True)
+    (ca_certs_dir / "ca-certificates.crt").write_text("# system CA bundle\n")
+
     patcher = patch.object(TraefikIngressCharm, "version", property(lambda *_: "0.0.0"))
     patcher.start()
 


### PR DESCRIPTION
#### What this PR does

This pull request refactors how Traefik's static configuration is updated to manage CA certificates, ensuring that all trusted CAs (including those received via relations) are correctly reflected in the `serversTransport.rootCAs` field. The changes eliminate the need to manually run `update-ca-certificates` and instead regenerate the static config whenever CA certs are added or removed. The integration and unit tests are also updated to verify this new behavior.

#### Why we need it

Optimization for #612 

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I added a [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) for user-relevant changes in `docs/release-notes/artifacts`. If no change artifact is necessary, I tagged the PR with the label `no-release-note`.
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this PR modifies charm libraries owned by this project**: I incremented the `LIBAPI` and `LIBPATCH` values

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

