### PR TITLE
Fix: Add readTimeout config

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-06-24
+
+- Fixed Traefik entrypoint `readTimeout` defaults for HTTP and TCP traffic entrypoints so large uploads are not cut off after 60 seconds on Traefik v2.11.2+.
+
 ## 2026-06-19
 
 - Removed "How to force HTTPS redirect" documentation as it is stale code. 

--- a/docs/release-notes/artifacts/pr0720.yaml
+++ b/docs/release-notes/artifacts/pr0720.yaml
@@ -1,0 +1,18 @@
+# Version of the artifact schema
+version_schema: 2
+# The key holding the change(s)
+changes:
+  - title: Restored unlimited read timeout for traffic entrypoints
+    author: swetha1654
+    type: bugfix
+    description: |
+      Explicitly set Traefik's entrypoint read timeout to `0s` for HTTP and TCP
+      traffic entrypoints so large uploads are not truncated by the Traefik v2.11.2+
+      default of 60s.
+    urls:
+      pr:
+        - https://github.com/canonical/traefik-k8s-operator/pull/720
+      related_doc:
+      related_issue: https://github.com/canonical/traefik-k8s-operator/issues/719
+    visibility: public
+    highlight: false

--- a/src/traefik.py
+++ b/src/traefik.py
@@ -53,6 +53,7 @@ TLS_CIPHER_SUITES = [
 ]
 
 _DIAGNOSTICS_PORT = 8082  # Prometheus metrics, healthcheck/ping
+_ENTRYPOINT_READ_TIMEOUT = "0s"
 
 
 @dataclasses.dataclass
@@ -321,6 +322,12 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 "redirections": {"entryPoint": {"to": "websecure", "scheme": "https"}},
             }
 
+        # Traefik v2.11.2 changed the default readTimeout to 60s, which can break
+        # large uploads and slow requests. Keep the historic Traefik behavior.
+        entrypoint_transport_config = {
+            "transport": {"respondingTimeouts": {"readTimeout": _ENTRYPOINT_READ_TIMEOUT}}
+        }
+
         static_config = {
             "global": {
                 "checknewversion": False,
@@ -330,10 +337,19 @@ class Traefik:  # pylint: disable=too-many-instance-attributes,too-many-public-m
             },
             "entryPoints": {
                 "diagnostics": {"address": f":{_DIAGNOSTICS_PORT}"},
-                "web": web_config,
-                "websecure": {"address": f":{self.tls_port}"},
+                "web": {
+                    **web_config,
+                    **entrypoint_transport_config,
+                },
+                "websecure": {
+                    "address": f":{self.tls_port}",
+                    **entrypoint_transport_config,
+                },
                 **{
-                    tcp_entrypoint_name: {"address": f":{port}"}
+                    tcp_entrypoint_name: {
+                        "address": f":{port}",
+                        **entrypoint_transport_config,
+                    }
                     for tcp_entrypoint_name, port in tcp_entrypoints.items()
                 },
                 **{

--- a/tests/integration/legacy/test_charm_route.py
+++ b/tests/integration/legacy/test_charm_route.py
@@ -76,7 +76,10 @@ async def test_static_config_updated(ops_test: OpsTest):
     # the route tester charm does:
     # static = {"entryPoints": {"test-port": {"address": ":4545"}},
     # "test-udp-port": {"address": ":4646/udp"}}},
-    assert contents_yaml["entryPoints"]["test-port"] == {"address": ":4545"}
+    assert contents_yaml["entryPoints"]["test-port"] == {
+        "address": ":4545",
+        "transport": {"respondingTimeouts": {"readTimeout": "0s"}},
+    }
     assert contents_yaml["entryPoints"]["test-udp-port"] == {"address": ":4646/udp"}
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -466,7 +466,13 @@ class TestTraefikIngressCharm(unittest.TestCase):
         assert cfg["log"] == {"level": "DEBUG"}
         assert cfg["entryPoints"]["diagnostics"]["address"]
         assert cfg["entryPoints"]["web"]["address"]
+        assert cfg["entryPoints"]["web"]["transport"]["respondingTimeouts"] == {
+            "readTimeout": "0s"
+        }
         assert cfg["entryPoints"]["websecure"]["address"]
+        assert cfg["entryPoints"]["websecure"]["transport"]["respondingTimeouts"] == {
+            "readTimeout": "0s"
+        }
         assert cfg["ping"]["entryPoint"] == "diagnostics"
         assert cfg["providers"]["file"]["directory"]
         assert cfg["providers"]["file"]["watch"] is True
@@ -495,7 +501,10 @@ class TestTraefikIngressCharm(unittest.TestCase):
         prefix = charm._get_prefix(data)
         assert charm._tcp_entrypoints() == {prefix: 3000}
 
-        expected_entrypoint = {"address": ":3000"}
+        expected_entrypoint = {
+            "address": ":3000",
+            "transport": {"respondingTimeouts": {"readTimeout": "0s"}},
+        }
         static_config = charm.unit.get_container("traefik").pull(STATIC_CONFIG_PATH).read()
         assert yaml.safe_load(static_config)["entryPoints"][prefix] == expected_entrypoint
 


### PR DESCRIPTION
#### What this PR does

Fixes: #719

#### Why we need it

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I added a [change artifact](https://github.com/canonical/traefik-k8s-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) for user-relevant changes in `docs/release-notes/artifacts` according to the [contributing guidelines](https://github.com/canonical/traefik-k8s-operator/blob/main/CONTRIBUTING.md#release-notes). If no change artifact is necessary, I tagged the PR with the label `no-release-note`.
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this PR modifies charm libraries owned by this project**: I incremented the `LIBAPI` and `LIBPATCH` values

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

