### PR TITLE
Revert "chore: update charm libraries"

### DIFF
--- a/lib/charms/loki_k8s/v1/loki_push_api.py
+++ b/lib/charms/loki_k8s/v1/loki_push_api.py
@@ -544,7 +544,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 29
+LIBPATCH = 26
 
 PYDEPS = ["cosl"]
 
@@ -1198,10 +1198,6 @@ class LokiPushApiProvider(Object):
                 if self._charm.unit.is_leader():
                     relation.data[self._charm.app]["event"] = json.dumps({"errors": errmsg})
                 continue
-            if self._charm.unit.is_leader():
-                event_data = json.loads(relation.data[self._charm.app].get("event", "{}"))
-                event_data.pop("errors", None)
-                relation.data[self._charm.app]["event"] = json.dumps(event_data)
 
             alerts[identifier] = alert_rules
 
@@ -1409,6 +1405,7 @@ class ConsumerBase(Object):
                 endpoints.append(deserialized_endpoint)
 
         return endpoints
+
 
 
 class LokiPushApiConsumer(ConsumerBase):
@@ -1703,7 +1700,7 @@ class LogProxyConsumer(ConsumerBase):
         self._promtails_ports = self._generate_promtails_ports(logs_scheme)
 
         # architecture used for promtail binary
-        arch = platform.machine()
+        arch = platform.processor()
         if arch in ["x86_64", "amd64"]:
             self._arch = "amd64"
         elif arch in ["aarch64", "arm64", "armv8b", "armv8l"]:
@@ -2297,7 +2294,6 @@ class _PebbleLogClient:
                         "juju_model_uuid": topology._model_uuid,
                         "juju_application": topology._application,
                         "juju_unit": topology._unit,
-                        "job": f"juju_{topology.identifier}",
                     },
                 }
             )

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -361,7 +361,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 61
+LIBPATCH = 59
 
 # Version 0.0.53 needed for cosl.rules.generic_alert_groups
 PYDEPS = ["cosl>=0.0.53"]
@@ -999,10 +999,6 @@ class MetricsEndpointConsumer(Object):
         self.framework.observe(
             events.relation_departed, self._on_metrics_provider_relation_departed
         )
-        self.framework.observe(
-            events.relation_broken, self._on_metrics_provider_relation_departed
-        )
-
 
     def _on_metrics_provider_relation_changed(self, event):
         """Handle changes with related metrics providers.
@@ -1145,7 +1141,6 @@ class MetricsEndpointConsumer(Object):
 
             _, errmsg = self._tool.validate_alert_rules(alert_rules)
             if errmsg:
-                logger.error(f"Invalid alert rule file: {errmsg}")
                 if alerts[identifier]:
                     del alerts[identifier]
                 if self._charm.unit.is_leader():
@@ -1153,10 +1148,6 @@ class MetricsEndpointConsumer(Object):
                     data["errors"] = errmsg
                     relation.data[self._charm.app]["event"] = json.dumps(data)
                 continue
-            if self._charm.unit.is_leader():
-                data = json.loads(relation.data[self._charm.app].get("event", "{}"))
-                data.pop("errors", None)
-                relation.data[self._charm.app]["event"] = json.dumps(data)
 
         return alerts
 
@@ -1643,7 +1634,8 @@ class MetricsEndpointProvider(Object):
     def _on_relation_changed(self, event):
         """Check for alert rule messages in the relation data before moving on."""
         # Refresh the unit address on every `relation_changed`. This reacts faster than waiting for
-        # the next `update_status` when the pod IP changes, and is safe to call repeatedly.
+        # the next `update_status` when the pod IP changes, and is a no-op when the address is
+        # unchanged. See https://github.com/canonical/opentelemetry-collector-k8s-operator/issues/270
         self._set_unit_ip()
 
         if self._charm.unit.is_leader():
@@ -1822,7 +1814,6 @@ class PrometheusRulesProvider(Object):
             events.relation_changed,
             self._charm.on.leader_elected,
             self._charm.on.upgrade_charm,
-            self._charm.on.config_changed,
         ]
 
         for event_source in event_sources:

--- a/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py
@@ -33,7 +33,7 @@ def _remove_stale_otel_sdk_packages():
     import shutil
     from collections import defaultdict
 
-    from importlib.metadata import distributions
+    from importlib_metadata import distributions
 
     otel_logger = logging.getLogger("charm_tracing_otel_patcher")
     otel_logger.debug("Applying _remove_stale_otel_sdk_packages patch on charm upgrade")
@@ -143,7 +143,7 @@ LIBAPI = 0
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
 
-LIBPATCH = 13
+LIBPATCH = 12
 
 PYDEPS = ["opentelemetry-exporter-otlp-proto-http==1.21.0"]
 


### PR DESCRIPTION
Reverts canonical/traefik-k8s-operator#710

# Root cause

The `charm_tracing.py` library currently fails during upgrade:
```
unit-traefik-public-1: 10:01:58 INFO juju.worker.uniter found queued "upgrade-charm" hook
unit-traefik-public-1: 10:01:59 WARNING unit.traefik-public/1.upgrade-charm Traceback (most recent call last):
unit-traefik-public-1: 10:01:59 WARNING unit.traefik-public/1.upgrade-charm   File "/var/lib/juju/agents/unit-traefik-public-1/charm/src/charm.py", line 39, in <module>
unit-traefik-public-1: 10:01:59 WARNING unit.traefik-public/1.upgrade-charm     from charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
unit-traefik-public-1: 10:01:59 WARNING unit.traefik-public/1.upgrade-charm   File "/var/lib/juju/agents/unit-traefik-public-1/charm/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py", line 70, in <module>
unit-traefik-public-1: 10:01:59 WARNING unit.traefik-public/1.upgrade-charm     _remove_stale_otel_sdk_packages()
unit-traefik-public-1: 10:01:59 WARNING unit.traefik-public/1.upgrade-charm   File "/var/lib/juju/agents/unit-traefik-public-1/charm/lib/charms/tempo_coordinator_k8s/v0/charm_tracing.py", line 43, in _remove_stale_otel_sdk_packages
unit-traefik-public-1: 10:01:59 WARNING unit.traefik-public/1.upgrade-charm     name = distribution._normalized_name  # type: ignore
unit-traefik-public-1: 10:01:59 WARNING unit.traefik-public/1.upgrade-charm AttributeError: 'PathDistribution' object has no attribute '_normalized_name'
unit-traefik-public-1: 10:02:00 ERROR juju.worker.uniter.operation hook "upgrade-charm" (via hook dispatching script: dispatch) failed: exit status 1
```

Will add some integration tests in a follow up PR to test upgrades.