### PR TITLE
test: adopt pytest-jubilant in jubilant integration tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "pytest-asyncio==0.21.2",
     "pytest-operator",
     "jubilant",
+    "pytest-jubilant",
     "juju",
     "tenacity==8.5.0",
     "sh",

--- a/spread.yaml
+++ b/spread.yaml
@@ -26,7 +26,7 @@ integration-suites:
     systems:
     - ubuntu-24.04
     auto-discover: true
-    pytest-arguments-template: '-x --log-format="%(asctime)s %(levelname)s %(message)s" --no-juju-teardown --juju-model testing --base {{ env.get("BASE", "ubuntu@26.04") }}'
+    pytest-arguments-template: '-x --log-format="%(asctime)s %(levelname)s %(message)s" --no-juju-teardown --juju-model testing --keep-models --model testing --base {{ env.get("BASE", "ubuntu@26.04") }}'
     environment:
       # Juju 4 tests
       MODULE/jubilant_test_dynamic_configs_juju4: tests/integration/test_dynamic_configs.py
@@ -48,6 +48,6 @@ integration-suites:
     systems:
     - ubuntu-24.04-arm64
     auto-discover: false
-    pytest-arguments-template: '-x --log-format="%(asctime)s %(levelname)s %(message)s" --no-juju-teardown --juju-model testing'
+    pytest-arguments-template: '-x --log-format="%(asctime)s %(levelname)s %(message)s" --no-juju-teardown --juju-model testing --keep-models --model testing'
     environment:
       MODULE/legacy_test_charm_ipa: tests/integration/legacy/test_charm_ipa.py

--- a/spread.yaml
+++ b/spread.yaml
@@ -26,7 +26,7 @@ integration-suites:
     systems:
     - ubuntu-24.04
     auto-discover: true
-    pytest-arguments-template: '-x --log-format="%(asctime)s %(levelname)s %(message)s" --keep-models --model testing --base {{ env.get("BASE", "ubuntu@26.04") }}'
+    pytest-arguments-template: '-x --log-format="%(asctime)s %(levelname)s %(message)s" --no-juju-teardown --juju-model testing --base {{ env.get("BASE", "ubuntu@26.04") }}'
     environment:
       # Juju 4 tests
       MODULE/jubilant_test_dynamic_configs_juju4: tests/integration/test_dynamic_configs.py
@@ -48,6 +48,6 @@ integration-suites:
     systems:
     - ubuntu-24.04-arm64
     auto-discover: false
-    pytest-arguments-template: '-x --log-format="%(asctime)s %(levelname)s %(message)s" --keep-models --model testing'
+    pytest-arguments-template: '-x --log-format="%(asctime)s %(levelname)s %(message)s" --no-juju-teardown --juju-model testing'
     environment:
       MODULE/legacy_test_charm_ipa: tests/integration/legacy/test_charm_ipa.py

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -33,17 +33,18 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 
 @pytest.fixture(scope="module")
-def juju(juju: jubilant.Juju) -> jubilant.Juju:
-    """Wrap pytest-jubilant's juju fixture with project-specific configuration.
+def juju(juju_factory) -> jubilant.Juju:
+    """Wrap pytest-jubilant's juju_factory with project-specific configuration.
 
     - Sets a longer wait_timeout (jubilant's default is 3 min; charm operations need 10 min).
     - Pre-grants secret RBAC permissions so Juju 4 + canonical k8s secret hooks work reliably.
       This is safe for both newly-created and pre-existing models because kubectl apply is
       idempotent.
     """
-    juju.wait_timeout = 10 * 60
-    _grant_secret_rbac(juju.model)
-    return juju
+    _juju = juju_factory.get_juju("")
+    _juju.wait_timeout = 10 * 60
+    _grant_secret_rbac(_juju.model)
+    return _juju
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -32,9 +32,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-@pytest.fixture(scope="module", autouse=True)
-def _configure_juju(juju: jubilant.Juju):
-    """Configure the juju fixture for all integration test modules.
+@pytest.fixture(scope="module")
+def juju(juju: jubilant.Juju) -> jubilant.Juju:
+    """Wrap pytest-jubilant's juju fixture with project-specific configuration.
 
     - Sets a longer wait_timeout (jubilant's default is 3 min; charm operations need 10 min).
     - Pre-grants secret RBAC permissions so Juju 4 + canonical k8s secret hooks work reliably.
@@ -43,6 +43,7 @@ def _configure_juju(juju: jubilant.Juju):
     """
     juju.wait_timeout = 10 * 60
     _grant_secret_rbac(juju.model)
+    return juju
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,6 @@
 import logging
 import subprocess
 from pathlib import Path
-from typing import cast
 
 import jubilant
 import pytest
@@ -31,6 +30,19 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption(
         "--base", action="store", default="ubuntu@26.04", help="Base to use for the integration test",
     )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _configure_juju(juju: jubilant.Juju):
+    """Configure the juju fixture for all integration test modules.
+
+    - Sets a longer wait_timeout (jubilant's default is 3 min; charm operations need 10 min).
+    - Pre-grants secret RBAC permissions so Juju 4 + canonical k8s secret hooks work reliably.
+      This is safe for both newly-created and pre-existing models because kubectl apply is
+      idempotent.
+    """
+    juju.wait_timeout = 10 * 60
+    _grant_secret_rbac(juju.model)
 
 
 @pytest.fixture(scope="module")
@@ -72,27 +84,6 @@ def alertmanager_fixture(juju, traefik_app):
     juju.integrate(f"{ALERTMANAGER_APP_NAME}:ingress", traefik_app)
     juju.wait(jubilant.all_active, timeout=600)
     return ALERTMANAGER_APP_NAME
-
-
-@pytest.fixture(scope="module", name="juju")
-def juju_fixture(request):
-    """Jubilant Juju fixture.
-
-    Honours ``--model`` (use a pre-existing model, e.g. the one bootstrapped by
-    concierge in CI) and ``--keep-models`` (preserve the temp model on failure).
-    """
-    model = request.config.getoption("--model")
-    if model:
-        _juju = jubilant.Juju(model=model)
-        _juju.wait_timeout = 10 * 60
-        _grant_secret_rbac(model)
-        yield _juju
-        return
-
-    keep_models = cast(bool, request.config.getoption("--keep-models"))
-    with jubilant.temp_model(keep=keep_models) as _juju:
-        _juju.wait_timeout = 10 * 60
-        yield _juju
 
 
 def _grant_secret_rbac(namespace: str) -> None:

--- a/tests/integration/test_receive_ca_cert_status.py
+++ b/tests/integration/test_receive_ca_cert_status.py
@@ -8,7 +8,6 @@ import time
 from pathlib import Path
 
 import jubilant
-import pytest
 import yaml
 
 APP_NAME = "traefik-rca"
@@ -16,14 +15,6 @@ SSC_NAME = "ssc-rca"
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 RESOURCES = {"traefik-image": METADATA["resources"]["traefik-image"]["upstream-source"]}
-
-
-@pytest.fixture(scope="module")
-def juju():
-    with jubilant.temp_model() as juju:
-        juju.wait_timeout = 10 * 60
-        yield juju
-
 
 def test_build_and_deploy(juju: jubilant.Juju, traefik_charm):
     juju.deploy(

--- a/uv.lock
+++ b/uv.lock
@@ -2382,6 +2382,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-jubilant"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jubilant" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/11/3baee677f3cf51ef41e06a7cbcfe8551613723695a458997b9d63026e0b5/pytest_jubilant-2.1.1.tar.gz", hash = "sha256:04c083ef1366f92237da79e3d499094ca50f50519a19462f388c38c699ee495a", size = 17971, upload-time = "2026-06-09T23:01:56.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/ea/33ecce9a52a022547544ab3b6393368944b1b55480a35ae00b7d9bd02f39/pytest_jubilant-2.1.1-py3-none-any.whl", hash = "sha256:d710cf9c41fb8daed6218d7b6ce68f4d4c234c5b0ee066d2be1dc9dd07265d35", size = 14922, upload-time = "2026-06-09T23:01:55.13Z" },
+]
+
+[[package]]
 name = "pytest-operator"
 version = "0.43.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3284,6 +3297,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-interface-tester" },
+    { name = "pytest-jubilant" },
     { name = "pytest-operator" },
     { name = "pytest-subtests" },
     { name = "ruff" },
@@ -3322,6 +3336,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = "==8.3.5" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "==0.21.2" },
     { name = "pytest-interface-tester", marker = "extra == 'dev'", specifier = ">0.3" },
+    { name = "pytest-jubilant", marker = "extra == 'dev'" },
     { name = "pytest-operator", marker = "extra == 'dev'" },
     { name = "pytest-subtests", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },


### PR DESCRIPTION
Replace the hand-rolled `juju` fixture with `pytest-jubilant`, fixing two latent bugs:

- **RBAC bug**: `_grant_secret_rbac` was only called for pre-existing (`--model`) models, silently skipped for new temp models. An autouse `_configure_juju` fixture now calls it unconditionally.
- **wait_timeout**: jubilant's default is 3 min; the previous fixture set 10 min. The plugin's `juju` fixture doesn't set this — `_configure_juju` restores the 10-min override.

Also removes the inline `juju` fixture from `test_receive_ca_cert_status.py` (which never had the RBAC workaround), and updates `spread.yaml` flags (`--keep-models`/`--model` → `--no-juju-teardown`/`--juju-model`).