### PR TITLE
fix: Put the correct cryptography package

### DIFF
--- a/docs/reference/cryptographic-documentation-for-cos-lite-charms.md
+++ b/docs/reference/cryptographic-documentation-for-cos-lite-charms.md
@@ -45,7 +45,7 @@ password and formatting the configuration string.
 
 ## List of packages and cryptographic tech used
 
-- to generate private keys for setting up TLS communication: the `rsa.generate_private_key` function from the [`rsa` package](https://stuvel.eu/software/rsa/). They use the following parameters (hardcoded, not user-configurable):
+- to generate private keys for setting up TLS communication: the `rsa.generate_private_key` function from the [`cryptography` package](https://github.com/pyca/cryptography/). They use the following parameters (hardcoded, not user-configurable):
   - `key_size = 2048`
   - `public_exponent = 65537`
 - to generate admin passwords for user admin login: the  [`secrets`](https://docs.python.org/3/library/secrets.html) module from the Python standard library. See for example: [usage in grafana](https://github.com/canonical/grafana-k8s-operator/blob/main/src/charm.py#L1289).


### PR DESCRIPTION
#### What this PR does

The python-rsa package is not used in the charm. It is a dependency of the integration tests, not used by the charm. The correct one is the `cryptography` package.

#### Why we need it

#### Checklist

- [ ] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [ ] I added a [change artifact](https://github.com/canonical/traefik-k8s-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) for user-relevant changes in `docs/release-notes/artifacts` according to the [contributing guidelines](https://github.com/canonical/traefik-k8s-operator/blob/main/CONTRIBUTING.md#release-notes). If no change artifact is necessary, I tagged the PR with the label `no-release-note`.
- [ ] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this PR modifies charm libraries owned by this project**: I incremented the `LIBAPI` and `LIBPATCH` values

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

