### PR TITLE
Set active status when a certificate is pending

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-07-10
+
+- Changed the unit status to active (from blocked) while a certificate is pending, keeping the "Certificate not available yet" message.
+
 ## 2026-07-08
 
 - Added migration logic to handle TLS private key and CSR migration.

--- a/docs/release-notes/artifacts/pr0739.yaml
+++ b/docs/release-notes/artifacts/pr0739.yaml
@@ -8,9 +8,7 @@ changes:
     description: |
       Changed the unit status shown while a certificate signing request is
       outstanding from blocked to active, keeping the "Certificate not available
-      yet" message. Traefik continues serving existing routes while waiting for
-      the certificate provider to respond, so this state no longer surfaces as
-      a blocking error.
+      yet" message.
     urls:
       pr:
         - https://github.com/canonical/traefik-k8s-operator/pull/739

--- a/docs/release-notes/artifacts/pr0739.yaml
+++ b/docs/release-notes/artifacts/pr0739.yaml
@@ -1,0 +1,20 @@
+# Version of the artifact schema
+version_schema: 2
+# The key holding the change(s)
+changes:
+  - title: Set active status when a certificate is pending
+    author: swetha1654
+    type: bugfix
+    description: |
+      Changed the unit status shown while a certificate signing request is
+      outstanding from blocked to active, keeping the "Certificate not available
+      yet" message. Traefik continues serving existing routes while waiting for
+      the certificate provider to respond, so this state no longer surfaces as
+      a blocking error.
+    urls:
+      pr:
+        - https://github.com/canonical/traefik-k8s-operator/pull/739
+      related_doc:
+      related_issue:
+    visibility: public
+    highlight: false

--- a/src/charm.py
+++ b/src/charm.py
@@ -1387,7 +1387,7 @@ class TraefikIngressCharm(CharmBase):  # pylint: disable=too-many-instance-attri
         self._refresh_certs_if_needed()
 
         if self._certificates_pending() and isinstance(self.unit.status, ActiveStatus):
-            self.unit.status = BlockedStatus("Certificate not available yet")
+            self.unit.status = ActiveStatus("Certificate not available yet")
 
     def _update_ingress_configurations(self) -> None:
         # step 1: determine whether the STATIC config should be changed and traefik restarted.

--- a/tests/integration/test_upgrade_mtls_leader_change_from_298.py
+++ b/tests/integration/test_upgrade_mtls_leader_change_from_298.py
@@ -15,7 +15,7 @@ Scenario:
 3. Assert the ingress URL is broken over HTTPS on the new leader only; all other
    units (including the restored old leader) continue to serve correctly.
 4. Refresh traefik to the locally built charm (the version under test).
-5. Assert the new leader is blocked with "Certificate not available yet" and
+5. Assert the new leader is active with "Certificate not available yet" and
    manual-tls has exactly one outstanding CSR.
 """
 
@@ -98,11 +98,11 @@ def test_leader_change_breaks_tls_then_upgrade_blocks_and_requests_certificate(
 
     status = juju.status()
     leader_status = status.apps[TRAEFIK_APP_NAME].units[new_leader].workload_status
-    assert leader_status.current == "blocked", (
-        f"expected {new_leader} to be blocked after upgrade, got {leader_status.current!r}"
+    assert leader_status.current == "active", (
+        f"expected {new_leader} to be active after upgrade, got {leader_status.current!r}"
     )
     assert leader_status.message == "Certificate not available yet", (
-        "unexpected blocked message on upgraded leader: "
+        "unexpected active message on upgraded leader: "
         f"{leader_status.message!r}"
     )
 


### PR DESCRIPTION
#### What this PR does

Set active status when a certificate is pending

#### Why we need it

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I added a [change artifact](https://github.com/canonical/traefik-k8s-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) for user-relevant changes in `docs/release-notes/artifacts` according to the [contributing guidelines](https://github.com/canonical/traefik-k8s-operator/blob/main/CONTRIBUTING.md#release-notes). If no change artifact is necessary, I tagged the PR with the label `no-release-note`.
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this PR modifies charm libraries owned by this project**: I incremented the `LIBAPI` and `LIBPATCH` values

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

