### PR TITLE
Unskip the unit and integration tests

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-08-25
+
+- Stabilized the `test_charm_trace_collection` unit test by isolating it from the shared charm tracing buffer file.
+
 ## 2026-08-19
 
 - Updated Sphinx Stack from 1.4.1 to 2.0 with the following changes:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ Each revision is versioned by the date of the revision.
 ## 2026-08-25
 
 - Stabilized the `test_charm_trace_collection` unit test by isolating it from the shared charm tracing buffer file.
+- Updated the TLS integration test to verify HTTPS with the self-signed provider's CA certificate and stronger post-integration waits.
 
 ## 2026-08-19
 

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -54,12 +54,6 @@ def test_ingressed_endpoints_reachable_after_metallb_enabled(juju: jubilant.Juju
         response.raise_for_status()
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Failing due to #491. Remove this after #509 is implemented. "
-        "See also: https://github.com/canonical/traefik-k8s-operator/issues/521"
-    )
-)
 def test_tls_termination(juju: jubilant.Juju):
     juju.config(TRAEFIK_APP, {"external_hostname": MOCK_HOSTNAME})
     juju.deploy("ch:self-signed-certificates", ROOT_CA_APP, channel="1/stable")
@@ -73,7 +67,6 @@ def test_tls_termination(juju: jubilant.Juju):
     _assert_https_endpoints(juju, cert_path, traefik_ip)
 
 
-@pytest.mark.xfail(reason="Flaky test; cannot reproduce failure locally.")
 def test_tls_termination_after_charm_upgrade(juju: jubilant.Juju, traefik_charm):
     juju.refresh(TRAEFIK_APP, path=traefik_charm, resources=_TRAEFIK_RESOURCES)
     juju.wait(all_settled, timeout=600)

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -7,7 +7,6 @@
 from pathlib import Path
 
 import jubilant
-import pytest
 import requests
 import yaml
 
@@ -15,6 +14,7 @@ from tests.integration.dns_adapter import DNSResolverHTTPSAdapter
 from tests.integration.helpers import (
     all_settled,
     get_k8s_service_address,
+    pull_ssc_ca_certificate,
     remove_application,
 )
 
@@ -24,8 +24,6 @@ ALERTMANAGER_APP = "alertmanager"
 GRAFANA_APP = "grafana"
 ROOT_CA_APP = "root-ca"
 MOCK_HOSTNAME = "juju.local"
-_ARTIFACT_DIR = Path("tests/integration/.artifacts")
-_CERT_PATH = _ARTIFACT_DIR / "test-tls-local.cert"
 
 _METADATA = yaml.safe_load(Path("./metadata.yaml").read_text(encoding="utf-8"))
 _TRAEFIK_RESOURCES = {
@@ -47,32 +45,40 @@ def test_build_and_deploy(juju: jubilant.Juju, traefik_charm):
 
 
 def test_ingressed_endpoints_reachable_after_metallb_enabled(juju: jubilant.Juju):
-    traefik_ip = get_k8s_service_address(juju.model, f"{TRAEFIK_APP}-lb")
+    model_name = juju.model
+    assert model_name is not None
+    traefik_ip = get_k8s_service_address(model_name, f"{TRAEFIK_APP}-lb")
     assert traefik_ip, "Expected a traefik load balancer address"
-    for endpoint in _endpoints(juju.model, "http", traefik_ip):
+    for endpoint in _endpoints(model_name, "http", traefik_ip):
         response = requests.get(endpoint, timeout=30)
         response.raise_for_status()
 
 
-def test_tls_termination(juju: jubilant.Juju):
+def test_tls_termination(juju: jubilant.Juju, tmp_path: Path):
+    model_name = juju.model
+    assert model_name is not None
     juju.config(TRAEFIK_APP, {"external_hostname": MOCK_HOSTNAME})
-    juju.deploy("ch:self-signed-certificates", ROOT_CA_APP, channel="1/stable")
+    juju.deploy("ch:self-signed-certificates", ROOT_CA_APP, channel="1/stable", trust=True)
     juju.config(ROOT_CA_APP, {"ca-common-name": "demo.ca.local"})
     juju.integrate(f"{ROOT_CA_APP}:certificates", TRAEFIK_APP)
-    juju.wait(all_settled, timeout=300)
+    juju.wait(all_settled, timeout=600, delay=2, successes=5)
 
-    cert_path = _pull_server_cert(juju)
-    traefik_ip = get_k8s_service_address(juju.model, f"{TRAEFIK_APP}-lb")
+    cert_path = pull_ssc_ca_certificate(juju, tmp_path, ssc_app=ROOT_CA_APP)
+    traefik_ip = get_k8s_service_address(model_name, f"{TRAEFIK_APP}-lb")
     assert traefik_ip, "Expected a traefik load balancer address"
     _assert_https_endpoints(juju, cert_path, traefik_ip)
 
 
-def test_tls_termination_after_charm_upgrade(juju: jubilant.Juju, traefik_charm):
+def test_tls_termination_after_charm_upgrade(
+    juju: jubilant.Juju, traefik_charm, tmp_path: Path
+):
+    model_name = juju.model
+    assert model_name is not None
     juju.refresh(TRAEFIK_APP, path=traefik_charm, resources=_TRAEFIK_RESOURCES)
-    juju.wait(all_settled, timeout=600)
+    juju.wait(all_settled, timeout=600, delay=2, successes=5)
 
-    cert_path = _CERT_PATH if _CERT_PATH.exists() else _pull_server_cert(juju)
-    traefik_ip = get_k8s_service_address(juju.model, f"{TRAEFIK_APP}-lb")
+    cert_path = pull_ssc_ca_certificate(juju, tmp_path, ssc_app=ROOT_CA_APP)
+    traefik_ip = get_k8s_service_address(model_name, f"{TRAEFIK_APP}-lb")
     assert traefik_ip, "Expected a traefik load balancer address"
     _assert_https_endpoints(juju, cert_path, traefik_ip)
 
@@ -96,21 +102,12 @@ def _endpoints(model: str, scheme: str, netloc: str) -> list[str]:
     ]
 
 
-def _pull_server_cert(juju: jubilant.Juju) -> Path:
-    _ARTIFACT_DIR.mkdir(exist_ok=True)
-    cert = juju.ssh(
-        f"{TRAEFIK_APP}/0",
-        "cat /opt/traefik/juju/server.cert",
-        container="traefik",
-    )
-    _CERT_PATH.write_text(cert, encoding="utf-8")
-    return _CERT_PATH
-
-
 def _assert_https_endpoints(juju: jubilant.Juju, cert_path: Path, traefik_ip: str) -> None:
+    model_name = juju.model
+    assert model_name is not None
     session = requests.Session()
     session.mount("https://", DNSResolverHTTPSAdapter(MOCK_HOSTNAME, traefik_ip))
     session.verify = str(cert_path)
-    for endpoint in _endpoints(juju.model, "https", MOCK_HOSTNAME):
+    for endpoint in _endpoints(model_name, "https", MOCK_HOSTNAME):
         response = session.get(endpoint, timeout=30)
         response.raise_for_status()

--- a/tests/unit/test_tracing_integration.py
+++ b/tests/unit/test_tracing_integration.py
@@ -5,14 +5,14 @@ from unittest.mock import patch
 
 import pytest
 import yaml
-from opentelemetry import trace as otel_trace
-from opentelemetry.sdk.trace.export import SpanExportResult
-from opentelemetry.util._once import Once
 from charms.tempo_coordinator_k8s.v0.charm_tracing import (
     CHARM_TRACING_ENABLED,
     charm_tracing_disabled,
 )
 from charms.tempo_coordinator_k8s.v0.tracing import ProtocolType, Receiver, TracingProviderAppData
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace.export import SpanExportResult
+from opentelemetry.util._once import Once
 from scenario import Relation, State
 
 from traefik import STATIC_CONFIG_PATH

--- a/tests/unit/test_tracing_integration.py
+++ b/tests/unit/test_tracing_integration.py
@@ -3,9 +3,11 @@
 
 from unittest.mock import patch
 
-import opentelemetry
 import pytest
 import yaml
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace.export import SpanExportResult
+from opentelemetry.util._once import Once
 from charms.tempo_coordinator_k8s.v0.charm_tracing import (
     CHARM_TRACING_ENABLED,
     charm_tracing_disabled,
@@ -51,6 +53,8 @@ def test_charm_trace_collection(
 ):
     # GIVEN the presence of a tracing relation
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER", None)
+    monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER_SET_ONCE", Once())
 
     state_in = State(relations=[charm_tracing_relation], containers=[traefik_container])
 
@@ -58,13 +62,14 @@ def test_charm_trace_collection(
     with patch(
         "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter.export"
     ) as f:
-        f.return_value = opentelemetry.sdk.trace.export.SpanExportResult.SUCCESS
+        f.return_value = SpanExportResult.SUCCESS
         monkeypatch.setenv(CHARM_TRACING_ENABLED, "1")
         # WHEN traefik receives <any event>
         traefik_ctx.run(charm_tracing_relation.changed_event, state_in)
 
     # assert "Setting up span exporter to endpoint: foo.com:81" in caplog.text
     # assert "Starting root trace with id=" in caplog.text
+    assert f.call_args_list
     span = f.call_args_list[0].args[0][0]
     assert span.resource.attributes["service.name"] == "traefik-k8s-charm"
     assert span.resource.attributes["compose_service"] == "traefik-k8s-charm"

--- a/tests/unit/test_tracing_integration.py
+++ b/tests/unit/test_tracing_integration.py
@@ -1,7 +1,6 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import os
 from unittest.mock import patch
 
 import opentelemetry
@@ -47,14 +46,11 @@ def workload_tracing_relation():
     return workload_tracing
 
 
-@pytest.mark.skip(
-    reason=(
-        "Intermittent failure, and it takes a long time to fail. "
-        "See https://github.com/canonical/traefik-k8s-operator/issues/519"
-    )
-)
-def test_charm_trace_collection(traefik_ctx, traefik_container, caplog, charm_tracing_relation):
+def test_charm_trace_collection(
+    traefik_ctx, traefik_container, caplog, charm_tracing_relation, monkeypatch, tmp_path
+):
     # GIVEN the presence of a tracing relation
+    monkeypatch.chdir(tmp_path)
 
     state_in = State(relations=[charm_tracing_relation], containers=[traefik_container])
 
@@ -63,7 +59,7 @@ def test_charm_trace_collection(traefik_ctx, traefik_container, caplog, charm_tr
         "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter.export"
     ) as f:
         f.return_value = opentelemetry.sdk.trace.export.SpanExportResult.SUCCESS
-        os.environ[CHARM_TRACING_ENABLED] = "1"
+        monkeypatch.setenv(CHARM_TRACING_ENABLED, "1")
         # WHEN traefik receives <any event>
         traefik_ctx.run(charm_tracing_relation.changed_event, state_in)
 

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ allowlist_externals=
     /usr/bin/env
 commands =
     coverage run --source={[vars]src_path} -m pytest \
-        {[vars]tst_path}/unit {[vars]tst_path}/scenario {posargs}
+        {posargs:{[vars]tst_path}/unit {[vars]tst_path}/scenario}
 
 [testenv:coverage-report]
 description = Report test coverage


### PR DESCRIPTION
#### What this PR does

Fixes the skipped flaky unit test
Fixes #519
Also fixes #521 as that should already be working and we just need to remove the xfail mark. 

Also updated tox.ini to allow passing posargs properly. Currently if we pass the file name, it does not run only the unit tests from that file but rather all the unit tests.

#### Why we need it

The flaky part is that the test was accidentally sharing a leftover file with previous test runs.

The tracing library stores unsent traces in a local buffer file named `.charm_tracing_buffer.raw`. Because the charm tracing setup uses that default file path in `charm_tracing.py`, one test run could leave old traces behind for the next run.

Then the test in `test_tracing_integration.py` behaved differently depending on whether that file already had old data:

1. If the buffer file was empty, the test used the mocked export call and passed.
2. If the buffer file had old traces, the tracing code tried to resend those old traces during shutdown.
3. That resend path uses a different internal method, so it bypassed the mock in the test.
4. Once that happened, the code tried a real network call to foo.com, and the test failed.

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [ ] I added a [change artifact](https://github.com/canonical/traefik-k8s-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) for user-relevant changes in `docs/release-notes/artifacts` according to the [contributing guidelines](https://github.com/canonical/traefik-k8s-operator/blob/main/CONTRIBUTING.md#release-notes). If no change artifact is necessary, I tagged the PR with the label `no-release-note`.
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this PR modifies charm libraries owned by this project**: I incremented the `LIBAPI` and `LIBPATCH` values

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

