### PR TITLE
fix: unify successes, delays, and errors in waits in integration tests (ISD-6559)

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,7 +16,7 @@ from tests.integration.constants import (
     SSC_CHARM,
     TRAEFIK_APP_NAME,
 )
-from tests.integration.helpers import all_settled, any_error
+from tests.integration.helpers import all_settled
 
 logger = logging.getLogger(__name__)
 
@@ -70,9 +70,9 @@ def deploy_traefik(juju, traefik_charm):
         resources=TRAEFIK_RESOURCES,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     juju.config(TRAEFIK_APP_NAME, {"external_hostname": "traefik-demo.local"})
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
     return TRAEFIK_APP_NAME
 
 
@@ -87,7 +87,7 @@ def alertmanager_fixture(juju):
     )
     juju.wait(
         lambda status: jubilant.all_active(status, ALERTMANAGER_APP_NAME),
-        error=any_error,
+        error=jubilant.any_error,
         delay=5,
         successes=5,
     )
@@ -100,7 +100,7 @@ def mtls_fixture(juju):
     juju.deploy(MANUAL_TLS_APP_NAME, MANUAL_TLS_APP_NAME, channel=MANUAL_TLS_CHANNEL)
     juju.wait(
         lambda status: jubilant.all_active(status, MANUAL_TLS_APP_NAME),
-        error=any_error,
+        error=jubilant.any_error,
         delay=5,
         successes=5,
     )
@@ -113,7 +113,7 @@ def self_signed_certificates_fixture(juju):
     juju.deploy(SSC_CHARM, SSC_APP_NAME, channel=SSC_CHANNEL, trust=True)
     juju.wait(
         lambda status: jubilant.all_active(status, SSC_APP_NAME),
-        error=any_error,
+        error=jubilant.any_error,
         delay=5,
         successes=5,
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -72,7 +72,7 @@ def deploy_traefik(juju, traefik_charm):
     )
     juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
     juju.config(TRAEFIK_APP_NAME, {"external_hostname": "traefik-demo.local"})
-    juju.wait(all_settled, delay=5, timeout=600)
+    juju.wait(all_settled, delay=5, successes=5)
     return TRAEFIK_APP_NAME
 
 
@@ -87,7 +87,8 @@ def alertmanager_fixture(juju):
     )
     juju.wait(
         lambda status: jubilant.all_active(status, ALERTMANAGER_APP_NAME),
-        timeout=600,
+        delay=5,
+        successes=5,
     )
     return ALERTMANAGER_APP_NAME
 
@@ -98,7 +99,8 @@ def mtls_fixture(juju):
     juju.deploy(MANUAL_TLS_APP_NAME, MANUAL_TLS_APP_NAME, channel=MANUAL_TLS_CHANNEL)
     juju.wait(
         lambda status: jubilant.all_active(status, MANUAL_TLS_APP_NAME),
-        timeout=600,
+        delay=5,
+        successes=5,
     )
     return MANUAL_TLS_APP_NAME
 
@@ -109,6 +111,7 @@ def self_signed_certificates_fixture(juju):
     juju.deploy(SSC_CHARM, SSC_APP_NAME, channel=SSC_CHANNEL, trust=True)
     juju.wait(
         lambda status: jubilant.all_active(status, SSC_APP_NAME),
-        timeout=600,
+        delay=5,
+        successes=5,
     )
     return SSC_APP_NAME

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,7 +16,7 @@ from tests.integration.constants import (
     SSC_CHARM,
     TRAEFIK_APP_NAME,
 )
-from tests.integration.helpers import all_settled
+from tests.integration.helpers import all_settled, any_error
 
 logger = logging.getLogger(__name__)
 
@@ -70,9 +70,9 @@ def deploy_traefik(juju, traefik_charm):
         resources=TRAEFIK_RESOURCES,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     juju.config(TRAEFIK_APP_NAME, {"external_hostname": "traefik-demo.local"})
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
     return TRAEFIK_APP_NAME
 
 
@@ -87,6 +87,7 @@ def alertmanager_fixture(juju):
     )
     juju.wait(
         lambda status: jubilant.all_active(status, ALERTMANAGER_APP_NAME),
+        error=any_error,
         delay=5,
         successes=5,
     )
@@ -99,6 +100,7 @@ def mtls_fixture(juju):
     juju.deploy(MANUAL_TLS_APP_NAME, MANUAL_TLS_APP_NAME, channel=MANUAL_TLS_CHANNEL)
     juju.wait(
         lambda status: jubilant.all_active(status, MANUAL_TLS_APP_NAME),
+        error=any_error,
         delay=5,
         successes=5,
     )
@@ -111,6 +113,7 @@ def self_signed_certificates_fixture(juju):
     juju.deploy(SSC_CHARM, SSC_APP_NAME, channel=SSC_CHANNEL, trust=True)
     juju.wait(
         lambda status: jubilant.all_active(status, SSC_APP_NAME),
+        error=any_error,
         delay=5,
         successes=5,
     )

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -54,16 +54,7 @@ def all_settled(status: jubilant.Status) -> bool:
 
 def any_error(status: jubilant.Status, *apps: str) -> bool:
     """Return True when any app/unit is in workload error or any unit agent is lost."""
-    if jubilant.any_error(status, *apps):
-        return True
-    for app in apps or tuple(status.apps):
-        app_info = status.apps.get(app)
-        if app_info is None:
-            continue
-        for unit_info in status.get_units(app).values():
-            if unit_info.juju_status.current == "lost":
-                return True
-    return False
+    return jubilant.any_error(status, *apps):
 
 
 def assert_can_connect(ip: str, port: int) -> None:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -52,11 +52,6 @@ def all_settled(status: jubilant.Status) -> bool:
     return jubilant.all_active(status) and jubilant.all_agents_idle(status)
 
 
-def any_error(status: jubilant.Status, *apps: str) -> bool:
-    """Return True when any app/unit is in workload error or any unit agent is lost."""
-    return jubilant.any_error(status, *apps)
-
-
 def assert_can_connect(ip: str, port: int) -> None:
     """Assert that a TCP connection can be established to ip:port."""
     target = (ip, int(port))
@@ -85,8 +80,10 @@ def get_k8s_service_address(model: str, service_name: str) -> Optional[str]:
         result = subprocess.run(
             [
                 "kubectl",
-                "-n", model,
-                "get", f"service/{service_name}",
+                "-n",
+                model,
+                "get",
+                f"service/{service_name}",
                 "-o=jsonpath={.status.loadBalancer.ingress[0].ip}",
             ],
             capture_output=True,
@@ -118,7 +115,7 @@ def remove_application(
     )
     juju.wait(
         lambda status: all(app_name not in status.apps for app_name in existing_apps),
-        error=any_error,
+        error=jubilant.any_error,
         timeout=timeout,
     )
 
@@ -159,6 +156,7 @@ def wait_for_tcp_echo(host: str, port: int, payload: bytes = b"Hello, world") ->
 
 def fetch_with_retry(url: str, expected_status: int = 200) -> requests.Response:
     """Fetch a URL with retries until the expected status is returned."""
+
     @retry(
         stop=stop_after_delay(150),
         wait=wait_fixed(5),
@@ -214,9 +212,7 @@ def sign_csr(ca_key: PrivateKey, ca_cert: Certificate, csr_pem: str) -> str:
 
 
 # --- manual-tls-certificates actions ---------------------------------------
-def get_outstanding_csrs(
-    juju: jubilant.Juju, mtls_app: str = MANUAL_TLS_APP_NAME
-) -> List[dict]:
+def get_outstanding_csrs(juju: jubilant.Juju, mtls_app: str = MANUAL_TLS_APP_NAME) -> List[dict]:
     """Return the list of outstanding certificate requests on the mTLS charm."""
     task = juju.run(f"{mtls_app}/leader", "get-outstanding-certificate-requests")
     raw = task.results.get("result", [])
@@ -414,8 +410,7 @@ def verify_http_on_all_units(
     """
     alertmanager_url = _alertmanager_url(juju)
     assert alertmanager_url.startswith("http://"), (
-        "expected plain HTTP proxied URL without a certificate provider, got "
-        f"{alertmanager_url!r}"
+        f"expected plain HTTP proxied URL without a certificate provider, got {alertmanager_url!r}"
     )
     if expected_url is not None:
         assert alertmanager_url == expected_url, (
@@ -453,7 +448,9 @@ def _unit_address(juju: jubilant.Juju, unit_name: str, app: str = TRAEFIK_APP_NA
 def force_leader_change(juju: jubilant.Juju, app: str = TRAEFIK_APP_NAME) -> str:
     """Force a leadership change by stopping the current leader's unit agent."""
     old_leader = leader_unit_name(juju, app)
-    logger.info("Stopping the container-agent on leader %s to force a leadership change", old_leader)
+    logger.info(
+        "Stopping the container-agent on leader %s to force a leadership change", old_leader
+    )
     # stop-checks liveness prevents pebble from restarting the agent as unhealthy.
     juju.ssh(old_leader, "/charm/bin/pebble", "stop-checks", "liveness", container="charm")
     juju.ssh(old_leader, "/charm/bin/pebble", "stop", "container-agent", container="charm")
@@ -498,8 +495,7 @@ def verify_https_on_unit(juju: jubilant.Juju, unit_name: str, alertmanager_url: 
 def verify_http_on_unit(juju: jubilant.Juju, unit_name: str, alertmanager_url: str) -> None:
     """Assert HTTP returns 200 on a specific traefik unit."""
     assert alertmanager_url.startswith("http://"), (
-        "expected plain HTTP proxied URL without a certificate provider, got "
-        f"{alertmanager_url!r}"
+        f"expected plain HTTP proxied URL without a certificate provider, got {alertmanager_url!r}"
     )
     unit_ip = _unit_address(juju, unit_name)
     logger.info("Verifying HTTP on %s (%s) -> %s", unit_name, unit_ip, alertmanager_url)
@@ -520,12 +516,12 @@ def bring_up_certified_traefik(juju: jubilant.Juju, tmp_path: Path) -> str:
     generate_ca(tmp_path)
 
     juju.integrate(f"{ALERTMANAGER_APP_NAME}:ingress", TRAEFIK_APP_NAME)
-    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     juju.integrate(f"{MANUAL_TLS_APP_NAME}:certificates", f"{TRAEFIK_APP_NAME}:certificates")
 
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     sign_csrs_and_provide_cert(juju)
-    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=900, delay=5, successes=5)
 
     return verify_https_on_all_units(juju)
 
@@ -535,10 +531,10 @@ def bring_up_self_signed_traefik(
 ) -> str:
     """Integrate self-signed-certificates + alertmanager and verify HTTPS on traefik."""
     juju.integrate(f"{ALERTMANAGER_APP_NAME}:ingress", TRAEFIK_APP_NAME)
-    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     juju.integrate(f"{ssc_app}:certificates", f"{TRAEFIK_APP_NAME}:certificates")
 
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     pull_ssc_ca_certificate(juju, tmp_path, ssc_app=ssc_app)
 
     return verify_https_on_all_units(juju)
@@ -547,6 +543,5 @@ def bring_up_self_signed_traefik(
 def bring_up_traefik_without_certificate_provider(juju: jubilant.Juju) -> str:
     """Integrate alertmanager only and verify plain HTTP on all traefik units."""
     juju.integrate(f"{ALERTMANAGER_APP_NAME}:ingress", TRAEFIK_APP_NAME)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     return verify_http_on_all_units(juju)
-

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -52,6 +52,20 @@ def all_settled(status: jubilant.Status) -> bool:
     return jubilant.all_active(status) and jubilant.all_agents_idle(status)
 
 
+def any_error(status: jubilant.Status, *apps: str) -> bool:
+    """Return True when any app/unit is in workload error or any unit agent is lost."""
+    if jubilant.any_error(status, *apps):
+        return True
+    for app in apps or tuple(status.apps):
+        app_info = status.apps.get(app)
+        if app_info is None:
+            continue
+        for unit_info in status.get_units(app).values():
+            if unit_info.juju_status.current == "lost":
+                return True
+    return False
+
+
 def assert_can_connect(ip: str, port: int) -> None:
     """Assert that a TCP connection can be established to ip:port."""
     target = (ip, int(port))
@@ -113,6 +127,7 @@ def remove_application(
     )
     juju.wait(
         lambda status: all(app_name not in status.apps for app_name in existing_apps),
+        error=any_error,
         timeout=timeout,
     )
 
@@ -458,6 +473,8 @@ def force_leader_change(juju: jubilant.Juju, app: str = TRAEFIK_APP_NAME) -> str
         return len(leaders) == 1 and leaders[0] != old_leader
 
     try:
+        # No error= here: the old leader's agent is deliberately stopped above, so it
+        # may legitimately report "lost"/error while we wait for a new leader to be elected.
         juju.wait(_reelected, timeout=120, delay=5)
     except TimeoutError as exc:
         raise AssertionError(
@@ -512,12 +529,12 @@ def bring_up_certified_traefik(juju: jubilant.Juju, tmp_path: Path) -> str:
     generate_ca(tmp_path)
 
     juju.integrate(f"{ALERTMANAGER_APP_NAME}:ingress", TRAEFIK_APP_NAME)
-    juju.wait(all_settled, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
     juju.integrate(f"{MANUAL_TLS_APP_NAME}:certificates", f"{TRAEFIK_APP_NAME}:certificates")
 
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     sign_csrs_and_provide_cert(juju)
-    juju.wait(all_settled, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
 
     return verify_https_on_all_units(juju)
 
@@ -527,10 +544,10 @@ def bring_up_self_signed_traefik(
 ) -> str:
     """Integrate self-signed-certificates + alertmanager and verify HTTPS on traefik."""
     juju.integrate(f"{ALERTMANAGER_APP_NAME}:ingress", TRAEFIK_APP_NAME)
-    juju.wait(all_settled, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
     juju.integrate(f"{ssc_app}:certificates", f"{TRAEFIK_APP_NAME}:certificates")
 
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     pull_ssc_ca_certificate(juju, tmp_path, ssc_app=ssc_app)
 
     return verify_https_on_all_units(juju)
@@ -539,6 +556,6 @@ def bring_up_self_signed_traefik(
 def bring_up_traefik_without_certificate_provider(juju: jubilant.Juju) -> str:
     """Integrate alertmanager only and verify plain HTTP on all traefik units."""
     juju.integrate(f"{ALERTMANAGER_APP_NAME}:ingress", TRAEFIK_APP_NAME)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     return verify_http_on_all_units(juju)
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -517,7 +517,7 @@ def bring_up_certified_traefik(juju: jubilant.Juju, tmp_path: Path) -> str:
 
     juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
     sign_csrs_and_provide_cert(juju)
-    juju.wait(all_settled, timeout=900)
+    juju.wait(all_settled, timeout=900, delay=5, successes=5)
 
     return verify_https_on_all_units(juju)
 
@@ -530,7 +530,7 @@ def bring_up_self_signed_traefik(
     juju.wait(all_settled, timeout=900, delay=5, successes=5)
     juju.integrate(f"{ssc_app}:certificates", f"{TRAEFIK_APP_NAME}:certificates")
 
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     pull_ssc_ca_certificate(juju, tmp_path, ssc_app=ssc_app)
 
     return verify_https_on_all_units(juju)
@@ -539,6 +539,6 @@ def bring_up_self_signed_traefik(
 def bring_up_traefik_without_certificate_provider(juju: jubilant.Juju) -> str:
     """Integrate alertmanager only and verify plain HTTP on all traefik units."""
     juju.integrate(f"{ALERTMANAGER_APP_NAME}:ingress", TRAEFIK_APP_NAME)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     return verify_http_on_all_units(juju)
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -54,7 +54,7 @@ def all_settled(status: jubilant.Status) -> bool:
 
 def any_error(status: jubilant.Status, *apps: str) -> bool:
     """Return True when any app/unit is in workload error or any unit agent is lost."""
-    return jubilant.any_error(status, *apps):
+    return jubilant.any_error(status, *apps)
 
 
 def assert_can_connect(ip: str, port: int) -> None:

--- a/tests/integration/test_basic_auth.py
+++ b/tests/integration/test_basic_auth.py
@@ -17,7 +17,7 @@ from tests.integration.any_charm_helpers import (
     PYTHON_PACKAGES,
     ipa_src_overwrite,
 )
-from tests.integration.helpers import all_settled, rpc
+from tests.integration.helpers import all_settled, any_error, rpc
 
 TRAEFIK_APP = "traefik"
 IPA_TESTER_APP = "ipa-tester"
@@ -43,31 +43,31 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
             "python-packages": PYTHON_PACKAGES,
         },
     )
-    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
     juju.integrate(f"{IPA_TESTER_APP}:require-ingress", f"{TRAEFIK_APP}:ingress")
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
 
 
 def test_ipa_charm_ingress_noauth(juju: jubilant.Juju):
     juju.config(TRAEFIK_APP, {"basic_auth_user": ""})
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
     _assert_status(_get_tester_url(juju), SUCCESS_STATUS)
 
 
 def test_ipa_charm_ingress_auth(juju: jubilant.Juju):
     tester_url = _get_tester_url(juju)
     juju.config(TRAEFIK_APP, {"basic_auth_user": TEST_AUTH_USER})
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
     _assert_status(tester_url, 401)
     _assert_status(tester_url, SUCCESS_STATUS, auth=(USERNAME, PASSWORD))
 
 
 def test_ipa_charm_ingress_auth_disable(juju: jubilant.Juju):
     juju.config(TRAEFIK_APP, {"basic_auth_user": ""})
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
     _assert_status(_get_tester_url(juju), SUCCESS_STATUS)
 
 

--- a/tests/integration/test_basic_auth.py
+++ b/tests/integration/test_basic_auth.py
@@ -43,31 +43,31 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
             "python-packages": PYTHON_PACKAGES,
         },
     )
-    juju.wait(all_settled, timeout=1000)
+    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
     juju.integrate(f"{IPA_TESTER_APP}:require-ingress", f"{TRAEFIK_APP}:ingress")
-    juju.wait(all_settled, timeout=600)
+    juju.wait(all_settled, delay=5, successes=5)
 
 
 def test_ipa_charm_ingress_noauth(juju: jubilant.Juju):
     juju.config(TRAEFIK_APP, {"basic_auth_user": ""})
-    juju.wait(all_settled, timeout=600)
+    juju.wait(all_settled, delay=5, successes=5)
     _assert_status(_get_tester_url(juju), SUCCESS_STATUS)
 
 
 def test_ipa_charm_ingress_auth(juju: jubilant.Juju):
     tester_url = _get_tester_url(juju)
     juju.config(TRAEFIK_APP, {"basic_auth_user": TEST_AUTH_USER})
-    juju.wait(all_settled, timeout=600)
+    juju.wait(all_settled, delay=5, successes=5)
     _assert_status(tester_url, 401)
     _assert_status(tester_url, SUCCESS_STATUS, auth=(USERNAME, PASSWORD))
 
 
 def test_ipa_charm_ingress_auth_disable(juju: jubilant.Juju):
     juju.config(TRAEFIK_APP, {"basic_auth_user": ""})
-    juju.wait(all_settled, timeout=600)
+    juju.wait(all_settled, delay=5, successes=5)
     _assert_status(_get_tester_url(juju), SUCCESS_STATUS)
 
 

--- a/tests/integration/test_basic_auth.py
+++ b/tests/integration/test_basic_auth.py
@@ -17,7 +17,7 @@ from tests.integration.any_charm_helpers import (
     PYTHON_PACKAGES,
     ipa_src_overwrite,
 )
-from tests.integration.helpers import all_settled, any_error, rpc
+from tests.integration.helpers import all_settled, rpc
 
 TRAEFIK_APP = "traefik"
 IPA_TESTER_APP = "ipa-tester"
@@ -43,31 +43,31 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
             "python-packages": PYTHON_PACKAGES,
         },
     )
-    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
     juju.integrate(f"{IPA_TESTER_APP}:require-ingress", f"{TRAEFIK_APP}:ingress")
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
 
 
 def test_ipa_charm_ingress_noauth(juju: jubilant.Juju):
     juju.config(TRAEFIK_APP, {"basic_auth_user": ""})
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
     _assert_status(_get_tester_url(juju), SUCCESS_STATUS)
 
 
 def test_ipa_charm_ingress_auth(juju: jubilant.Juju):
     tester_url = _get_tester_url(juju)
     juju.config(TRAEFIK_APP, {"basic_auth_user": TEST_AUTH_USER})
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
     _assert_status(tester_url, 401)
     _assert_status(tester_url, SUCCESS_STATUS, auth=(USERNAME, PASSWORD))
 
 
 def test_ipa_charm_ingress_auth_disable(juju: jubilant.Juju):
     juju.config(TRAEFIK_APP, {"basic_auth_user": ""})
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
     _assert_status(_get_tester_url(juju), SUCCESS_STATUS)
 
 

--- a/tests/integration/test_charm_health.py
+++ b/tests/integration/test_charm_health.py
@@ -19,7 +19,6 @@ from tests.integration.any_charm_helpers import (
 )
 from tests.integration.helpers import (
     all_settled,
-    any_error,
     get_k8s_service_address,
     remove_application,
     rpc,
@@ -47,12 +46,12 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
         num_units=3,
         trust=True,
     )
-    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
     juju.integrate(f"{HEALTH_TESTER_APP}:require-ingress", f"{TRAEFIK_APP}:ingress")
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
 
 
 def test_health(juju: jubilant.Juju):
@@ -61,7 +60,7 @@ def test_health(juju: jubilant.Juju):
     health_address = f"http://{traefik_address}/{juju.model}-{HEALTH_TESTER_APP}/health"
 
     rpc(juju, f"{HEALTH_TESTER_APP}/2", "set_health", is_healthy=False)
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
     for _ in range(10):
         status, content = _fetch_health(health_address)
         assert status == 200
@@ -71,7 +70,7 @@ def test_health(juju: jubilant.Juju):
         ]
 
     rpc(juju, f"{HEALTH_TESTER_APP}/1", "set_health", is_healthy=False)
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
     for _ in range(10):
         status, content = _fetch_health(health_address)
         assert status == 200

--- a/tests/integration/test_charm_health.py
+++ b/tests/integration/test_charm_health.py
@@ -17,7 +17,13 @@ from tests.integration.any_charm_helpers import (
     PYTHON_PACKAGES,
     health_src_overwrite,
 )
-from tests.integration.helpers import all_settled, get_k8s_service_address, remove_application, rpc
+from tests.integration.helpers import (
+    all_settled,
+    any_error,
+    get_k8s_service_address,
+    remove_application,
+    rpc,
+)
 
 TRAEFIK_APP = "traefik-k8s"
 HEALTH_TESTER_APP = "health-tester"
@@ -41,12 +47,12 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
         num_units=3,
         trust=True,
     )
-    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
     juju.integrate(f"{HEALTH_TESTER_APP}:require-ingress", f"{TRAEFIK_APP}:ingress")
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
 
 
 def test_health(juju: jubilant.Juju):
@@ -55,7 +61,7 @@ def test_health(juju: jubilant.Juju):
     health_address = f"http://{traefik_address}/{juju.model}-{HEALTH_TESTER_APP}/health"
 
     rpc(juju, f"{HEALTH_TESTER_APP}/2", "set_health", is_healthy=False)
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
     for _ in range(10):
         status, content = _fetch_health(health_address)
         assert status == 200
@@ -65,7 +71,7 @@ def test_health(juju: jubilant.Juju):
         ]
 
     rpc(juju, f"{HEALTH_TESTER_APP}/1", "set_health", is_healthy=False)
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
     for _ in range(10):
         status, content = _fetch_health(health_address)
         assert status == 200

--- a/tests/integration/test_charm_health.py
+++ b/tests/integration/test_charm_health.py
@@ -41,12 +41,12 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
         num_units=3,
         trust=True,
     )
-    juju.wait(all_settled, timeout=1000)
+    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
     juju.integrate(f"{HEALTH_TESTER_APP}:require-ingress", f"{TRAEFIK_APP}:ingress")
-    juju.wait(all_settled, timeout=600)
+    juju.wait(all_settled, delay=5, successes=5)
 
 
 def test_health(juju: jubilant.Juju):
@@ -55,7 +55,7 @@ def test_health(juju: jubilant.Juju):
     health_address = f"http://{traefik_address}/{juju.model}-{HEALTH_TESTER_APP}/health"
 
     rpc(juju, f"{HEALTH_TESTER_APP}/2", "set_health", is_healthy=False)
-    juju.wait(all_settled, timeout=600, delay=5, successes=5)
+    juju.wait(all_settled, delay=5, successes=5)
     for _ in range(10):
         status, content = _fetch_health(health_address)
         assert status == 200
@@ -65,7 +65,7 @@ def test_health(juju: jubilant.Juju):
         ]
 
     rpc(juju, f"{HEALTH_TESTER_APP}/1", "set_health", is_healthy=False)
-    juju.wait(all_settled, timeout=600, delay=5, successes=5)
+    juju.wait(all_settled, delay=5, successes=5)
     for _ in range(10):
         status, content = _fetch_health(health_address)
         assert status == 200

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -86,6 +86,8 @@ def test_remove_relation(juju: jubilant.Juju):
             and jubilant.all_agents_idle(status)
         ),
         timeout=300,
+        delay=5,
+        successes=5,
     )
     data = rpc(juju, f"{IPA_TESTER_APP}/0", "get_relation_data")
     assert not data["url"], "Expected ingress URL to be cleared after relation removal"

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -18,6 +18,7 @@ from tests.integration.any_charm_helpers import (
 )
 from tests.integration.helpers import (
     all_settled,
+    any_error,
     assert_can_connect,
     get_k8s_service_address,
     remove_application,
@@ -44,12 +45,12 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
             "python-packages": PYTHON_PACKAGES,
         },
     )
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
     juju.integrate(f"{IPA_TESTER_APP}:require-ingress", f"{TRAEFIK_APP}:ingress")
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
 
 
 def test_ipa_charm_has_ingress(juju: jubilant.Juju):
@@ -85,6 +86,7 @@ def test_remove_relation(juju: jubilant.Juju):
             jubilant.all_active(status, TRAEFIK_APP, IPA_TESTER_APP)
             and jubilant.all_agents_idle(status)
         ),
+        error=any_error,
         timeout=300,
         delay=5,
         successes=5,

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -44,12 +44,12 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
             "python-packages": PYTHON_PACKAGES,
         },
     )
-    juju.wait(all_settled, timeout=600)
+    juju.wait(all_settled, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
     juju.integrate(f"{IPA_TESTER_APP}:require-ingress", f"{TRAEFIK_APP}:ingress")
-    juju.wait(all_settled, timeout=600)
+    juju.wait(all_settled, delay=5, successes=5)
 
 
 def test_ipa_charm_has_ingress(juju: jubilant.Juju):

--- a/tests/integration/test_charm_ipa.py
+++ b/tests/integration/test_charm_ipa.py
@@ -18,7 +18,6 @@ from tests.integration.any_charm_helpers import (
 )
 from tests.integration.helpers import (
     all_settled,
-    any_error,
     assert_can_connect,
     get_k8s_service_address,
     remove_application,
@@ -45,12 +44,12 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
             "python-packages": PYTHON_PACKAGES,
         },
     )
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
     juju.integrate(f"{IPA_TESTER_APP}:require-ingress", f"{TRAEFIK_APP}:ingress")
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
 
 
 def test_ipa_charm_has_ingress(juju: jubilant.Juju):
@@ -86,7 +85,7 @@ def test_remove_relation(juju: jubilant.Juju):
             jubilant.all_active(status, TRAEFIK_APP, IPA_TESTER_APP)
             and jubilant.all_agents_idle(status)
         ),
-        error=any_error,
+        error=jubilant.any_error,
         timeout=300,
         delay=5,
         successes=5,

--- a/tests/integration/test_charm_ipu.py
+++ b/tests/integration/test_charm_ipu.py
@@ -18,6 +18,7 @@ from tests.integration.any_charm_helpers import (
 )
 from tests.integration.helpers import (
     all_settled,
+    any_error,
     assert_can_connect,
     get_k8s_service_address,
     remove_application,
@@ -44,7 +45,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
             "python-packages": PYTHON_PACKAGES,
         },
     )
-    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
@@ -52,7 +53,7 @@ def test_relate(juju: jubilant.Juju):
         f"{IPU_TESTER_APP}:require-ingress-per-unit",
         f"{TRAEFIK_APP}:ingress-per-unit",
     )
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
 
 
 def test_ipu_charm_has_ingress(juju: jubilant.Juju):
@@ -94,6 +95,7 @@ def test_remove_relation(juju: jubilant.Juju):
             jubilant.all_active(status, TRAEFIK_APP, IPU_TESTER_APP)
             and jubilant.all_agents_idle(status)
         ),
+        error=any_error,
         timeout=300,
         delay=5,
         successes=5,

--- a/tests/integration/test_charm_ipu.py
+++ b/tests/integration/test_charm_ipu.py
@@ -44,7 +44,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
             "python-packages": PYTHON_PACKAGES,
         },
     )
-    juju.wait(all_settled, timeout=1000)
+    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
@@ -52,7 +52,7 @@ def test_relate(juju: jubilant.Juju):
         f"{IPU_TESTER_APP}:require-ingress-per-unit",
         f"{TRAEFIK_APP}:ingress-per-unit",
     )
-    juju.wait(all_settled, timeout=600)
+    juju.wait(all_settled, delay=5, successes=5)
 
 
 def test_ipu_charm_has_ingress(juju: jubilant.Juju):

--- a/tests/integration/test_charm_ipu.py
+++ b/tests/integration/test_charm_ipu.py
@@ -95,6 +95,8 @@ def test_remove_relation(juju: jubilant.Juju):
             and jubilant.all_agents_idle(status)
         ),
         timeout=300,
+        delay=5,
+        successes=5,
     )
     data = rpc(juju, f"{IPU_TESTER_APP}/0", "get_ingress_data")
     assert not data.get("urls"), "Expected ingress URLs to be cleared after relation removal"

--- a/tests/integration/test_charm_ipu.py
+++ b/tests/integration/test_charm_ipu.py
@@ -18,7 +18,6 @@ from tests.integration.any_charm_helpers import (
 )
 from tests.integration.helpers import (
     all_settled,
-    any_error,
     assert_can_connect,
     get_k8s_service_address,
     remove_application,
@@ -45,7 +44,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
             "python-packages": PYTHON_PACKAGES,
         },
     )
-    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
@@ -53,7 +52,7 @@ def test_relate(juju: jubilant.Juju):
         f"{IPU_TESTER_APP}:require-ingress-per-unit",
         f"{TRAEFIK_APP}:ingress-per-unit",
     )
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
 
 
 def test_ipu_charm_has_ingress(juju: jubilant.Juju):
@@ -95,7 +94,7 @@ def test_remove_relation(juju: jubilant.Juju):
             jubilant.all_active(status, TRAEFIK_APP, IPU_TESTER_APP)
             and jubilant.all_agents_idle(status)
         ),
-        error=any_error,
+        error=jubilant.any_error,
         timeout=300,
         delay=5,
         successes=5,

--- a/tests/integration/test_charm_ipu_tcp.py
+++ b/tests/integration/test_charm_ipu_tcp.py
@@ -44,7 +44,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
         },
         trust=True,
     )
-    juju.wait(all_settled, timeout=1000)
+    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
@@ -52,7 +52,7 @@ def test_relate(juju: jubilant.Juju):
         f"{TCP_TESTER_APP}:require-ingress-per-unit",
         f"{TRAEFIK_APP}:ingress-per-unit",
     )
-    juju.wait(all_settled, timeout=600, delay=3, successes=5)
+    juju.wait(all_settled, delay=5, successes=5)
 
 
 def test_relation_data_shape(juju: jubilant.Juju):

--- a/tests/integration/test_charm_ipu_tcp.py
+++ b/tests/integration/test_charm_ipu_tcp.py
@@ -92,6 +92,8 @@ def test_remove_relation(juju: jubilant.Juju):
         lambda status: jubilant.all_active(status, TRAEFIK_APP)
         and jubilant.all_agents_idle(status),
         timeout=300,
+        delay=5,
+        successes=5,
     )
 
 

--- a/tests/integration/test_charm_ipu_tcp.py
+++ b/tests/integration/test_charm_ipu_tcp.py
@@ -17,6 +17,7 @@ from tests.integration.any_charm_helpers import (
 )
 from tests.integration.helpers import (
     all_settled,
+    any_error,
     get_k8s_service_address,
     remove_application,
     rpc,
@@ -44,7 +45,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
         },
         trust=True,
     )
-    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
@@ -52,7 +53,7 @@ def test_relate(juju: jubilant.Juju):
         f"{TCP_TESTER_APP}:require-ingress-per-unit",
         f"{TRAEFIK_APP}:ingress-per-unit",
     )
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
 
 
 def test_relation_data_shape(juju: jubilant.Juju):
@@ -91,6 +92,7 @@ def test_remove_relation(juju: jubilant.Juju):
     juju.wait(
         lambda status: jubilant.all_active(status, TRAEFIK_APP)
         and jubilant.all_agents_idle(status),
+        error=any_error,
         timeout=300,
         delay=5,
         successes=5,

--- a/tests/integration/test_charm_ipu_tcp.py
+++ b/tests/integration/test_charm_ipu_tcp.py
@@ -17,7 +17,6 @@ from tests.integration.any_charm_helpers import (
 )
 from tests.integration.helpers import (
     all_settled,
-    any_error,
     get_k8s_service_address,
     remove_application,
     rpc,
@@ -45,7 +44,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
         },
         trust=True,
     )
-    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
@@ -53,7 +52,7 @@ def test_relate(juju: jubilant.Juju):
         f"{TCP_TESTER_APP}:require-ingress-per-unit",
         f"{TRAEFIK_APP}:ingress-per-unit",
     )
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
 
 
 def test_relation_data_shape(juju: jubilant.Juju):
@@ -92,7 +91,7 @@ def test_remove_relation(juju: jubilant.Juju):
     juju.wait(
         lambda status: jubilant.all_active(status, TRAEFIK_APP)
         and jubilant.all_agents_idle(status),
-        error=any_error,
+        error=jubilant.any_error,
         timeout=300,
         delay=5,
         successes=5,

--- a/tests/integration/test_charm_route.py
+++ b/tests/integration/test_charm_route.py
@@ -127,6 +127,8 @@ def test_remove_relation(juju: jubilant.Juju):
             and jubilant.all_agents_idle(status)
         ),
         timeout=300,
+        delay=5,
+        successes=5,
     )
 
 

--- a/tests/integration/test_charm_route.py
+++ b/tests/integration/test_charm_route.py
@@ -17,6 +17,7 @@ from tests.integration.any_charm_helpers import (
 )
 from tests.integration.helpers import (
     all_settled,
+    any_error,
     fetch_with_retry,
     get_k8s_service_address,
     remove_application,
@@ -43,7 +44,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
         config={"src-overwrite": route_src_overwrite()},
         trust=True,
     )
-    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
@@ -51,7 +52,7 @@ def test_relate(juju: jubilant.Juju):
         f"{ROUTE_TESTER_APP}:require-traefik-route",
         f"{TRAEFIK_APP}:traefik-route",
     )
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
 
 
 def test_dynamic_config_created(juju: jubilant.Juju):
@@ -102,6 +103,7 @@ def test_scale_and_get_external_host(juju: jubilant.Juju):
         lambda status: (
             len(status.apps[ROUTE_TESTER_APP].units) == 2 and all_settled(status)
         ),
+        error=any_error,
         timeout=1000,
         delay=5,
         successes=5,
@@ -126,6 +128,7 @@ def test_remove_relation(juju: jubilant.Juju):
             jubilant.all_active(status, TRAEFIK_APP, ROUTE_TESTER_APP)
             and jubilant.all_agents_idle(status)
         ),
+        error=any_error,
         timeout=300,
         delay=5,
         successes=5,

--- a/tests/integration/test_charm_route.py
+++ b/tests/integration/test_charm_route.py
@@ -43,7 +43,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
         config={"src-overwrite": route_src_overwrite()},
         trust=True,
     )
-    juju.wait(all_settled, timeout=1000)
+    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
@@ -51,7 +51,7 @@ def test_relate(juju: jubilant.Juju):
         f"{ROUTE_TESTER_APP}:require-traefik-route",
         f"{TRAEFIK_APP}:traefik-route",
     )
-    juju.wait(all_settled, timeout=600, delay=3, successes=5)
+    juju.wait(all_settled, delay=5, successes=5)
 
 
 def test_dynamic_config_created(juju: jubilant.Juju):
@@ -103,6 +103,8 @@ def test_scale_and_get_external_host(juju: jubilant.Juju):
             len(status.apps[ROUTE_TESTER_APP].units) == 2 and all_settled(status)
         ),
         timeout=1000,
+        delay=5,
+        successes=5,
     )
 
     external_host_0 = rpc(juju, f"{ROUTE_TESTER_APP}/0", "get_external_host")

--- a/tests/integration/test_charm_route.py
+++ b/tests/integration/test_charm_route.py
@@ -17,7 +17,6 @@ from tests.integration.any_charm_helpers import (
 )
 from tests.integration.helpers import (
     all_settled,
-    any_error,
     fetch_with_retry,
     get_k8s_service_address,
     remove_application,
@@ -44,7 +43,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
         config={"src-overwrite": route_src_overwrite()},
         trust=True,
     )
-    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
@@ -52,7 +51,7 @@ def test_relate(juju: jubilant.Juju):
         f"{ROUTE_TESTER_APP}:require-traefik-route",
         f"{TRAEFIK_APP}:traefik-route",
     )
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
 
 
 def test_dynamic_config_created(juju: jubilant.Juju):
@@ -103,7 +102,7 @@ def test_scale_and_get_external_host(juju: jubilant.Juju):
         lambda status: (
             len(status.apps[ROUTE_TESTER_APP].units) == 2 and all_settled(status)
         ),
-        error=any_error,
+        error=jubilant.any_error,
         timeout=1000,
         delay=5,
         successes=5,
@@ -128,7 +127,7 @@ def test_remove_relation(juju: jubilant.Juju):
             jubilant.all_active(status, TRAEFIK_APP, ROUTE_TESTER_APP)
             and jubilant.all_agents_idle(status)
         ),
-        error=any_error,
+        error=jubilant.any_error,
         timeout=300,
         delay=5,
         successes=5,

--- a/tests/integration/test_dynamic_configs.py
+++ b/tests/integration/test_dynamic_configs.py
@@ -14,7 +14,7 @@ import jubilant
 import pytest
 import yaml
 
-from tests.integration.helpers import all_settled, any_error
+from tests.integration.helpers import all_settled
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ def deploy_catalogue(juju):
         channel="1/edge",
         trust=True,
     )
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
     return CATALOGUE_APP_NAME
 
 
@@ -49,7 +49,7 @@ def test_dynamic_configs_present(juju, traefik_app, alertmanager_app, deploy_cat
     """After integrating 2 apps, verify dynamic config files exist in the container."""
     juju.integrate(f"{CATALOGUE_APP_NAME}:ingress", traefik_app)
     juju.integrate(f"{alertmanager_app}:ingress", traefik_app)
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
     files = _list_dynamic_configs(juju, traefik_app)
     logger.info("Dynamic config files in container: %s", files)
 
@@ -148,7 +148,7 @@ def test_dynamic_config_removed_after_relation_removed(
                 for r in status.apps[alertmanager_app].relations.get("ingress", [])
             )
         ),
-        error=any_error,
+        error=jubilant.any_error,
         timeout=300,
     )
 

--- a/tests/integration/test_dynamic_configs.py
+++ b/tests/integration/test_dynamic_configs.py
@@ -31,7 +31,7 @@ def deploy_catalogue(juju):
         channel="1/edge",
         trust=True,
     )
-    juju.wait(all_settled, delay=5, timeout=600)
+    juju.wait(all_settled, delay=5, successes=5)
     return CATALOGUE_APP_NAME
 
 
@@ -49,7 +49,7 @@ def test_dynamic_configs_present(juju, traefik_app, alertmanager_app, deploy_cat
     """After integrating 2 apps, verify dynamic config files exist in the container."""
     juju.integrate(f"{CATALOGUE_APP_NAME}:ingress", traefik_app)
     juju.integrate(f"{alertmanager_app}:ingress", traefik_app)
-    juju.wait(all_settled, delay=5, timeout=600)
+    juju.wait(all_settled, delay=5, successes=5)
     files = _list_dynamic_configs(juju, traefik_app)
     logger.info("Dynamic config files in container: %s", files)
 

--- a/tests/integration/test_dynamic_configs.py
+++ b/tests/integration/test_dynamic_configs.py
@@ -14,7 +14,7 @@ import jubilant
 import pytest
 import yaml
 
-from tests.integration.helpers import all_settled
+from tests.integration.helpers import all_settled, any_error
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ def deploy_catalogue(juju):
         channel="1/edge",
         trust=True,
     )
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
     return CATALOGUE_APP_NAME
 
 
@@ -49,7 +49,7 @@ def test_dynamic_configs_present(juju, traefik_app, alertmanager_app, deploy_cat
     """After integrating 2 apps, verify dynamic config files exist in the container."""
     juju.integrate(f"{CATALOGUE_APP_NAME}:ingress", traefik_app)
     juju.integrate(f"{alertmanager_app}:ingress", traefik_app)
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
     files = _list_dynamic_configs(juju, traefik_app)
     logger.info("Dynamic config files in container: %s", files)
 
@@ -148,6 +148,7 @@ def test_dynamic_config_removed_after_relation_removed(
                 for r in status.apps[alertmanager_app].relations.get("ingress", [])
             )
         ),
+        error=any_error,
         timeout=300,
     )
 

--- a/tests/integration/test_forward_auth.py
+++ b/tests/integration/test_forward_auth.py
@@ -21,7 +21,12 @@ from tests.integration.any_charm_helpers import (
     PYTHON_PACKAGES,
     forward_auth_src_overwrite,
 )
-from tests.integration.helpers import all_settled, get_k8s_service_address, remove_application
+from tests.integration.helpers import (
+    all_settled,
+    any_error,
+    get_k8s_service_address,
+    remove_application,
+)
 
 OATHKEEPER_APP = "oathkeeper"
 TRAEFIK_APP = "traefik-k8s"
@@ -53,7 +58,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
     juju.integrate(f"{IAP_REQUIRER_APP}:require-auth-proxy", OATHKEEPER_APP)
     juju.integrate(f"{TRAEFIK_APP}:experimental-forward-auth", OATHKEEPER_APP)
     juju.model_config({"update-status-hook-interval": "5m"})
-    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
 
 
 @pytest.mark.xfail(reason="See https://github.com/canonical/traefik-k8s-operator/issues/522")
@@ -101,7 +106,7 @@ def test_forward_auth_url_response_headers(
 
 def test_remove_forward_auth_integration(juju: jubilant.Juju):
     juju.remove_relation(OATHKEEPER_APP, f"{TRAEFIK_APP}:experimental-forward-auth")
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
 
 
 def test_cleanup(juju: jubilant.Juju):

--- a/tests/integration/test_forward_auth.py
+++ b/tests/integration/test_forward_auth.py
@@ -23,7 +23,6 @@ from tests.integration.any_charm_helpers import (
 )
 from tests.integration.helpers import (
     all_settled,
-    any_error,
     get_k8s_service_address,
     remove_application,
 )
@@ -58,7 +57,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
     juju.integrate(f"{IAP_REQUIRER_APP}:require-auth-proxy", OATHKEEPER_APP)
     juju.integrate(f"{TRAEFIK_APP}:experimental-forward-auth", OATHKEEPER_APP)
     juju.model_config({"update-status-hook-interval": "5m"})
-    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=1000, delay=5, successes=5)
 
 
 @pytest.mark.xfail(reason="See https://github.com/canonical/traefik-k8s-operator/issues/522")
@@ -106,7 +105,7 @@ def test_forward_auth_url_response_headers(
 
 def test_remove_forward_auth_integration(juju: jubilant.Juju):
     juju.remove_relation(OATHKEEPER_APP, f"{TRAEFIK_APP}:experimental-forward-auth")
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
 
 
 def test_cleanup(juju: jubilant.Juju):

--- a/tests/integration/test_forward_auth.py
+++ b/tests/integration/test_forward_auth.py
@@ -53,7 +53,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
     juju.integrate(f"{IAP_REQUIRER_APP}:require-auth-proxy", OATHKEEPER_APP)
     juju.integrate(f"{TRAEFIK_APP}:experimental-forward-auth", OATHKEEPER_APP)
     juju.model_config({"update-status-hook-interval": "5m"})
-    juju.wait(all_settled, timeout=1000)
+    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
 
 
 @pytest.mark.xfail(reason="See https://github.com/canonical/traefik-k8s-operator/issues/522")
@@ -101,7 +101,7 @@ def test_forward_auth_url_response_headers(
 
 def test_remove_forward_auth_integration(juju: jubilant.Juju):
     juju.remove_relation(OATHKEEPER_APP, f"{TRAEFIK_APP}:experimental-forward-auth")
-    juju.wait(all_settled, timeout=600)
+    juju.wait(all_settled, delay=5, successes=5)
 
 
 def test_cleanup(juju: jubilant.Juju):

--- a/tests/integration/test_https_multi_unit.py
+++ b/tests/integration/test_https_multi_unit.py
@@ -7,7 +7,7 @@
 import jubilant
 from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS
-from helpers import all_settled, any_error, pull_ssc_ca_certificate, verify_https_on_all_units
+from helpers import all_settled, pull_ssc_ca_certificate, verify_https_on_all_units
 
 
 def test_https_on_all_units(
@@ -26,7 +26,7 @@ def test_https_on_all_units(
     juju.integrate(f"{ssc_app}:certificates", TRAEFIK_APP_NAME)
     juju.integrate(f"{alertmanager_app}:ingress", TRAEFIK_APP_NAME)
 
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
 
     # Pull the CA certificate from the SSC charm for HTTPS verification.
     pull_ssc_ca_certificate(juju, tmp_path, ssc_app=ssc_app)

--- a/tests/integration/test_https_multi_unit.py
+++ b/tests/integration/test_https_multi_unit.py
@@ -26,7 +26,7 @@ def test_https_on_all_units(
     juju.integrate(f"{ssc_app}:certificates", TRAEFIK_APP_NAME)
     juju.integrate(f"{alertmanager_app}:ingress", TRAEFIK_APP_NAME)
 
-    juju.wait(all_settled, timeout=600, delay=5, successes=5)
+    juju.wait(all_settled, delay=5, successes=5)
 
     # Pull the CA certificate from the SSC charm for HTTPS verification.
     pull_ssc_ca_certificate(juju, tmp_path, ssc_app=ssc_app)

--- a/tests/integration/test_https_multi_unit.py
+++ b/tests/integration/test_https_multi_unit.py
@@ -7,7 +7,7 @@
 import jubilant
 from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS
-from helpers import all_settled, pull_ssc_ca_certificate, verify_https_on_all_units
+from helpers import all_settled, any_error, pull_ssc_ca_certificate, verify_https_on_all_units
 
 
 def test_https_on_all_units(
@@ -26,7 +26,7 @@ def test_https_on_all_units(
     juju.integrate(f"{ssc_app}:certificates", TRAEFIK_APP_NAME)
     juju.integrate(f"{alertmanager_app}:ingress", TRAEFIK_APP_NAME)
 
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
 
     # Pull the CA certificate from the SSC charm for HTTPS verification.
     pull_ssc_ca_certificate(juju, tmp_path, ssc_app=ssc_app)

--- a/tests/integration/test_loadbalancer_pending_status.py
+++ b/tests/integration/test_loadbalancer_pending_status.py
@@ -36,7 +36,7 @@ def test_recovery_after_annotations_cleared(juju: jubilant.Juju, traefik_app):
     """Charm recovers to active once the LB gets an IP again."""
     # Clear the bad annotations so MetalLB assigns an IP from its pool.
     juju.config(traefik_app, {"loadbalancer_annotations": ""})
-    juju.wait(all_settled, timeout=600, delay=5, successes=5)
+    juju.wait(all_settled, delay=5, successes=5)
 
     status = juju.status()
     app_status = status.apps[traefik_app].app_status

--- a/tests/integration/test_loadbalancer_pending_status.py
+++ b/tests/integration/test_loadbalancer_pending_status.py
@@ -5,7 +5,7 @@
 
 import jubilant
 
-from tests.integration.helpers import all_settled
+from tests.integration.helpers import all_settled, any_error
 
 # An IP outside the MetalLB pool (10.43.45.0/28) so the LB stays pending.
 UNREACHABLE_IP = "192.168.255.255"
@@ -20,6 +20,7 @@ def test_waiting_when_lb_pending(juju: jubilant.Juju, traefik_app):
 
     juju.wait(
         lambda status: jubilant.all_waiting(status, traefik_app),
+        error=any_error,
         timeout=300,
         delay=5,
     )
@@ -36,7 +37,7 @@ def test_recovery_after_annotations_cleared(juju: jubilant.Juju, traefik_app):
     """Charm recovers to active once the LB gets an IP again."""
     # Clear the bad annotations so MetalLB assigns an IP from its pool.
     juju.config(traefik_app, {"loadbalancer_annotations": ""})
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
 
     status = juju.status()
     app_status = status.apps[traefik_app].app_status

--- a/tests/integration/test_loadbalancer_pending_status.py
+++ b/tests/integration/test_loadbalancer_pending_status.py
@@ -5,7 +5,7 @@
 
 import jubilant
 
-from tests.integration.helpers import all_settled, any_error
+from tests.integration.helpers import all_settled
 
 # An IP outside the MetalLB pool (10.43.45.0/28) so the LB stays pending.
 UNREACHABLE_IP = "192.168.255.255"
@@ -20,7 +20,7 @@ def test_waiting_when_lb_pending(juju: jubilant.Juju, traefik_app):
 
     juju.wait(
         lambda status: jubilant.all_waiting(status, traefik_app),
-        error=any_error,
+        error=jubilant.any_error,
         timeout=300,
         delay=5,
     )
@@ -37,7 +37,7 @@ def test_recovery_after_annotations_cleared(juju: jubilant.Juju, traefik_app):
     """Charm recovers to active once the LB gets an IP again."""
     # Clear the bad annotations so MetalLB assigns an IP from its pool.
     juju.config(traefik_app, {"loadbalancer_annotations": ""})
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
 
     status = juju.status()
     app_status = status.apps[traefik_app].app_status

--- a/tests/integration/test_pebble_restart_after_cert_relation_joined.py
+++ b/tests/integration/test_pebble_restart_after_cert_relation_joined.py
@@ -26,16 +26,16 @@ def test_build_and_deploy(juju: jubilant.Juju, traefik_charm):
     juju.deploy(traefik_charm, TRAEFIK_APP, resources=_TRAEFIK_RESOURCES, trust=True)
     juju.deploy("ch:alertmanager-k8s", ALERTMANAGER_APP, channel="2/edge", trust=True)
     juju.deploy("ch:self-signed-certificates", SSC_APP, channel="1/stable", trust=True)
-    juju.wait(jubilant.all_active, timeout=600)
+    juju.wait(jubilant.all_active, delay=5, successes=5)
 
     juju.integrate(f"{ALERTMANAGER_APP}:ingress", TRAEFIK_APP)
     juju.integrate(f"{SSC_APP}:certificates", ALERTMANAGER_APP)
-    juju.wait(all_settled, timeout=600)
+    juju.wait(all_settled, delay=5, successes=5)
 
 
 def test_can_route_ingress_using_tls(juju: jubilant.Juju):
     juju.integrate(f"{SSC_APP}:certificates", TRAEFIK_APP)
-    juju.wait(all_settled, timeout=600)
+    juju.wait(all_settled, delay=5, successes=5)
 
     traefik_url = _external_url(juju, TRAEFIK_APP)
     alertmanager_url = f"{traefik_url}/{juju.model}-{ALERTMANAGER_APP}"

--- a/tests/integration/test_pebble_restart_after_cert_relation_joined.py
+++ b/tests/integration/test_pebble_restart_after_cert_relation_joined.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import jubilant
 import yaml
 
-from tests.integration.helpers import all_settled, any_error, fetch_with_retry
+from tests.integration.helpers import all_settled, fetch_with_retry
 
 TRAEFIK_APP = "traefik"
 ALERTMANAGER_APP = "alertmanager"
@@ -26,16 +26,16 @@ def test_build_and_deploy(juju: jubilant.Juju, traefik_charm):
     juju.deploy(traefik_charm, TRAEFIK_APP, resources=_TRAEFIK_RESOURCES, trust=True)
     juju.deploy("ch:alertmanager-k8s", ALERTMANAGER_APP, channel="2/edge", trust=True)
     juju.deploy("ch:self-signed-certificates", SSC_APP, channel="1/stable", trust=True)
-    juju.wait(jubilant.all_active, error=any_error, delay=5, successes=5)
+    juju.wait(jubilant.all_active, error=jubilant.any_error, delay=5, successes=5)
 
     juju.integrate(f"{ALERTMANAGER_APP}:ingress", TRAEFIK_APP)
     juju.integrate(f"{SSC_APP}:certificates", ALERTMANAGER_APP)
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
 
 
 def test_can_route_ingress_using_tls(juju: jubilant.Juju):
     juju.integrate(f"{SSC_APP}:certificates", TRAEFIK_APP)
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
 
     traefik_url = _external_url(juju, TRAEFIK_APP)
     alertmanager_url = f"{traefik_url}/{juju.model}-{ALERTMANAGER_APP}"

--- a/tests/integration/test_pebble_restart_after_cert_relation_joined.py
+++ b/tests/integration/test_pebble_restart_after_cert_relation_joined.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import jubilant
 import yaml
 
-from tests.integration.helpers import all_settled, fetch_with_retry
+from tests.integration.helpers import all_settled, any_error, fetch_with_retry
 
 TRAEFIK_APP = "traefik"
 ALERTMANAGER_APP = "alertmanager"
@@ -26,16 +26,16 @@ def test_build_and_deploy(juju: jubilant.Juju, traefik_charm):
     juju.deploy(traefik_charm, TRAEFIK_APP, resources=_TRAEFIK_RESOURCES, trust=True)
     juju.deploy("ch:alertmanager-k8s", ALERTMANAGER_APP, channel="2/edge", trust=True)
     juju.deploy("ch:self-signed-certificates", SSC_APP, channel="1/stable", trust=True)
-    juju.wait(jubilant.all_active, delay=5, successes=5)
+    juju.wait(jubilant.all_active, error=any_error, delay=5, successes=5)
 
     juju.integrate(f"{ALERTMANAGER_APP}:ingress", TRAEFIK_APP)
     juju.integrate(f"{SSC_APP}:certificates", ALERTMANAGER_APP)
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
 
 
 def test_can_route_ingress_using_tls(juju: jubilant.Juju):
     juju.integrate(f"{SSC_APP}:certificates", TRAEFIK_APP)
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
 
     traefik_url = _external_url(juju, TRAEFIK_APP)
     alertmanager_url = f"{traefik_url}/{juju.model}-{ALERTMANAGER_APP}"

--- a/tests/integration/test_receive_ca_cert_status.py
+++ b/tests/integration/test_receive_ca_cert_status.py
@@ -31,12 +31,12 @@ def test_build_and_deploy(juju: jubilant.Juju, traefik_charm):
         trust=True,
     )
 
-    juju.wait(jubilant.all_active, timeout=900)
+    juju.wait(jubilant.all_active, timeout=900, delay=5, successes=5)
 
 
 def test_status_is_not_stuck_restarting_after_receive_ca_cert_removal(juju: jubilant.Juju):
     juju.integrate(f"{SSC_NAME}:send-ca-cert", f"{APP_NAME}:receive-ca-cert")
-    juju.wait(jubilant.all_active, timeout=600)
+    juju.wait(jubilant.all_active, delay=5, successes=5)
 
     juju.remove_relation(f"{SSC_NAME}:send-ca-cert", f"{APP_NAME}:receive-ca-cert")
 
@@ -55,4 +55,4 @@ def test_status_is_not_stuck_restarting_after_receive_ca_cert_removal(juju: jubi
         current == "maintenance" and message == "restarting traefik..."
     ), "Traefik unit remained in maintenance/restarting after receive-ca-cert removal"
 
-    juju.wait(jubilant.all_active, timeout=600)
+    juju.wait(jubilant.all_active, delay=5, successes=5)

--- a/tests/integration/test_receive_ca_cert_status.py
+++ b/tests/integration/test_receive_ca_cert_status.py
@@ -10,6 +10,8 @@ from pathlib import Path
 import jubilant
 import yaml
 
+from tests.integration.helpers import any_error
+
 APP_NAME = "traefik-rca"
 SSC_NAME = "ssc-rca"
 
@@ -23,7 +25,7 @@ def test_build_and_deploy(juju: jubilant.Juju, traefik_charm):
         resources=RESOURCES,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     juju.deploy(
         "ch:self-signed-certificates",
         SSC_NAME,
@@ -31,12 +33,12 @@ def test_build_and_deploy(juju: jubilant.Juju, traefik_charm):
         trust=True,
     )
 
-    juju.wait(jubilant.all_active, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_active, error=any_error, timeout=900, delay=5, successes=5)
 
 
 def test_status_is_not_stuck_restarting_after_receive_ca_cert_removal(juju: jubilant.Juju):
     juju.integrate(f"{SSC_NAME}:send-ca-cert", f"{APP_NAME}:receive-ca-cert")
-    juju.wait(jubilant.all_active, delay=5, successes=5)
+    juju.wait(jubilant.all_active, error=any_error, delay=5, successes=5)
 
     juju.remove_relation(f"{SSC_NAME}:send-ca-cert", f"{APP_NAME}:receive-ca-cert")
 
@@ -55,4 +57,4 @@ def test_status_is_not_stuck_restarting_after_receive_ca_cert_removal(juju: jubi
         current == "maintenance" and message == "restarting traefik..."
     ), "Traefik unit remained in maintenance/restarting after receive-ca-cert removal"
 
-    juju.wait(jubilant.all_active, delay=5, successes=5)
+    juju.wait(jubilant.all_active, error=any_error, delay=5, successes=5)

--- a/tests/integration/test_receive_ca_cert_status.py
+++ b/tests/integration/test_receive_ca_cert_status.py
@@ -10,8 +10,6 @@ from pathlib import Path
 import jubilant
 import yaml
 
-from tests.integration.helpers import any_error
-
 APP_NAME = "traefik-rca"
 SSC_NAME = "ssc-rca"
 
@@ -25,7 +23,7 @@ def test_build_and_deploy(juju: jubilant.Juju, traefik_charm):
         resources=RESOURCES,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     juju.deploy(
         "ch:self-signed-certificates",
         SSC_NAME,
@@ -33,12 +31,12 @@ def test_build_and_deploy(juju: jubilant.Juju, traefik_charm):
         trust=True,
     )
 
-    juju.wait(jubilant.all_active, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_active, error=jubilant.any_error, timeout=900, delay=5, successes=5)
 
 
 def test_status_is_not_stuck_restarting_after_receive_ca_cert_removal(juju: jubilant.Juju):
     juju.integrate(f"{SSC_NAME}:send-ca-cert", f"{APP_NAME}:receive-ca-cert")
-    juju.wait(jubilant.all_active, error=any_error, delay=5, successes=5)
+    juju.wait(jubilant.all_active, error=jubilant.any_error, delay=5, successes=5)
 
     juju.remove_relation(f"{SSC_NAME}:send-ca-cert", f"{APP_NAME}:receive-ca-cert")
 
@@ -57,4 +55,4 @@ def test_status_is_not_stuck_restarting_after_receive_ca_cert_removal(juju: jubi
         current == "maintenance" and message == "restarting traefik..."
     ), "Traefik unit remained in maintenance/restarting after receive-ca-cert removal"
 
-    juju.wait(jubilant.all_active, error=any_error, delay=5, successes=5)
+    juju.wait(jubilant.all_active, error=jubilant.any_error, delay=5, successes=5)

--- a/tests/integration/test_tcp_ipa_compatibility.py
+++ b/tests/integration/test_tcp_ipa_compatibility.py
@@ -20,6 +20,7 @@ from tests.integration.any_charm_helpers import (
 )
 from tests.integration.helpers import (
     all_settled,
+    any_error,
     assert_can_connect,
     get_k8s_service_address,
     remove_application,
@@ -58,7 +59,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
             "python-packages": PYTHON_PACKAGES,
         },
     )
-    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
@@ -67,7 +68,7 @@ def test_relate(juju: jubilant.Juju):
         f"{TRAEFIK_APP}:ingress-per-unit",
     )
     juju.integrate(f"{IPA_TESTER_APP}:require-ingress", f"{TRAEFIK_APP}:ingress")
-    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_tcp_ipa_compatibility(juju: jubilant.Juju):

--- a/tests/integration/test_tcp_ipa_compatibility.py
+++ b/tests/integration/test_tcp_ipa_compatibility.py
@@ -20,7 +20,6 @@ from tests.integration.any_charm_helpers import (
 )
 from tests.integration.helpers import (
     all_settled,
-    any_error,
     assert_can_connect,
     get_k8s_service_address,
     remove_application,
@@ -59,7 +58,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
             "python-packages": PYTHON_PACKAGES,
         },
     )
-    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
@@ -68,7 +67,7 @@ def test_relate(juju: jubilant.Juju):
         f"{TRAEFIK_APP}:ingress-per-unit",
     )
     juju.integrate(f"{IPA_TESTER_APP}:require-ingress", f"{TRAEFIK_APP}:ingress")
-    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_tcp_ipa_compatibility(juju: jubilant.Juju):

--- a/tests/integration/test_tcp_ipa_compatibility.py
+++ b/tests/integration/test_tcp_ipa_compatibility.py
@@ -58,7 +58,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
             "python-packages": PYTHON_PACKAGES,
         },
     )
-    juju.wait(all_settled, timeout=1000)
+    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
@@ -67,7 +67,7 @@ def test_relate(juju: jubilant.Juju):
         f"{TRAEFIK_APP}:ingress-per-unit",
     )
     juju.integrate(f"{IPA_TESTER_APP}:require-ingress", f"{TRAEFIK_APP}:ingress")
-    juju.wait(all_settled, timeout=1000)
+    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
 
 
 def test_tcp_ipa_compatibility(juju: jubilant.Juju):

--- a/tests/integration/test_tcp_ipu_compatibility.py
+++ b/tests/integration/test_tcp_ipu_compatibility.py
@@ -20,7 +20,6 @@ from tests.integration.any_charm_helpers import (
 )
 from tests.integration.helpers import (
     all_settled,
-    any_error,
     assert_can_connect,
     get_k8s_service_address,
     remove_application,
@@ -59,7 +58,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
             "python-packages": PYTHON_PACKAGES,
         },
     )
-    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
@@ -71,7 +70,7 @@ def test_relate(juju: jubilant.Juju):
         f"{IPU_TESTER_APP}:require-ingress-per-unit",
         f"{TRAEFIK_APP}:ingress-per-unit",
     )
-    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_tcp_ipu_compatibility(juju: jubilant.Juju):

--- a/tests/integration/test_tcp_ipu_compatibility.py
+++ b/tests/integration/test_tcp_ipu_compatibility.py
@@ -20,6 +20,7 @@ from tests.integration.any_charm_helpers import (
 )
 from tests.integration.helpers import (
     all_settled,
+    any_error,
     assert_can_connect,
     get_k8s_service_address,
     remove_application,
@@ -58,7 +59,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
             "python-packages": PYTHON_PACKAGES,
         },
     )
-    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
@@ -70,7 +71,7 @@ def test_relate(juju: jubilant.Juju):
         f"{IPU_TESTER_APP}:require-ingress-per-unit",
         f"{TRAEFIK_APP}:ingress-per-unit",
     )
-    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_tcp_ipu_compatibility(juju: jubilant.Juju):

--- a/tests/integration/test_tcp_ipu_compatibility.py
+++ b/tests/integration/test_tcp_ipu_compatibility.py
@@ -58,7 +58,7 @@ def test_deployment(juju: jubilant.Juju, traefik_charm):
             "python-packages": PYTHON_PACKAGES,
         },
     )
-    juju.wait(all_settled, timeout=1000)
+    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
 
 
 def test_relate(juju: jubilant.Juju):
@@ -70,7 +70,7 @@ def test_relate(juju: jubilant.Juju):
         f"{IPU_TESTER_APP}:require-ingress-per-unit",
         f"{TRAEFIK_APP}:ingress-per-unit",
     )
-    juju.wait(all_settled, timeout=1000)
+    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
 
 
 def test_tcp_ipu_compatibility(juju: jubilant.Juju):

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -13,7 +13,6 @@ import yaml
 from tests.integration.dns_adapter import DNSResolverHTTPSAdapter
 from tests.integration.helpers import (
     all_settled,
-    any_error,
     get_k8s_service_address,
     pull_ssc_ca_certificate,
     remove_application,
@@ -37,12 +36,12 @@ def test_build_and_deploy(juju: jubilant.Juju, traefik_charm):
     juju.deploy("ch:prometheus-k8s", PROMETHEUS_APP, channel="1/stable", trust=True)
     juju.deploy("ch:alertmanager-k8s", ALERTMANAGER_APP, channel="1/stable", trust=True)
     juju.deploy("ch:grafana-k8s", GRAFANA_APP, channel="1/stable", trust=True)
-    juju.wait(jubilant.all_active, error=any_error, delay=5, successes=5)
+    juju.wait(jubilant.all_active, error=jubilant.any_error, delay=5, successes=5)
 
     juju.integrate(f"{PROMETHEUS_APP}:ingress", TRAEFIK_APP)
     juju.integrate(f"{ALERTMANAGER_APP}:ingress", TRAEFIK_APP)
     juju.integrate(f"{GRAFANA_APP}:ingress", TRAEFIK_APP)
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
 
 
 def test_ingressed_endpoints_reachable_after_metallb_enabled(juju: jubilant.Juju):
@@ -62,7 +61,7 @@ def test_tls_termination(juju: jubilant.Juju, tmp_path: Path):
     juju.deploy("ch:self-signed-certificates", ROOT_CA_APP, channel="1/stable", trust=True)
     juju.config(ROOT_CA_APP, {"ca-common-name": "demo.ca.local"})
     juju.integrate(f"{ROOT_CA_APP}:certificates", TRAEFIK_APP)
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
 
     cert_path = pull_ssc_ca_certificate(juju, tmp_path, ssc_app=ROOT_CA_APP)
     traefik_ip = get_k8s_service_address(model_name, f"{TRAEFIK_APP}-lb")
@@ -76,7 +75,7 @@ def test_tls_termination_after_charm_upgrade(
     model_name = juju.model
     assert model_name is not None
     juju.refresh(TRAEFIK_APP, path=traefik_charm, resources=_TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
 
     cert_path = pull_ssc_ca_certificate(juju, tmp_path, ssc_app=ROOT_CA_APP)
     traefik_ip = get_k8s_service_address(model_name, f"{TRAEFIK_APP}-lb")
@@ -88,7 +87,7 @@ def test_disintegrate(juju: jubilant.Juju):
     if ROOT_CA_APP not in juju.status().apps:
         return
     juju.remove_relation(f"{ROOT_CA_APP}:certificates", f"{TRAEFIK_APP}:certificates")
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
 
 
 def test_cleanup(juju: jubilant.Juju):

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -36,12 +36,12 @@ def test_build_and_deploy(juju: jubilant.Juju, traefik_charm):
     juju.deploy("ch:prometheus-k8s", PROMETHEUS_APP, channel="1/stable", trust=True)
     juju.deploy("ch:alertmanager-k8s", ALERTMANAGER_APP, channel="1/stable", trust=True)
     juju.deploy("ch:grafana-k8s", GRAFANA_APP, channel="1/stable", trust=True)
-    juju.wait(jubilant.all_active, timeout=600)
+    juju.wait(jubilant.all_active, delay=5, successes=5)
 
     juju.integrate(f"{PROMETHEUS_APP}:ingress", TRAEFIK_APP)
     juju.integrate(f"{ALERTMANAGER_APP}:ingress", TRAEFIK_APP)
     juju.integrate(f"{GRAFANA_APP}:ingress", TRAEFIK_APP)
-    juju.wait(all_settled, timeout=600)
+    juju.wait(all_settled, delay=5, successes=5)
 
 
 def test_ingressed_endpoints_reachable_after_metallb_enabled(juju: jubilant.Juju):
@@ -61,7 +61,7 @@ def test_tls_termination(juju: jubilant.Juju, tmp_path: Path):
     juju.deploy("ch:self-signed-certificates", ROOT_CA_APP, channel="1/stable", trust=True)
     juju.config(ROOT_CA_APP, {"ca-common-name": "demo.ca.local"})
     juju.integrate(f"{ROOT_CA_APP}:certificates", TRAEFIK_APP)
-    juju.wait(all_settled, timeout=600, delay=2, successes=5)
+    juju.wait(all_settled, delay=5, successes=5)
 
     cert_path = pull_ssc_ca_certificate(juju, tmp_path, ssc_app=ROOT_CA_APP)
     traefik_ip = get_k8s_service_address(model_name, f"{TRAEFIK_APP}-lb")
@@ -75,7 +75,7 @@ def test_tls_termination_after_charm_upgrade(
     model_name = juju.model
     assert model_name is not None
     juju.refresh(TRAEFIK_APP, path=traefik_charm, resources=_TRAEFIK_RESOURCES)
-    juju.wait(all_settled, timeout=600, delay=2, successes=5)
+    juju.wait(all_settled, delay=5, successes=5)
 
     cert_path = pull_ssc_ca_certificate(juju, tmp_path, ssc_app=ROOT_CA_APP)
     traefik_ip = get_k8s_service_address(model_name, f"{TRAEFIK_APP}-lb")
@@ -87,7 +87,7 @@ def test_disintegrate(juju: jubilant.Juju):
     if ROOT_CA_APP not in juju.status().apps:
         return
     juju.remove_relation(f"{ROOT_CA_APP}:certificates", f"{TRAEFIK_APP}:certificates")
-    juju.wait(all_settled, timeout=600)
+    juju.wait(all_settled, delay=5, successes=5)
 
 
 def test_cleanup(juju: jubilant.Juju):

--- a/tests/integration/test_tls.py
+++ b/tests/integration/test_tls.py
@@ -13,6 +13,7 @@ import yaml
 from tests.integration.dns_adapter import DNSResolverHTTPSAdapter
 from tests.integration.helpers import (
     all_settled,
+    any_error,
     get_k8s_service_address,
     pull_ssc_ca_certificate,
     remove_application,
@@ -36,12 +37,12 @@ def test_build_and_deploy(juju: jubilant.Juju, traefik_charm):
     juju.deploy("ch:prometheus-k8s", PROMETHEUS_APP, channel="1/stable", trust=True)
     juju.deploy("ch:alertmanager-k8s", ALERTMANAGER_APP, channel="1/stable", trust=True)
     juju.deploy("ch:grafana-k8s", GRAFANA_APP, channel="1/stable", trust=True)
-    juju.wait(jubilant.all_active, delay=5, successes=5)
+    juju.wait(jubilant.all_active, error=any_error, delay=5, successes=5)
 
     juju.integrate(f"{PROMETHEUS_APP}:ingress", TRAEFIK_APP)
     juju.integrate(f"{ALERTMANAGER_APP}:ingress", TRAEFIK_APP)
     juju.integrate(f"{GRAFANA_APP}:ingress", TRAEFIK_APP)
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
 
 
 def test_ingressed_endpoints_reachable_after_metallb_enabled(juju: jubilant.Juju):
@@ -61,7 +62,7 @@ def test_tls_termination(juju: jubilant.Juju, tmp_path: Path):
     juju.deploy("ch:self-signed-certificates", ROOT_CA_APP, channel="1/stable", trust=True)
     juju.config(ROOT_CA_APP, {"ca-common-name": "demo.ca.local"})
     juju.integrate(f"{ROOT_CA_APP}:certificates", TRAEFIK_APP)
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
 
     cert_path = pull_ssc_ca_certificate(juju, tmp_path, ssc_app=ROOT_CA_APP)
     traefik_ip = get_k8s_service_address(model_name, f"{TRAEFIK_APP}-lb")
@@ -75,7 +76,7 @@ def test_tls_termination_after_charm_upgrade(
     model_name = juju.model
     assert model_name is not None
     juju.refresh(TRAEFIK_APP, path=traefik_charm, resources=_TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
 
     cert_path = pull_ssc_ca_certificate(juju, tmp_path, ssc_app=ROOT_CA_APP)
     traefik_ip = get_k8s_service_address(model_name, f"{TRAEFIK_APP}-lb")
@@ -87,7 +88,7 @@ def test_disintegrate(juju: jubilant.Juju):
     if ROOT_CA_APP not in juju.status().apps:
         return
     juju.remove_relation(f"{ROOT_CA_APP}:certificates", f"{TRAEFIK_APP}:certificates")
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
 
 
 def test_cleanup(juju: jubilant.Juju):

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -6,7 +6,7 @@
 
 import jubilant
 
-from tests.integration.helpers import all_settled, assert_traefik_revision
+from tests.integration.helpers import all_settled, any_error, assert_traefik_revision
 
 TRAEFIK_APP_NAME = "traefik"
 SSC_APP_NAME = "ssc"
@@ -28,7 +28,7 @@ def test_upgrade(juju: jubilant.Juju, traefik_charm, pytestconfig):
         config={"external_hostname": "traefik-demo.local"},
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
 
     juju.deploy(
         "ch:self-signed-certificates",
@@ -44,15 +44,15 @@ def test_upgrade(juju: jubilant.Juju, traefik_charm, pytestconfig):
         trust=True,
     )
 
-    juju.wait(jubilant.all_active, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_active, error=any_error, timeout=900, delay=5, successes=5)
 
     juju.integrate(f"{SSC_APP_NAME}:certificates", TRAEFIK_APP_NAME)
     juju.integrate(f"{INGRESS_REQUIRER_APP_NAME}:ingress", TRAEFIK_APP_NAME)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
 
     juju.refresh(
         TRAEFIK_APP_NAME,
         path=traefik_charm,
     )
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -6,7 +6,7 @@
 
 import jubilant
 
-from tests.integration.helpers import all_settled, any_error, assert_traefik_revision
+from tests.integration.helpers import all_settled, assert_traefik_revision
 
 TRAEFIK_APP_NAME = "traefik"
 SSC_APP_NAME = "ssc"
@@ -28,7 +28,7 @@ def test_upgrade(juju: jubilant.Juju, traefik_charm, pytestconfig):
         config={"external_hostname": "traefik-demo.local"},
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
 
     juju.deploy(
         "ch:self-signed-certificates",
@@ -44,15 +44,15 @@ def test_upgrade(juju: jubilant.Juju, traefik_charm, pytestconfig):
         trust=True,
     )
 
-    juju.wait(jubilant.all_active, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_active, error=jubilant.any_error, timeout=900, delay=5, successes=5)
 
     juju.integrate(f"{SSC_APP_NAME}:certificates", TRAEFIK_APP_NAME)
     juju.integrate(f"{INGRESS_REQUIRER_APP_NAME}:ingress", TRAEFIK_APP_NAME)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
 
     juju.refresh(
         TRAEFIK_APP_NAME,
         path=traefik_charm,
     )
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -44,15 +44,15 @@ def test_upgrade(juju: jubilant.Juju, traefik_charm, pytestconfig):
         trust=True,
     )
 
-    juju.wait(jubilant.all_active, timeout=900)
+    juju.wait(jubilant.all_active, timeout=900, delay=5, successes=5)
 
     juju.integrate(f"{SSC_APP_NAME}:certificates", TRAEFIK_APP_NAME)
     juju.integrate(f"{INGRESS_REQUIRER_APP_NAME}:ingress", TRAEFIK_APP_NAME)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
 
     juju.refresh(
         TRAEFIK_APP_NAME,
         path=traefik_charm,
     )
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)

--- a/tests/integration/test_upgrade_mtls_from_280.py
+++ b/tests/integration/test_upgrade_mtls_from_280.py
@@ -28,6 +28,7 @@ from constants import (
 )
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_certified_traefik,
     get_outstanding_csrs,
@@ -53,12 +54,12 @@ def test_upgrade_mtls_from_revision_280(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     url = bring_up_certified_traefik(juju, tmp_path)
 
     # Upgrade to the charm under test.
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     # The migrated key must still match the certificate on every unit ...

--- a/tests/integration/test_upgrade_mtls_from_280.py
+++ b/tests/integration/test_upgrade_mtls_from_280.py
@@ -28,7 +28,6 @@ from constants import (
 )
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_certified_traefik,
     get_outstanding_csrs,
@@ -54,12 +53,12 @@ def test_upgrade_mtls_from_revision_280(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     url = bring_up_certified_traefik(juju, tmp_path)
 
     # Upgrade to the charm under test.
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     # The migrated key must still match the certificate on every unit ...

--- a/tests/integration/test_upgrade_mtls_from_280.py
+++ b/tests/integration/test_upgrade_mtls_from_280.py
@@ -58,7 +58,7 @@ def test_upgrade_mtls_from_revision_280(
 
     # Upgrade to the charm under test.
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     # The migrated key must still match the certificate on every unit ...

--- a/tests/integration/test_upgrade_mtls_from_280_via_298.py
+++ b/tests/integration/test_upgrade_mtls_from_280_via_298.py
@@ -34,7 +34,6 @@ from constants import (
 )
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_certified_traefik,
     get_outstanding_csrs,
@@ -63,25 +62,25 @@ def test_upgrade_mtls_from_280_via_298(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     url = bring_up_certified_traefik(juju, tmp_path)
 
     # Intermediate hop: 280 -> 298. The intermediate revision raises a fresh
     # CSR, so sign until every unit is serving again, then confirm HTTPS works.
     juju.refresh(TRAEFIK_APP_NAME, channel=SOURCE_CHANNEL, revision=INTERMEDIATE_REVISION)
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
 
     # Sign CSRs; the resulting cert PEMs are stored in the module-level
     # ``signed_certificates`` global for re-use after the relation is re-created.
     sign_csrs_and_provide_cert(juju, MANUAL_TLS_APP_NAME)
-    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     assert_traefik_revision(juju, INTERMEDIATE_REVISION)
 
     verify_https_on_all_units(juju, expected_url=url)
 
     # Final hop: 298 -> charm under test.
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     # The migrated key must still match the certificate on every unit ...
@@ -93,10 +92,10 @@ def test_upgrade_mtls_from_280_via_298(
     )
 
     juju.remove_relation(f"{mtls_app}:certificates", f"{TRAEFIK_APP_NAME}:certificates")
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
 
     juju.integrate(f"{mtls_app}:certificates", f"{TRAEFIK_APP_NAME}:certificates")
-    juju.wait(jubilant.all_agents_idle, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, delay=5, timeout=900, successes=5)
 
     # A new CSR is expected (the relation data is fresh) but the private key
     # is reused, so the old certificate's public key still matches. Provide
@@ -108,7 +107,7 @@ def test_upgrade_mtls_from_280_via_298(
     )
 
     provide_existing_certificate(juju, outstanding)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
 
     assert len(get_outstanding_csrs(juju)) == 0, (
         "manual-tls-certificates still has outstanding requests after providing "

--- a/tests/integration/test_upgrade_mtls_from_280_via_298.py
+++ b/tests/integration/test_upgrade_mtls_from_280_via_298.py
@@ -68,19 +68,19 @@ def test_upgrade_mtls_from_280_via_298(
     # Intermediate hop: 280 -> 298. The intermediate revision raises a fresh
     # CSR, so sign until every unit is serving again, then confirm HTTPS works.
     juju.refresh(TRAEFIK_APP_NAME, channel=SOURCE_CHANNEL, revision=INTERMEDIATE_REVISION)
-    juju.wait(jubilant.all_agents_idle, timeout=900)
+    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
 
     # Sign CSRs; the resulting cert PEMs are stored in the module-level
     # ``signed_certificates`` global for re-use after the relation is re-created.
     sign_csrs_and_provide_cert(juju, MANUAL_TLS_APP_NAME)
-    juju.wait(all_settled, timeout=900)
+    juju.wait(all_settled, timeout=900, delay=5, successes=5)
     assert_traefik_revision(juju, INTERMEDIATE_REVISION)
 
     verify_https_on_all_units(juju, expected_url=url)
 
     # Final hop: 298 -> charm under test.
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     # The migrated key must still match the certificate on every unit ...

--- a/tests/integration/test_upgrade_mtls_from_280_via_298.py
+++ b/tests/integration/test_upgrade_mtls_from_280_via_298.py
@@ -34,6 +34,7 @@ from constants import (
 )
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_certified_traefik,
     get_outstanding_csrs,
@@ -62,25 +63,25 @@ def test_upgrade_mtls_from_280_via_298(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     url = bring_up_certified_traefik(juju, tmp_path)
 
     # Intermediate hop: 280 -> 298. The intermediate revision raises a fresh
     # CSR, so sign until every unit is serving again, then confirm HTTPS works.
     juju.refresh(TRAEFIK_APP_NAME, channel=SOURCE_CHANNEL, revision=INTERMEDIATE_REVISION)
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
 
     # Sign CSRs; the resulting cert PEMs are stored in the module-level
     # ``signed_certificates`` global for re-use after the relation is re-created.
     sign_csrs_and_provide_cert(juju, MANUAL_TLS_APP_NAME)
-    juju.wait(all_settled, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
     assert_traefik_revision(juju, INTERMEDIATE_REVISION)
 
     verify_https_on_all_units(juju, expected_url=url)
 
     # Final hop: 298 -> charm under test.
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     # The migrated key must still match the certificate on every unit ...
@@ -92,10 +93,10 @@ def test_upgrade_mtls_from_280_via_298(
     )
 
     juju.remove_relation(f"{mtls_app}:certificates", f"{TRAEFIK_APP_NAME}:certificates")
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
 
     juju.integrate(f"{mtls_app}:certificates", f"{TRAEFIK_APP_NAME}:certificates")
-    juju.wait(jubilant.all_agents_idle, delay=5, timeout=900, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, delay=5, timeout=900, successes=5)
 
     # A new CSR is expected (the relation data is fresh) but the private key
     # is reused, so the old certificate's public key still matches. Provide
@@ -107,7 +108,7 @@ def test_upgrade_mtls_from_280_via_298(
     )
 
     provide_existing_certificate(juju, outstanding)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
 
     assert len(get_outstanding_csrs(juju)) == 0, (
         "manual-tls-certificates still has outstanding requests after providing "

--- a/tests/integration/test_upgrade_mtls_from_298.py
+++ b/tests/integration/test_upgrade_mtls_from_298.py
@@ -58,7 +58,7 @@ def test_upgrade_mtls_from_revision_298(
 
     # Upgrade to the charm under test.
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     # The migrated key must still match the certificate on every unit ...

--- a/tests/integration/test_upgrade_mtls_from_298.py
+++ b/tests/integration/test_upgrade_mtls_from_298.py
@@ -28,6 +28,7 @@ from constants import (
 )
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_certified_traefik,
     get_outstanding_csrs,
@@ -53,12 +54,12 @@ def test_upgrade_mtls_from_revision_298(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     url = bring_up_certified_traefik(juju, tmp_path)
 
     # Upgrade to the charm under test.
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     # The migrated key must still match the certificate on every unit ...

--- a/tests/integration/test_upgrade_mtls_from_298.py
+++ b/tests/integration/test_upgrade_mtls_from_298.py
@@ -28,7 +28,6 @@ from constants import (
 )
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_certified_traefik,
     get_outstanding_csrs,
@@ -54,12 +53,12 @@ def test_upgrade_mtls_from_revision_298(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     url = bring_up_certified_traefik(juju, tmp_path)
 
     # Upgrade to the charm under test.
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     # The migrated key must still match the certificate on every unit ...

--- a/tests/integration/test_upgrade_mtls_leader_change_from_298.py
+++ b/tests/integration/test_upgrade_mtls_leader_change_from_298.py
@@ -33,6 +33,7 @@ from constants import (
 )
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_certified_traefik,
     force_leader_change,
@@ -59,13 +60,13 @@ def test_leader_change_breaks_tls_then_upgrade_blocks_and_requests_certificate(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     alertmanager_url = bring_up_certified_traefik(juju, tmp_path)
 
     # newly elected leader is expected to break.
     new_leader = force_leader_change(juju, TRAEFIK_APP_NAME)
 
-    juju.wait(all_settled, timeout=300, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=300, delay=5, successes=5)
 
     # All units except the new leader should still serve valid HTTPS (their per-unit
     # private keys are intact). The new leader lost the old leader's key on rev 298.
@@ -77,7 +78,7 @@ def test_leader_change_breaks_tls_then_upgrade_blocks_and_requests_certificate(
     for unit_name in working_units:
         verify_https_on_unit(juju, unit_name, alertmanager_url)
 
-    juju.wait(lambda _: len(get_outstanding_csrs(juju)) == 1, timeout=300)
+    juju.wait(lambda _: len(get_outstanding_csrs(juju)) == 1, error=any_error, timeout=300)
 
     # The new leader lost the old leader's key, so its served certificate is no
     # longer trusted (or the endpoint is down) -- HTTPS must fail here.
@@ -93,7 +94,7 @@ def test_leader_change_breaks_tls_then_upgrade_blocks_and_requests_certificate(
 
     # Upgrade to the charm under test.
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     assert_traefik_revision(juju, 0)
 
     status = juju.status()

--- a/tests/integration/test_upgrade_mtls_leader_change_from_298.py
+++ b/tests/integration/test_upgrade_mtls_leader_change_from_298.py
@@ -33,7 +33,6 @@ from constants import (
 )
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_certified_traefik,
     force_leader_change,
@@ -60,13 +59,13 @@ def test_leader_change_breaks_tls_then_upgrade_blocks_and_requests_certificate(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     alertmanager_url = bring_up_certified_traefik(juju, tmp_path)
 
     # newly elected leader is expected to break.
     new_leader = force_leader_change(juju, TRAEFIK_APP_NAME)
 
-    juju.wait(all_settled, error=any_error, timeout=300, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=300, delay=5, successes=5)
 
     # All units except the new leader should still serve valid HTTPS (their per-unit
     # private keys are intact). The new leader lost the old leader's key on rev 298.
@@ -78,7 +77,7 @@ def test_leader_change_breaks_tls_then_upgrade_blocks_and_requests_certificate(
     for unit_name in working_units:
         verify_https_on_unit(juju, unit_name, alertmanager_url)
 
-    juju.wait(lambda _: len(get_outstanding_csrs(juju)) == 1, error=any_error, timeout=300)
+    juju.wait(lambda _: len(get_outstanding_csrs(juju)) == 1, error=jubilant.any_error, timeout=300)
 
     # The new leader lost the old leader's key, so its served certificate is no
     # longer trusted (or the endpoint is down) -- HTTPS must fail here.
@@ -94,7 +93,7 @@ def test_leader_change_breaks_tls_then_upgrade_blocks_and_requests_certificate(
 
     # Upgrade to the charm under test.
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     assert_traefik_revision(juju, 0)
 
     status = juju.status()

--- a/tests/integration/test_upgrade_mtls_single_unit_from_280.py
+++ b/tests/integration/test_upgrade_mtls_single_unit_from_280.py
@@ -23,6 +23,7 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_certified_traefik,
     get_outstanding_csrs,
@@ -47,12 +48,12 @@ def test_upgrade_mtls_single_unit_from_280(
         revision=SOURCE_REVISION,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     url = bring_up_certified_traefik(juju, tmp_path)
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upgrade_mtls_single_unit_from_280.py
+++ b/tests/integration/test_upgrade_mtls_single_unit_from_280.py
@@ -52,7 +52,7 @@ def test_upgrade_mtls_single_unit_from_280(
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upgrade_mtls_single_unit_from_280.py
+++ b/tests/integration/test_upgrade_mtls_single_unit_from_280.py
@@ -23,7 +23,6 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_certified_traefik,
     get_outstanding_csrs,
@@ -48,12 +47,12 @@ def test_upgrade_mtls_single_unit_from_280(
         revision=SOURCE_REVISION,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     url = bring_up_certified_traefik(juju, tmp_path)
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upgrade_mtls_single_unit_from_280_via_298.py
+++ b/tests/integration/test_upgrade_mtls_single_unit_from_280_via_298.py
@@ -25,7 +25,6 @@ from conftest import MANUAL_TLS_APP_NAME, TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_certified_traefik,
     get_outstanding_csrs,
@@ -52,21 +51,21 @@ def test_upgrade_mtls_single_unit_from_280_via_298(
         revision=SOURCE_REVISION,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     url = bring_up_certified_traefik(juju, tmp_path)
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, channel=SOURCE_CHANNEL, revision=INTERMEDIATE_REVISION)
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
 
     sign_csrs_and_provide_cert(juju, MANUAL_TLS_APP_NAME)
-    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     assert_traefik_revision(juju, INTERMEDIATE_REVISION)
 
     verify_https_on_unit(juju, unit_name, url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upgrade_mtls_single_unit_from_280_via_298.py
+++ b/tests/integration/test_upgrade_mtls_single_unit_from_280_via_298.py
@@ -25,6 +25,7 @@ from conftest import MANUAL_TLS_APP_NAME, TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_certified_traefik,
     get_outstanding_csrs,
@@ -51,21 +52,21 @@ def test_upgrade_mtls_single_unit_from_280_via_298(
         revision=SOURCE_REVISION,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     url = bring_up_certified_traefik(juju, tmp_path)
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, channel=SOURCE_CHANNEL, revision=INTERMEDIATE_REVISION)
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
 
     sign_csrs_and_provide_cert(juju, MANUAL_TLS_APP_NAME)
-    juju.wait(all_settled, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
     assert_traefik_revision(juju, INTERMEDIATE_REVISION)
 
     verify_https_on_unit(juju, unit_name, url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upgrade_mtls_single_unit_from_280_via_298.py
+++ b/tests/integration/test_upgrade_mtls_single_unit_from_280_via_298.py
@@ -56,16 +56,16 @@ def test_upgrade_mtls_single_unit_from_280_via_298(
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, channel=SOURCE_CHANNEL, revision=INTERMEDIATE_REVISION)
-    juju.wait(jubilant.all_agents_idle, timeout=900)
+    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
 
     sign_csrs_and_provide_cert(juju, MANUAL_TLS_APP_NAME)
-    juju.wait(all_settled, timeout=900)
+    juju.wait(all_settled, timeout=900, delay=5, successes=5)
     assert_traefik_revision(juju, INTERMEDIATE_REVISION)
 
     verify_https_on_unit(juju, unit_name, url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upgrade_mtls_single_unit_from_298.py
+++ b/tests/integration/test_upgrade_mtls_single_unit_from_298.py
@@ -23,6 +23,7 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_certified_traefik,
     get_outstanding_csrs,
@@ -47,12 +48,12 @@ def test_upgrade_mtls_single_unit_from_298(
         revision=SOURCE_REVISION,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     url = bring_up_certified_traefik(juju, tmp_path)
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upgrade_mtls_single_unit_from_298.py
+++ b/tests/integration/test_upgrade_mtls_single_unit_from_298.py
@@ -52,7 +52,7 @@ def test_upgrade_mtls_single_unit_from_298(
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upgrade_mtls_single_unit_from_298.py
+++ b/tests/integration/test_upgrade_mtls_single_unit_from_298.py
@@ -23,7 +23,6 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_certified_traefik,
     get_outstanding_csrs,
@@ -48,12 +47,12 @@ def test_upgrade_mtls_single_unit_from_298(
         revision=SOURCE_REVISION,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     url = bring_up_certified_traefik(juju, tmp_path)
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upgrade_no_tls_from_280.py
+++ b/tests/integration/test_upgrade_no_tls_from_280.py
@@ -23,6 +23,7 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_traefik_without_certificate_provider,
     verify_http_on_all_units,
@@ -47,11 +48,11 @@ def test_upgrade_no_tls_from_revision_280(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     url = bring_up_traefik_without_certificate_provider(juju)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_http_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_no_tls_from_280.py
+++ b/tests/integration/test_upgrade_no_tls_from_280.py
@@ -51,7 +51,7 @@ def test_upgrade_no_tls_from_revision_280(
     url = bring_up_traefik_without_certificate_provider(juju)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_http_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_no_tls_from_280.py
+++ b/tests/integration/test_upgrade_no_tls_from_280.py
@@ -23,7 +23,6 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_traefik_without_certificate_provider,
     verify_http_on_all_units,
@@ -48,11 +47,11 @@ def test_upgrade_no_tls_from_revision_280(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     url = bring_up_traefik_without_certificate_provider(juju)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_http_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_no_tls_from_280_via_298.py
+++ b/tests/integration/test_upgrade_no_tls_from_280_via_298.py
@@ -50,11 +50,11 @@ def test_upgrade_no_tls_from_280_via_298(
     url = bring_up_traefik_without_certificate_provider(juju)
 
     juju.refresh(TRAEFIK_APP_NAME, channel=SOURCE_CHANNEL, revision=INTERMEDIATE_REVISION)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, INTERMEDIATE_REVISION)
     verify_http_on_all_units(juju, expected_url=url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
     verify_http_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_no_tls_from_280_via_298.py
+++ b/tests/integration/test_upgrade_no_tls_from_280_via_298.py
@@ -21,7 +21,6 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_traefik_without_certificate_provider,
     verify_http_on_all_units,
@@ -47,15 +46,15 @@ def test_upgrade_no_tls_from_280_via_298(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     url = bring_up_traefik_without_certificate_provider(juju)
 
     juju.refresh(TRAEFIK_APP_NAME, channel=SOURCE_CHANNEL, revision=INTERMEDIATE_REVISION)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, INTERMEDIATE_REVISION)
     verify_http_on_all_units(juju, expected_url=url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
     verify_http_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_no_tls_from_280_via_298.py
+++ b/tests/integration/test_upgrade_no_tls_from_280_via_298.py
@@ -21,6 +21,7 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_traefik_without_certificate_provider,
     verify_http_on_all_units,
@@ -46,15 +47,15 @@ def test_upgrade_no_tls_from_280_via_298(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     url = bring_up_traefik_without_certificate_provider(juju)
 
     juju.refresh(TRAEFIK_APP_NAME, channel=SOURCE_CHANNEL, revision=INTERMEDIATE_REVISION)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, INTERMEDIATE_REVISION)
     verify_http_on_all_units(juju, expected_url=url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
     verify_http_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_no_tls_from_298.py
+++ b/tests/integration/test_upgrade_no_tls_from_298.py
@@ -51,7 +51,7 @@ def test_upgrade_no_tls_from_revision_298(
     url = bring_up_traefik_without_certificate_provider(juju)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_http_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_no_tls_from_298.py
+++ b/tests/integration/test_upgrade_no_tls_from_298.py
@@ -23,6 +23,7 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_traefik_without_certificate_provider,
     verify_http_on_all_units,
@@ -47,11 +48,11 @@ def test_upgrade_no_tls_from_revision_298(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     url = bring_up_traefik_without_certificate_provider(juju)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_http_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_no_tls_from_298.py
+++ b/tests/integration/test_upgrade_no_tls_from_298.py
@@ -23,7 +23,6 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_traefik_without_certificate_provider,
     verify_http_on_all_units,
@@ -48,11 +47,11 @@ def test_upgrade_no_tls_from_revision_298(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     url = bring_up_traefik_without_certificate_provider(juju)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_http_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_no_tls_leader_change_from_298.py
+++ b/tests/integration/test_upgrade_no_tls_leader_change_from_298.py
@@ -22,6 +22,7 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_traefik_without_certificate_provider,
     force_leader_change,
@@ -47,15 +48,15 @@ def test_upgrade_no_tls_leader_change_from_298(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     alertmanager_url = bring_up_traefik_without_certificate_provider(juju)
 
     force_leader_change(juju, TRAEFIK_APP_NAME)
 
-    juju.wait(all_settled, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
     verify_http_on_all_units(juju, alertmanager_url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
     assert_traefik_revision(juju, 0)
     verify_http_on_all_units(juju, alertmanager_url)

--- a/tests/integration/test_upgrade_no_tls_leader_change_from_298.py
+++ b/tests/integration/test_upgrade_no_tls_leader_change_from_298.py
@@ -22,7 +22,6 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_traefik_without_certificate_provider,
     force_leader_change,
@@ -48,15 +47,15 @@ def test_upgrade_no_tls_leader_change_from_298(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     alertmanager_url = bring_up_traefik_without_certificate_provider(juju)
 
     force_leader_change(juju, TRAEFIK_APP_NAME)
 
-    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     verify_http_on_all_units(juju, alertmanager_url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     assert_traefik_revision(juju, 0)
     verify_http_on_all_units(juju, alertmanager_url)

--- a/tests/integration/test_upgrade_no_tls_leader_change_from_298.py
+++ b/tests/integration/test_upgrade_no_tls_leader_change_from_298.py
@@ -56,6 +56,6 @@ def test_upgrade_no_tls_leader_change_from_298(
     verify_http_on_all_units(juju, alertmanager_url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, timeout=900, delay=5)
+    juju.wait(all_settled, timeout=900, delay=5, successes=5)
     assert_traefik_revision(juju, 0)
     verify_http_on_all_units(juju, alertmanager_url)

--- a/tests/integration/test_upgrade_ssc_from_280.py
+++ b/tests/integration/test_upgrade_ssc_from_280.py
@@ -49,7 +49,7 @@ def test_upgrade_ssc_from_revision_280(
     url = bring_up_self_signed_traefik(juju, tmp_path)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_ssc_from_280.py
+++ b/tests/integration/test_upgrade_ssc_from_280.py
@@ -21,7 +21,6 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_self_signed_traefik,
     verify_https_on_all_units,
@@ -46,11 +45,11 @@ def test_upgrade_ssc_from_revision_280(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     url = bring_up_self_signed_traefik(juju, tmp_path)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_ssc_from_280.py
+++ b/tests/integration/test_upgrade_ssc_from_280.py
@@ -21,6 +21,7 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_self_signed_traefik,
     verify_https_on_all_units,
@@ -45,11 +46,11 @@ def test_upgrade_ssc_from_revision_280(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     url = bring_up_self_signed_traefik(juju, tmp_path)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_ssc_from_280_via_298.py
+++ b/tests/integration/test_upgrade_ssc_from_280_via_298.py
@@ -22,7 +22,6 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_self_signed_traefik,
     verify_https_on_all_units,
@@ -48,17 +47,17 @@ def test_upgrade_ssc_from_280_via_298(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     url = bring_up_self_signed_traefik(juju, tmp_path)
 
     juju.refresh(TRAEFIK_APP_NAME, channel=SOURCE_CHANNEL, revision=INTERMEDIATE_REVISION)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, INTERMEDIATE_REVISION)
 
     verify_https_on_all_units(juju, expected_url=url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_ssc_from_280_via_298.py
+++ b/tests/integration/test_upgrade_ssc_from_280_via_298.py
@@ -22,6 +22,7 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_self_signed_traefik,
     verify_https_on_all_units,
@@ -47,17 +48,17 @@ def test_upgrade_ssc_from_280_via_298(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     url = bring_up_self_signed_traefik(juju, tmp_path)
 
     juju.refresh(TRAEFIK_APP_NAME, channel=SOURCE_CHANNEL, revision=INTERMEDIATE_REVISION)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, INTERMEDIATE_REVISION)
 
     verify_https_on_all_units(juju, expected_url=url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_ssc_from_280_via_298.py
+++ b/tests/integration/test_upgrade_ssc_from_280_via_298.py
@@ -51,13 +51,13 @@ def test_upgrade_ssc_from_280_via_298(
     url = bring_up_self_signed_traefik(juju, tmp_path)
 
     juju.refresh(TRAEFIK_APP_NAME, channel=SOURCE_CHANNEL, revision=INTERMEDIATE_REVISION)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, INTERMEDIATE_REVISION)
 
     verify_https_on_all_units(juju, expected_url=url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_ssc_from_298.py
+++ b/tests/integration/test_upgrade_ssc_from_298.py
@@ -21,6 +21,7 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_self_signed_traefik,
     verify_https_on_all_units,
@@ -45,11 +46,11 @@ def test_upgrade_ssc_from_revision_298(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     url = bring_up_self_signed_traefik(juju, tmp_path)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_ssc_from_298.py
+++ b/tests/integration/test_upgrade_ssc_from_298.py
@@ -49,7 +49,7 @@ def test_upgrade_ssc_from_revision_298(
     url = bring_up_self_signed_traefik(juju, tmp_path)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_ssc_from_298.py
+++ b/tests/integration/test_upgrade_ssc_from_298.py
@@ -21,7 +21,6 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_self_signed_traefik,
     verify_https_on_all_units,
@@ -46,11 +45,11 @@ def test_upgrade_ssc_from_revision_298(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     url = bring_up_self_signed_traefik(juju, tmp_path)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_all_units(juju, expected_url=url)

--- a/tests/integration/test_upgrade_ssc_leader_change_from_298.py
+++ b/tests/integration/test_upgrade_ssc_leader_change_from_298.py
@@ -24,7 +24,6 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_self_signed_traefik,
     force_leader_change,
@@ -50,15 +49,15 @@ def test_upgrade_ssc_leader_change_from_298(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     alertmanager_url = bring_up_self_signed_traefik(juju, tmp_path)
 
     force_leader_change(juju, TRAEFIK_APP_NAME)
 
-    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     verify_https_on_all_units(juju, alertmanager_url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     assert_traefik_revision(juju, 0)
     verify_https_on_all_units(juju, alertmanager_url)

--- a/tests/integration/test_upgrade_ssc_leader_change_from_298.py
+++ b/tests/integration/test_upgrade_ssc_leader_change_from_298.py
@@ -24,6 +24,7 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, NUM_TRAEFIK_UNITS, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_self_signed_traefik,
     force_leader_change,
@@ -49,15 +50,15 @@ def test_upgrade_ssc_leader_change_from_298(
         num_units=NUM_TRAEFIK_UNITS,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     alertmanager_url = bring_up_self_signed_traefik(juju, tmp_path)
 
     force_leader_change(juju, TRAEFIK_APP_NAME)
 
-    juju.wait(all_settled, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
     verify_https_on_all_units(juju, alertmanager_url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, timeout=900, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=900, delay=5, successes=5)
     assert_traefik_revision(juju, 0)
     verify_https_on_all_units(juju, alertmanager_url)

--- a/tests/integration/test_upgrade_ssc_leader_change_from_298.py
+++ b/tests/integration/test_upgrade_ssc_leader_change_from_298.py
@@ -58,6 +58,6 @@ def test_upgrade_ssc_leader_change_from_298(
     verify_https_on_all_units(juju, alertmanager_url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, timeout=900, delay=5)
+    juju.wait(all_settled, timeout=900, delay=5, successes=5)
     assert_traefik_revision(juju, 0)
     verify_https_on_all_units(juju, alertmanager_url)

--- a/tests/integration/test_upgrade_ssc_single_unit_from_280.py
+++ b/tests/integration/test_upgrade_ssc_single_unit_from_280.py
@@ -40,7 +40,7 @@ def test_upgrade_ssc_single_unit_from_280(
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upgrade_ssc_single_unit_from_280.py
+++ b/tests/integration/test_upgrade_ssc_single_unit_from_280.py
@@ -12,6 +12,7 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_self_signed_traefik,
     verify_https_on_unit,
@@ -35,12 +36,12 @@ def test_upgrade_ssc_single_unit_from_280(
         revision=SOURCE_REVISION,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     url = bring_up_self_signed_traefik(juju, tmp_path)
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upgrade_ssc_single_unit_from_280.py
+++ b/tests/integration/test_upgrade_ssc_single_unit_from_280.py
@@ -12,7 +12,6 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_self_signed_traefik,
     verify_https_on_unit,
@@ -36,12 +35,12 @@ def test_upgrade_ssc_single_unit_from_280(
         revision=SOURCE_REVISION,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     url = bring_up_self_signed_traefik(juju, tmp_path)
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upgrade_ssc_single_unit_from_280_via_298.py
+++ b/tests/integration/test_upgrade_ssc_single_unit_from_280_via_298.py
@@ -41,13 +41,13 @@ def test_upgrade_ssc_single_unit_from_280_via_298(
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, channel=SOURCE_CHANNEL, revision=INTERMEDIATE_REVISION)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, INTERMEDIATE_REVISION)
 
     verify_https_on_unit(juju, unit_name, url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upgrade_ssc_single_unit_from_280_via_298.py
+++ b/tests/integration/test_upgrade_ssc_single_unit_from_280_via_298.py
@@ -12,6 +12,7 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_self_signed_traefik,
     verify_https_on_unit,
@@ -36,18 +37,18 @@ def test_upgrade_ssc_single_unit_from_280_via_298(
         revision=SOURCE_REVISION,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     url = bring_up_self_signed_traefik(juju, tmp_path)
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, channel=SOURCE_CHANNEL, revision=INTERMEDIATE_REVISION)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, INTERMEDIATE_REVISION)
 
     verify_https_on_unit(juju, unit_name, url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upgrade_ssc_single_unit_from_280_via_298.py
+++ b/tests/integration/test_upgrade_ssc_single_unit_from_280_via_298.py
@@ -12,7 +12,6 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_self_signed_traefik,
     verify_https_on_unit,
@@ -37,18 +36,18 @@ def test_upgrade_ssc_single_unit_from_280_via_298(
         revision=SOURCE_REVISION,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     url = bring_up_self_signed_traefik(juju, tmp_path)
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, channel=SOURCE_CHANNEL, revision=INTERMEDIATE_REVISION)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, INTERMEDIATE_REVISION)
 
     verify_https_on_unit(juju, unit_name, url)
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upgrade_ssc_single_unit_from_298.py
+++ b/tests/integration/test_upgrade_ssc_single_unit_from_298.py
@@ -12,6 +12,7 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
+    any_error,
     assert_traefik_revision,
     bring_up_self_signed_traefik,
     verify_https_on_unit,
@@ -35,12 +36,12 @@ def test_upgrade_ssc_single_unit_from_298(
         revision=SOURCE_REVISION,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
     url = bring_up_self_signed_traefik(juju, tmp_path)
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upgrade_ssc_single_unit_from_298.py
+++ b/tests/integration/test_upgrade_ssc_single_unit_from_298.py
@@ -40,7 +40,7 @@ def test_upgrade_ssc_single_unit_from_298(
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, delay=5, timeout=900)
+    juju.wait(all_settled, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upgrade_ssc_single_unit_from_298.py
+++ b/tests/integration/test_upgrade_ssc_single_unit_from_298.py
@@ -12,7 +12,6 @@ from conftest import TRAEFIK_APP_NAME, TRAEFIK_RESOURCES
 from constants import MOCK_HOSTNAME, SOURCE_CHANNEL, TRAEFIK_CHARM
 from helpers import (
     all_settled,
-    any_error,
     assert_traefik_revision,
     bring_up_self_signed_traefik,
     verify_https_on_unit,
@@ -36,12 +35,12 @@ def test_upgrade_ssc_single_unit_from_298(
         revision=SOURCE_REVISION,
         trust=True,
     )
-    juju.wait(jubilant.all_agents_idle, error=any_error, timeout=900, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, timeout=900, delay=5, successes=5)
     url = bring_up_self_signed_traefik(juju, tmp_path)
     unit_name = next(iter(juju.status().apps[TRAEFIK_APP_NAME].units))
 
     juju.refresh(TRAEFIK_APP_NAME, path=traefik_charm, resources=TRAEFIK_RESOURCES)
-    juju.wait(all_settled, error=any_error, delay=5, timeout=900, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, timeout=900, successes=5)
     assert_traefik_revision(juju, 0)
 
     verify_https_on_unit(juju, unit_name, url)

--- a/tests/integration/test_upstream_ingress.py
+++ b/tests/integration/test_upstream_ingress.py
@@ -17,7 +17,7 @@ from tests.integration.any_charm_helpers import (
     PYTHON_PACKAGES,
     ingress_requirer_mock_src_overwrite,
 )
-from tests.integration.helpers import all_settled, fetch_with_retry
+from tests.integration.helpers import all_settled, any_error, fetch_with_retry
 
 TRAEFIK = "traefik-k8s"
 UPSTREAM_INGRESS = f"{TRAEFIK}-upstream"
@@ -34,7 +34,7 @@ _TRAEFIK_RESOURCES = {
 
 def test_deployment(juju: jubilant.Juju, traefik_charm):
     juju.deploy(traefik_charm, TRAEFIK, resources=_TRAEFIK_RESOURCES, trust=True)
-    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_deploy_dependencies(juju: jubilant.Juju, traefik_charm):
@@ -49,7 +49,7 @@ def test_deploy_dependencies(juju: jubilant.Juju, traefik_charm):
         resources=_TRAEFIK_RESOURCES,
         trust=True,
     )
-    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_deploy_testers(juju: jubilant.Juju):
@@ -78,14 +78,14 @@ def test_deploy_testers(juju: jubilant.Juju):
         config=config,
         trust=True,
     )
-    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_relate_testers(juju: jubilant.Juju):
     juju.integrate(f"{TRAEFIK}:ingress", f"{IPA_TESTER}:require-ingress")
     juju.integrate(f"{TRAEFIK}:ingress-per-unit", f"{IPU_TESTER}:require-ingress-per-unit")
     juju.integrate(f"{TRAEFIK}:traefik-route", f"{ROUTE_TESTER}:require-traefik-route")
-    juju.wait(all_settled, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, delay=5, successes=5)
 
 
 def test_ipa_ingressed_no_upstream_ingress(juju: jubilant.Juju):
@@ -102,7 +102,7 @@ def test_traefik_route_ingressed_no_upstream_ingress(juju: jubilant.Juju):
 
 def test_add_upstream_ingress(juju: jubilant.Juju):
     juju.integrate(f"{TRAEFIK}:upstream-ingress", f"{UPSTREAM_INGRESS}:ingress")
-    juju.wait(all_settled, timeout=300)
+    juju.wait(all_settled, error=any_error, timeout=300)
 
 
 def test_ipa_ingressed_through_upstream_ingress(juju: jubilant.Juju):
@@ -131,16 +131,24 @@ def test_traefik_with_upstream_ingress_blocked_if_in_subdomain_mode(juju: jubila
         "Expected Traefik to be active before triggering subdomain-mode block"
     )
     juju.config(TRAEFIK, {"routing_mode": "subdomain"})
-    juju.wait(lambda status: status.apps[TRAEFIK].app_status.current == "blocked", timeout=300)
+    juju.wait(
+        lambda status: status.apps[TRAEFIK].app_status.current == "blocked",
+        error=any_error,
+        timeout=300,
+    )
 
     juju.config(TRAEFIK, {"routing_mode": "path"})
-    juju.wait(lambda status: status.apps[TRAEFIK].app_status.current == "active", timeout=300)
+    juju.wait(
+        lambda status: status.apps[TRAEFIK].app_status.current == "active",
+        error=any_error,
+        timeout=300,
+    )
 
 
 def test_add_tls_to_all_ingresses(juju: jubilant.Juju):
     juju.integrate(f"{TRAEFIK}:certificates", CERTIFICATE_PROVIDER)
     juju.integrate(f"{UPSTREAM_INGRESS}:certificates", CERTIFICATE_PROVIDER)
-    juju.wait(all_settled, timeout=300)
+    juju.wait(all_settled, error=any_error, timeout=300)
 
 
 def test_ipa_ingressed_through_upstream_ingress_with_tls(juju: jubilant.Juju):

--- a/tests/integration/test_upstream_ingress.py
+++ b/tests/integration/test_upstream_ingress.py
@@ -17,7 +17,7 @@ from tests.integration.any_charm_helpers import (
     PYTHON_PACKAGES,
     ingress_requirer_mock_src_overwrite,
 )
-from tests.integration.helpers import all_settled, any_error, fetch_with_retry
+from tests.integration.helpers import all_settled, fetch_with_retry
 
 TRAEFIK = "traefik-k8s"
 UPSTREAM_INGRESS = f"{TRAEFIK}-upstream"
@@ -34,7 +34,7 @@ _TRAEFIK_RESOURCES = {
 
 def test_deployment(juju: jubilant.Juju, traefik_charm):
     juju.deploy(traefik_charm, TRAEFIK, resources=_TRAEFIK_RESOURCES, trust=True)
-    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_deploy_dependencies(juju: jubilant.Juju, traefik_charm):
@@ -49,7 +49,7 @@ def test_deploy_dependencies(juju: jubilant.Juju, traefik_charm):
         resources=_TRAEFIK_RESOURCES,
         trust=True,
     )
-    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_deploy_testers(juju: jubilant.Juju):
@@ -78,14 +78,14 @@ def test_deploy_testers(juju: jubilant.Juju):
         config=config,
         trust=True,
     )
-    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=1000, delay=5, successes=5)
 
 
 def test_relate_testers(juju: jubilant.Juju):
     juju.integrate(f"{TRAEFIK}:ingress", f"{IPA_TESTER}:require-ingress")
     juju.integrate(f"{TRAEFIK}:ingress-per-unit", f"{IPU_TESTER}:require-ingress-per-unit")
     juju.integrate(f"{TRAEFIK}:traefik-route", f"{ROUTE_TESTER}:require-traefik-route")
-    juju.wait(all_settled, error=any_error, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, delay=5, successes=5)
 
 
 def test_ipa_ingressed_no_upstream_ingress(juju: jubilant.Juju):
@@ -102,7 +102,7 @@ def test_traefik_route_ingressed_no_upstream_ingress(juju: jubilant.Juju):
 
 def test_add_upstream_ingress(juju: jubilant.Juju):
     juju.integrate(f"{TRAEFIK}:upstream-ingress", f"{UPSTREAM_INGRESS}:ingress")
-    juju.wait(all_settled, error=any_error, timeout=300)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=300)
 
 
 def test_ipa_ingressed_through_upstream_ingress(juju: jubilant.Juju):
@@ -133,14 +133,14 @@ def test_traefik_with_upstream_ingress_blocked_if_in_subdomain_mode(juju: jubila
     juju.config(TRAEFIK, {"routing_mode": "subdomain"})
     juju.wait(
         lambda status: status.apps[TRAEFIK].app_status.current == "blocked",
-        error=any_error,
+        error=jubilant.any_error,
         timeout=300,
     )
 
     juju.config(TRAEFIK, {"routing_mode": "path"})
     juju.wait(
         lambda status: status.apps[TRAEFIK].app_status.current == "active",
-        error=any_error,
+        error=jubilant.any_error,
         timeout=300,
     )
 
@@ -148,7 +148,7 @@ def test_traefik_with_upstream_ingress_blocked_if_in_subdomain_mode(juju: jubila
 def test_add_tls_to_all_ingresses(juju: jubilant.Juju):
     juju.integrate(f"{TRAEFIK}:certificates", CERTIFICATE_PROVIDER)
     juju.integrate(f"{UPSTREAM_INGRESS}:certificates", CERTIFICATE_PROVIDER)
-    juju.wait(all_settled, error=any_error, timeout=300)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=300)
 
 
 def test_ipa_ingressed_through_upstream_ingress_with_tls(juju: jubilant.Juju):

--- a/tests/integration/test_upstream_ingress.py
+++ b/tests/integration/test_upstream_ingress.py
@@ -34,7 +34,7 @@ _TRAEFIK_RESOURCES = {
 
 def test_deployment(juju: jubilant.Juju, traefik_charm):
     juju.deploy(traefik_charm, TRAEFIK, resources=_TRAEFIK_RESOURCES, trust=True)
-    juju.wait(all_settled, timeout=1000)
+    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
 
 
 def test_deploy_dependencies(juju: jubilant.Juju, traefik_charm):
@@ -49,7 +49,7 @@ def test_deploy_dependencies(juju: jubilant.Juju, traefik_charm):
         resources=_TRAEFIK_RESOURCES,
         trust=True,
     )
-    juju.wait(all_settled, timeout=1000)
+    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
 
 
 def test_deploy_testers(juju: jubilant.Juju):
@@ -78,14 +78,14 @@ def test_deploy_testers(juju: jubilant.Juju):
         config=config,
         trust=True,
     )
-    juju.wait(all_settled, timeout=1000)
+    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
 
 
 def test_relate_testers(juju: jubilant.Juju):
     juju.integrate(f"{TRAEFIK}:ingress", f"{IPA_TESTER}:require-ingress")
     juju.integrate(f"{TRAEFIK}:ingress-per-unit", f"{IPU_TESTER}:require-ingress-per-unit")
     juju.integrate(f"{TRAEFIK}:traefik-route", f"{ROUTE_TESTER}:require-traefik-route")
-    juju.wait(all_settled, timeout=600)
+    juju.wait(all_settled, delay=5, successes=5)
 
 
 def test_ipa_ingressed_no_upstream_ingress(juju: jubilant.Juju):

--- a/tests/integration/test_workload_tracing.py
+++ b/tests/integration/test_workload_tracing.py
@@ -12,7 +12,7 @@ import requests
 import yaml
 from tenacity import retry, stop_after_attempt, wait_exponential
 
-from tests.integration.helpers import all_settled
+from tests.integration.helpers import all_settled, any_error
 
 TRAEFIK_APP = "traefik"
 TEMPO_APP = "tempo"
@@ -41,6 +41,7 @@ def test_workload_tracing_is_present(juju: jubilant.Juju, traefik_charm):
     juju.deploy(traefik_charm, TRAEFIK_APP, resources=_TRAEFIK_RESOURCES, trust=True)
     juju.wait(
         lambda status: jubilant.all_active(status, TRAEFIK_APP),
+        error=any_error,
         timeout=300,
         delay=5,
         successes=5,
@@ -48,7 +49,7 @@ def test_workload_tracing_is_present(juju: jubilant.Juju, traefik_charm):
 
     juju.integrate(f"{TRAEFIK_APP}:workload-tracing", f"{TEMPO_APP}:tracing")
     juju.integrate(f"{TEMPO_APP}:ingress", f"{TRAEFIK_APP}:traefik-route")
-    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
 
     tempo_host = juju.status().apps[TEMPO_APP].address
     assert _get_traces_patiently(tempo_host)
@@ -78,7 +79,7 @@ def _deploy_tempo_cluster(juju: jubilant.Juju) -> None:
 
     # s3-integrator's unit agent must be up (installed) before we can run an action
     # against it below.
-    juju.wait(jubilant.all_agents_idle, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=any_error, delay=5, successes=5)
 
     # microceph's RGW runs on the spread runner host (set up by s3-installation.sh) and
     # is reachable from the single-node k8s cluster via the host's own IP address.
@@ -95,7 +96,7 @@ def _deploy_tempo_cluster(juju: jubilant.Juju) -> None:
         "sync-s3-credentials",
         params={"access-key": S3_ACCESS_KEY, "secret-key": S3_SECRET_KEY},
     )
-    juju.wait(all_settled, timeout=2000, delay=5, successes=5)
+    juju.wait(all_settled, error=any_error, timeout=2000, delay=5, successes=5)
 
 
 @retry(stop=stop_after_attempt(15), wait=wait_exponential(multiplier=1, min=4, max=10))

--- a/tests/integration/test_workload_tracing.py
+++ b/tests/integration/test_workload_tracing.py
@@ -12,7 +12,7 @@ import requests
 import yaml
 from tenacity import retry, stop_after_attempt, wait_exponential
 
-from tests.integration.helpers import all_settled, any_error
+from tests.integration.helpers import all_settled
 
 TRAEFIK_APP = "traefik"
 TEMPO_APP = "tempo"
@@ -41,7 +41,7 @@ def test_workload_tracing_is_present(juju: jubilant.Juju, traefik_charm):
     juju.deploy(traefik_charm, TRAEFIK_APP, resources=_TRAEFIK_RESOURCES, trust=True)
     juju.wait(
         lambda status: jubilant.all_active(status, TRAEFIK_APP),
-        error=any_error,
+        error=jubilant.any_error,
         timeout=300,
         delay=5,
         successes=5,
@@ -49,7 +49,7 @@ def test_workload_tracing_is_present(juju: jubilant.Juju, traefik_charm):
 
     juju.integrate(f"{TRAEFIK_APP}:workload-tracing", f"{TEMPO_APP}:tracing")
     juju.integrate(f"{TEMPO_APP}:ingress", f"{TRAEFIK_APP}:traefik-route")
-    juju.wait(all_settled, error=any_error, timeout=1000, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=1000, delay=5, successes=5)
 
     tempo_host = juju.status().apps[TEMPO_APP].address
     assert _get_traces_patiently(tempo_host)
@@ -79,7 +79,7 @@ def _deploy_tempo_cluster(juju: jubilant.Juju) -> None:
 
     # s3-integrator's unit agent must be up (installed) before we can run an action
     # against it below.
-    juju.wait(jubilant.all_agents_idle, error=any_error, delay=5, successes=5)
+    juju.wait(jubilant.all_agents_idle, error=jubilant.any_error, delay=5, successes=5)
 
     # microceph's RGW runs on the spread runner host (set up by s3-installation.sh) and
     # is reachable from the single-node k8s cluster via the host's own IP address.
@@ -96,7 +96,7 @@ def _deploy_tempo_cluster(juju: jubilant.Juju) -> None:
         "sync-s3-credentials",
         params={"access-key": S3_ACCESS_KEY, "secret-key": S3_SECRET_KEY},
     )
-    juju.wait(all_settled, error=any_error, timeout=2000, delay=5, successes=5)
+    juju.wait(all_settled, error=jubilant.any_error, timeout=2000, delay=5, successes=5)
 
 
 @retry(stop=stop_after_attempt(15), wait=wait_exponential(multiplier=1, min=4, max=10))

--- a/tests/integration/test_workload_tracing.py
+++ b/tests/integration/test_workload_tracing.py
@@ -39,11 +39,16 @@ def test_workload_tracing_is_present(juju: jubilant.Juju, traefik_charm):
     _deploy_tempo_cluster(juju)
 
     juju.deploy(traefik_charm, TRAEFIK_APP, resources=_TRAEFIK_RESOURCES, trust=True)
-    juju.wait(lambda status: jubilant.all_active(status, TRAEFIK_APP), timeout=300)
+    juju.wait(
+        lambda status: jubilant.all_active(status, TRAEFIK_APP),
+        timeout=300,
+        delay=5,
+        successes=5,
+    )
 
     juju.integrate(f"{TRAEFIK_APP}:workload-tracing", f"{TEMPO_APP}:tracing")
     juju.integrate(f"{TEMPO_APP}:ingress", f"{TRAEFIK_APP}:traefik-route")
-    juju.wait(all_settled, timeout=1000)
+    juju.wait(all_settled, timeout=1000, delay=5, successes=5)
 
     tempo_host = juju.status().apps[TEMPO_APP].address
     assert _get_traces_patiently(tempo_host)
@@ -73,7 +78,7 @@ def _deploy_tempo_cluster(juju: jubilant.Juju) -> None:
 
     # s3-integrator's unit agent must be up (installed) before we can run an action
     # against it below.
-    juju.wait(jubilant.all_agents_idle, timeout=600)
+    juju.wait(jubilant.all_agents_idle, delay=5, successes=5)
 
     # microceph's RGW runs on the spread runner host (set up by s3-installation.sh) and
     # is reachable from the single-node k8s cluster via the host's own IP address.
@@ -90,7 +95,7 @@ def _deploy_tempo_cluster(juju: jubilant.Juju) -> None:
         "sync-s3-credentials",
         params={"access-key": S3_ACCESS_KEY, "secret-key": S3_SECRET_KEY},
     )
-    juju.wait(all_settled, timeout=2000)
+    juju.wait(all_settled, timeout=2000, delay=5, successes=5)
 
 
 @retry(stop=stop_after_attempt(15), wait=wait_exponential(multiplier=1, min=4, max=10))


### PR DESCRIPTION
#### What this PR does

Adds the delays (5s) and successes (5) to all the waits to avoid bypassing the wait by a transitive state cause by a slow model.

Adds the error as any_error to avoid having to wait for the model to timeout when there is an error in the model

all 600s timeouts where removed as this is the default timeout to reduce clutter

Note:
I tested checking for the agent status (specifically "lost") but that resulted in a lot of failures. Seems like it is common to have lost agents, and we should not be failing the wait because of it

#### Why we need it

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated the documentation (if applicable)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [ ] I added a [change artifact](https://github.com/canonical/traefik-k8s-operator/blob/main/docs/release-notes/template/_change-artifact-template.yaml) for user-relevant changes in `docs/release-notes/artifacts` according to the [contributing guidelines](https://github.com/canonical/traefik-k8s-operator/blob/main/CONTRIBUTING.md#release-notes). If no change artifact is necessary, I tagged the PR with the label `no-release-note`.
- [ ] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If this PR involves a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this PR modifies charm libraries owned by this project**: I incremented the `LIBAPI` and `LIBPATCH` values

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

